### PR TITLE
Fix tutorial-SEBook consistency issues

### DIFF
--- a/SEBook/tools/make.md
+++ b/SEBook/tools/make.md
@@ -337,9 +337,10 @@ To write flexible and scalable Makefiles, you will use a few specific syntactic 
 
 * **Variables (Macros)**: Variables act as placeholders for command-line options, making the build rules cleaner and easier to modify. For example, you can define a variable for your compiler (`CC = clang`) and your compiler flags (`CFLAGS = -Wall -g`). When you want to use the variable, you wrap it in parentheses and a dollar sign: `$(CC)`.
 * **String Substitution**: You can easily transform lists of files. For example, to generate a list of `.o` object files from a list of `.c` source files, you can use the syntax: `OBJS = $(SRCS:.c=.o)`.
-* **Automatic Variables**: `make` provides special variables to make rules more concise. 
+* **Automatic Variables**: `make` provides special variables to make rules more concise.
     * `$@` represents the target name.
     * `$<` represents the first prerequisite.
+    * `$^` represents all prerequisites.
 * **Pattern Rules**: Pattern rules serve as templates for creating many rules with the identical structure. For instance, `%.o : %.c` defines a generic rule for creating a `.o` (object) file from a corresponding `.c` (source) file.
 
 ### A Worked Example

--- a/SEBook/tools/nodejs.md
+++ b/SEBook/tools/nodejs.md
@@ -22,6 +22,26 @@ let count = 0;       // A variable that can be reassigned
 const name = "UCLA"; // A constant that cannot be reassigned
 ```
 
+> **Never use `var`** — it has function-scoped hoisting rules that violate the block-scope behavior you learned in C++ and Python. Always prefer `let` or `const`.
+
+**Destructuring:**
+JavaScript provides a concise shorthand for unpacking values from arrays and objects — used constantly in modern JS and React:
+
+```javascript
+// Array destructuring (like Python's tuple unpacking):
+const coords = [40.7, -74.0];
+const [lat, lng] = coords;      // lat = 40.7, lng = -74.0
+
+// Object destructuring — extract properties by name:
+const student = { name: "Alice", grade: 95 };
+const { name, grade } = student;   // name = "Alice", grade = 95
+
+// Commonly used in function parameters:
+function printStudent({ name, grade }) {
+    console.log(`${name}: ${grade}`);
+}
+```
+
 ### What is Node.js? (Taking off the Training Wheels)
 Historically, JavaScript was trapped inside the web browser. It was strictly a front-end language used to make websites interactive. 
 
@@ -94,9 +114,9 @@ A Promise is exactly what it sounds like: an object representing the eventual co
 // A modern asynchronous function
 async function fetchUserData(userId) {
     try {
-        // 'await' tells the Event Loop: "Pause this function's execution 
+        // 'await' tells the Event Loop: "Pause this function's execution
         // until the database responds, but go do other things in the meantime."
-        const response = await database.getUser(userId); 
+        const response = await database.getUser(userId);
         console.log(`User found: ${response.name}`);
     } catch (error) {
         // Error handling looks exactly like C++ or Python
@@ -104,6 +124,17 @@ async function fetchUserData(userId) {
     }
 }
 ```
+
+> **⚠️ Sequential vs. Parallel `await`:** A critical performance trap is awaiting independent operations one after the other, when they could run in parallel:
+> ```javascript
+> // SLOWER — sequential: total time = time(A) + time(B)
+> const userA = await fetchUser('alice');
+> const userB = await fetchUser('bob');
+>
+> // FASTER — parallel: total time = max(time(A), time(B))
+> const [userA, userB] = await Promise.all([fetchUser('alice'), fetchUser('bob')]);
+> ```
+> When two async operations are independent, always prefer `Promise.all()` to run them concurrently.
 
 ### Data Representation: JavaScript Objects and JSON
 If you understand Python dictionaries, you already understand the *general structure* of JavaScript Objects. Unlike C++, where you must define a `struct` or `class` before instantiating an object, JavaScript allows you to create objects on the fly using key-value pairs. 

--- a/SEBook/tools/nodejs.md
+++ b/SEBook/tools/nodejs.md
@@ -144,16 +144,16 @@ Understanding callbacks is essential — all of Node.js's async operations notif
 JavaScript has compact syntax for extracting values from arrays and objects:
 
 ```javascript
-// Array destructuring (like Python's tuple unpacking: lat, lng = coords)
-const [lat, lng] = [40.7, -74.0];
+// Array destructuring (like Python's tuple unpacking: r, g, b = color)
+const [red, green, blue] = [255, 128, 0];
 
 // Object destructuring (extract properties by name)
-const student = { name: "Alice", grade: 95 };
-const { name, grade } = student;   // name = "Alice", grade = 95
+const config = { host: "localhost", port: 3000, debug: true };
+const { host, port } = config;   // host = "localhost", port = 3000
 
-// Works in function parameters — you will see this in every React component:
-function printStudent({ name, grade }) {
-    console.log(`${name}: ${grade}`);
+// Works in function parameters — you will see this in every Express route and React component:
+function startServer({ host, port }) {
+    console.log(`Listening on ${host}:${port}`);
 }
 ```
 

