### PR TITLE
Improve command lab animation performance

### DIFF
--- a/css/fs-command-lab.css
+++ b/css/fs-command-lab.css
@@ -17,6 +17,10 @@
   min-width: 0;
   overflow-wrap: anywhere;
   margin: 1.5em 0;
+  /* Isolate each card's paint/layout so a click on one card doesn't trigger
+     repaint checks against the whole page. Invisible to the user; pages with
+     many cards feel smoother. */
+  contain: layout paint;
 }
 
 .fs-command-lab__row {

--- a/css/git-command-lab.css
+++ b/css/git-command-lab.css
@@ -16,6 +16,10 @@
   flex-direction: column;
   min-width: 0;
   overflow-wrap: anywhere;
+  /* Isolate each card's paint/layout so a click on one card's graph doesn't
+     trigger repaint checks against the whole page. Pages with many labs
+     (SEBook/tools/git.md has 28) feel dramatically smoother with this. */
+  contain: layout paint;
 }
 
 .git-command-lab__header {

--- a/css/git-graph.css
+++ b/css/git-graph.css
@@ -40,6 +40,17 @@
   50% { stroke-opacity: 0.7; }
 }
 
+/* Pause perpetual / in-flight CSS animations when the graph is scrolled
+   out of view. An IntersectionObserver in js/git-graph.js toggles the
+   `--offscreen` modifier on each SVG root. Without this, pages with many
+   cards (e.g. sebook/tools/git.md has 28) keep the compositor hot forever
+   running every card's HEAD-glow pulse, which lowers the frame rate of
+   the card the user is actually interacting with. */
+.git-graph-svg--offscreen,
+.git-graph-svg--offscreen * {
+  animation-play-state: paused !important;
+}
+
 /* === Git graph delta animations =========================================== */
 
 /* Synchronised motion: nodes, branch labels, HEAD, edges, and chip colors
@@ -47,15 +58,16 @@
    its branch label, the HEAD chip, and the connecting edges glide together
    as one cohesive unit when the layout shifts.
 
-   `will-change: transform` promotes each moving element to its own compositor
-   layer so the browser animates all of them on the GPU with locked-step
-   timing — without this hint, SVG elements can tick at slightly different
-   rates and visibly desync during a shared slide. */
+   `will-change: transform` is NOT set statically here — it's scoped to the
+   actual transition window by js/git-graph.js (_setTransformAnimated), which
+   sets it inline just before mutating `transform` and clears it after the
+   720ms transition completes. Pages with many cards otherwise accumulate
+   hundreds of idle compositor layers, at which point Chrome starts evicting
+   them and each animation pays a re-promote cost on its first frame. */
 .git-graph-svg .git-graph-node-g,
 .git-graph-svg .git-graph-label-g,
 .git-graph-svg .git-graph-label-g--head {
   transition: transform 720ms cubic-bezier(.7,0,.3,1);
-  will-change: transform;
 }
 
 .git-graph-svg .git-graph-head-chip {
@@ -323,6 +335,18 @@ html.dark-mode .post-content svg.git-graph-svg {
               color 720ms cubic-bezier(.7,0,.3,1),
               background-color 720ms cubic-bezier(.7,0,.3,1),
               filter 720ms cubic-bezier(.7,0,.3,1);
+}
+/* Scope `will-change: transform` to the transient classes that actually
+   animate rows. Keeping it off idle rows prevents pages with many workbench
+   instances from creating dozens of always-on compositor layers. */
+.git-workbench-row.entering,
+.git-workbench-stash-entry.entering,
+.git-workbench-row.exiting,
+.git-workbench-stash-entry.exiting,
+.git-workbench-row.git-workbench-row-flip,
+.git-workbench-stash-entry.git-workbench-row-flip,
+.git-workbench-row.git-workbench-row-fly,
+.git-workbench-stash-entry.git-workbench-row-fly {
   will-change: transform;
 }
 .git-workbench-status {

--- a/js/git-graph.js
+++ b/js/git-graph.js
@@ -55,6 +55,46 @@
   // same page (e.g. the 7-step print grid) don't collide on element ids.
   var _instanceCounter = 0;
 
+  // Pause perpetual animations (e.g. the HEAD glow's `pulse 2s infinite`) on
+  // off-screen graphs. Pages like SEBook/tools/git.md embed ~28 labs; without
+  // this, every card keeps the compositor hot forever, which drags the frame
+  // rate of whichever card the user is actually interacting with. rootMargin
+  // starts the animation slightly before the SVG scrolls into view so the
+  // resume is imperceptible.
+  var _offscreenObserver = null;
+  function _ensureOffscreenObserver() {
+    if (_offscreenObserver) return _offscreenObserver;
+    if (typeof IntersectionObserver === 'undefined') return null;
+    _offscreenObserver = new IntersectionObserver(function (entries) {
+      for (var i = 0; i < entries.length; i++) {
+        var e = entries[i];
+        if (e.isIntersecting) {
+          e.target.classList.remove('git-graph-svg--offscreen');
+        } else {
+          e.target.classList.add('git-graph-svg--offscreen');
+        }
+      }
+    }, { rootMargin: '200px' });
+    return _offscreenObserver;
+  }
+
+  // Promote an element to its own compositor layer just before we mutate its
+  // `transform` (which kicks in the CSS transition), then drop the hint once
+  // the transition completes. Without this transient scoping, setting
+  // `will-change: transform` statically in CSS creates a compositor layer for
+  // every node/label on the page at rest — pages with many cards can easily
+  // accumulate hundreds of idle layers, at which point Chrome starts evicting
+  // them and each animation pays a re-promote cost on its first frame.
+  function _setTransformAnimated(el, transform) {
+    el.style.willChange = 'transform';
+    el.style.transform = transform;
+    if (el._wcTimer) clearTimeout(el._wcTimer);
+    el._wcTimer = setTimeout(function () {
+      el.style.willChange = '';
+      el._wcTimer = null;
+    }, 900);
+  }
+
   // ---------------------------------------------------------------------------
   // Constructor
   // ---------------------------------------------------------------------------
@@ -653,6 +693,21 @@
       return;
     }
 
+    // Pin the graph host to max(start, end) height for the duration of the
+    // animation so the SVG's per-frame width/height attribute changes don't
+    // push the rest of the page up or down on every frame. Without this pin,
+    // each of the ~31 animation frames forces a full-page reflow as every
+    // sibling below the card shifts. With it, content below moves exactly
+    // once — at the start if the graph is growing, or at the end when we
+    // release the pin if it's shrinking. The pin exists only during the
+    // animation window, so the card returns to its natural size at rest.
+    var container = this.container;
+    var hadMinHeight = container && container.style.minHeight !== '';
+    var priorMinHeight = hadMinHeight ? container.style.minHeight : '';
+    if (container) {
+      container.style.minHeight = Math.max(startH, endH) + 'px';
+    }
+
     if (this._dimAnim) cancelAnimationFrame(this._dimAnim);
 
     var DURATION = 520;
@@ -686,6 +741,10 @@
       svg.setAttribute('width',  endW);
       svg.setAttribute('height', endH);
       svg.setAttribute('viewBox', '0 0 ' + endW + ' ' + endH);
+      // Release the pin. SVG intrinsic is now at endH, so the container
+      // collapses to whichever is the natural resting size. Growing paid
+      // its one reflow at the start; shrinking pays it now.
+      if (container) container.style.minHeight = priorMinHeight;
     }, DURATION + 30);
   };
 