--- a/SEBook/tools/react.md
+++ b/SEBook/tools/react.md
@@ -54,9 +54,46 @@ function UserProfile() {
 ```
 
 #### What is that HTML doing inside JavaScript?!
-You are looking at **JSX** (JavaScript XML). It is a special syntax extension for React. Under the hood, a compiler (like Babel) turns those HTML-like tags into regular JavaScript objects. 
+You are looking at **JSX** (JavaScript XML). It is a special syntax extension for React. Under the hood, a compiler (like Babel) transforms those HTML-like tags into plain JavaScript function calls:
+
+```jsx
+// JSX (what you write):
+<h1 className="title">Hello</h1>
+
+// What Babel compiles it to:
+React.createElement('h1', { className: 'title' }, 'Hello')
+```
+
+`React.createElement` returns a lightweight JavaScript object — the **Virtual DOM** node. React then compares these object trees to determine the minimal set of real DOM changes needed.
 
 Notice the `{username}` syntax? Just like f-strings in Python (`f"Hello {username}"`), JSX allows you to seamlessly inject JavaScript variables directly into your UI using curly braces `{}`.
+
+### Passing Data: Props
+
+A component with hardcoded values is like a function with no parameters — limited and not reusable. **Props** (short for properties) let you pass data *into* a component, exactly like function arguments in C++ or Python.
+
+```jsx
+// Defining a component that accepts props:
+function ProductCard({ name, price }) {
+  return (
+    <div>
+      <h3>{name}</h3>
+      <p>${price.toFixed(2)}</p>
+    </div>
+  );
+}
+
+// Using it — each instance gets different data:
+<ProductCard name="Laptop" price={999.99} />
+<ProductCard name="Mouse"  price={29.99}  />
+```
+
+**Key rules for props:**
+* **Props flow one way** — from parent component down to child, never upward. This predictable, top-down data flow makes it easy to reason about where data comes from.
+* **Props are read-only** inside the component. Mutating a prop would corrupt the parent's data and break React's data flow model. If a component needs to change a value, it should use local state (`useState`) instead.
+* **Any JavaScript value** can be a prop: string, number, boolean, object, array, function, or even another component.
+
+A common challenge as your app grows is **prop drilling** — passing a prop through several intermediate layers of components that don't use it themselves, just to reach a deeply nested component that does. Solutions include the React Context API or dedicated state management libraries.
 
 ### Adding Memory: State
 

--- a/SEBook/tools/react.md
+++ b/SEBook/tools/react.md
@@ -62,10 +62,10 @@ You are looking at **JSX** (JavaScript XML). It is a special syntax extension fo
 
 ```jsx
 // JSX (what you write):
-<h1 className="title">Hello</h1>
+<button className="btn-primary" disabled={false}>Save</button>
 
 // What Babel compiles it to:
-React.createElement('h1', { className: 'title' }, 'Hello')
+React.createElement('button', { className: 'btn-primary', disabled: false }, 'Save')
 ```
 
 `React.createElement` returns a lightweight JavaScript object — the **Virtual DOM** node. React then compares these object trees to determine the minimal set of real DOM changes needed.
@@ -78,18 +78,20 @@ A component with hardcoded values is like a function with no parameters — limi
 
 ```jsx
 // Defining a component that accepts props:
-function ProductCard({ name, price }) {
+function UserAvatar({ username, isOnline }) {
   return (
     <div>
-      <h3>{name}</h3>
-      <p>${price.toFixed(2)}</p>
+      <span>{username}</span>
+      <span style={{color: isOnline ? 'green' : 'grey'}}>
+        {isOnline ? 'Online' : 'Offline'}
+      </span>
     </div>
   );
 }
 
 // Using it — each instance gets different data:
-<ProductCard name="Laptop" price={999.99} />
-<ProductCard name="Mouse"  price={29.99}  />
+<UserAvatar username="alice" isOnline={true} />
+<UserAvatar username="bob"   isOnline={false} />
 ```
 
 **Key rules for props:**

--- a/_data/tutorials/react.yml
+++ b/_data/tutorials/react.yml
@@ -182,7 +182,7 @@ steps:
 
       ### Fixer-Upper: Four Classic JSX Bugs
 
-      The file below has **four bugs** that prevent it from rendering correctly.
+      The file below has **three bugs** that prevent it from rendering correctly.
 
       **Common JSX gotchas for C++/Python developers:**
 


### PR DESCRIPTION
- react.yml: correct bug count from four to three in Step 2 fixer-upper
- make.md: add missing $^ (all prerequisites) to automatic variables list
- react.md: add JSX/Babel compilation explanation, Props section (one-way data flow, read-only, prop drilling), covering topics taught in tutorial
- nodejs.md: add destructuring section and Promise.all() sequential-vs- parallel warning, covering topics taught in tutorial Steps 2 and 5