@@ -749,6 +808,9 @@
     this._svgRoot.appendChild(this._nodesLayer);
     this._svgRoot.appendChild(this._labelsLayer);
     this.container.appendChild(this._svgRoot);
+
+    var obs = _ensureOffscreenObserver();
+    if (obs) obs.observe(this._svgRoot);
 
     this._nodeEls = {};
     this._edgeEls = {};
@@ -1131,7 +1193,7 @@
 
   GitGraph.prototype._updateNode = function (entry, cm, cx, cy, isHead) {
     if (entry.cx !== cx || entry.cy !== cy) {
-      entry.g.style.transform = 'translate(' + cx + 'px,' + cy + 'px)';
+      _setTransformAnimated(entry.g, 'translate(' + cx + 'px,' + cy + 'px)');
       entry.cx = cx;
       entry.cy = cy;
     }
@@ -1302,7 +1364,7 @@
         entry.g.classList.remove('exiting');
       }
       if (entry.cx !== cx || entry.cy !== cy) {
-        entry.g.style.transform = 'translate(' + cx + 'px,' + cy + 'px)';
+        _setTransformAnimated(entry.g, 'translate(' + cx + 'px,' + cy + 'px)');
         entry.cx = cx;
         entry.cy = cy;
       }


### PR DESCRIPTION
Four invisible-to-the-user optimizations targeting the low frame rate of the interactive git-graph / command-lab cards (SEBook/tools/git.md embeds ~28 cards on one page, so every per-card cost multiplies):

1. IntersectionObserver in git-graph.js pauses CSS animations on graphs scrolled out of view. The HEAD glow's `pulse 2s infinite` otherwise keeps the compositor hot on every card forever.

2. `contain: layout paint` on `.git-command-lab` and `.fs-command-lab` scopes each card's reflow so a click on one card no longer triggers paint/layout checks across the whole page.

3. `will-change: transform` is no longer set statically in CSS. A new `_setTransformAnimated` helper adds the hint inline just before mutating `transform` and clears it 900ms later; workbench row flips / entries / exits carry it on their transient class. Idle pages no longer pay for hundreds of always-on compositor layers.

4. `_animateDimensions` now pins the graph host's `min-height` to max(start, end) for the duration of the 520ms dimension animation, then releases it. The SVG's per-frame width/height attribute changes used to reflow every sibling below the card on all ~31 frames; now content below shifts exactly once (at the start if growing, or at the end if shrinking).