### PR TITLE
Add pedagogical hints across advanced git tutorial

### DIFF
--- a/_data/tutorials/git-advanced.yml
+++ b/_data/tutorials/git-advanced.yml
@@ -11,146 +11,51 @@ steps:
 - title: Branch Internals and Detached HEAD
   view: git_graph
   instructions: |
-    ### Welcome to Advanced Git
+    This tutorial goes under the hood: the object database, refs, and HEAD
+    pointer — then uses that mental model to make sense of stash,
+    cherry-pick, blame, bisect, rebase, squash merge, and submodules.
 
-    You already know `init`, `add`, `commit`, `branch`, `merge`, and remotes.
-    This tutorial does two things the basic course did not:
+    You'll break things on purpose and recover with `git reflog`.
 
-    1. It lifts the hood and shows **how Git actually stores your work** —
-       the object database, refs, and HEAD pointer. Knowing the internals
-       turns intimidating commands like `rebase` and `bisect` into
-       predictable mechanical operations.
-    2. It practices **every tool from Lecture 10** in a realistic scenario:
-       detached HEAD, relative addresses, stash, cherry-pick, blame, bisect,
-       simple & interactive rebase, squash merge, and submodules.
+    ### Predict first
 
-    You will intentionally break things and recover them with `git reflog` —
-    a safe sandbox is the best place to learn destructive commands.
-
-    ### Two antipatterns you will *not* fall into by the end
-
-    Research on how students actually use Git (Isomöttönen & Cochez 2014)
-    identified two behaviours that separate novices from professionals:
-
-    1. **Blind-testing** — typing random permutations of `add`, `commit`,
-       `push`, `pull` until the terminal stops complaining. You get
-       a fragile *illusion* of competence that collapses the first
-       time you hit a conflict or divergence.
-    2. **"Burning down the repo"** — when something goes wrong, the
-       novice deletes their local folder, copies their uncommitted
-       code to a text file, re-clones from the server, pastes the
-       changes back, and force-commits. This "works" but destroys
-       atomic history and guarantees you never actually learn.
-
-    Both antipatterns come from the same root cause: **no accurate
-    mental model of what Git is doing.** Every step in this tutorial
-    is designed to build that model piece by piece. When you finish,
-    you won't need to guess or burn down anything — you'll read the
-    state and reach for the right tool.
-
-    ### Prerequisite self-check
-
-    Before you start, answer these in your head (no Git required).
-    If any feel shaky, **go back to the basic tutorial first** — the
-    advanced tutorial assumes every one of them is cold-reflex.
-
-    1. A new file appears red in `git status`. What's the one-word
-       state name, and which command promotes it to green?
-    2. You commit, then edit the file again. What does `git diff`
-       (no arguments) compare?
-    3. `main` and `feature` have diverged — each has commits the
-       other doesn't. Can `git merge feature` still fast-forward? Why
-       or why not?
-    4. A teammate pushed a buggy commit to shared `main`. Which is
-       safe — `git reset --hard HEAD~1` then force-push, or
-       `git revert <sha>`? Why?
-    5. Someone ran `git add .` and staged a `.env` file with
-       secrets. Adding `.env` to `.gitignore` now — does that stop
-       the secret from being committed?
-
-    <details><summary>Expected answers (check yourself)</summary>
-
-    1. **Untracked.** `git add` moves it to staged.
-    2. **Working directory vs. staging area.** Since nothing is
-       staged, the staging area still matches `HEAD`, so the diff
-       shows your unstaged edits.
-    3. **No.** Diverged branches need a three-way merge (new merge
-       commit with two parents). Fast-forward requires the target
-       branch to be a strict ancestor.
-    4. **`git revert`.** It appends an anti-commit without
-       rewriting history, so teammates who already pulled stay in
-       sync. `reset --hard` + force-push breaks every teammate's
-       local copy.
-    5. **No.** `.gitignore` only stops *future* tracking.
-       Already-staged files need `git restore --staged .env` now, or
-       `git rm --cached .env` if already committed — and for a real
-       secret, rotate the credential.
-
-    </details>
-
-    If you got 4-5 right, you're ready. If 2-3, skim the relevant
-    basic-tutorial steps before continuing — the concepts below
-    build directly on these.
-
-    ### What is a branch, really? — Predict first
-
-    You have seen branches behave like separate timelines.
-    Before we look under the hood, **write down your current mental
-    model** (on paper or in your head):
+    Before you read on, finish this sentence:
 
     > *"A branch in Git is physically stored as ________."*
 
-    Finish the sentence with your best guess **before** scrolling. A
-    folder? A snapshot? A compressed diff? A network resource? Keep
-    your guess; we will test it against reality in Task 1.
-
-    Once you have your guess, read on:
-
-    A branch is **not a copy** of your project — it is a **41-byte text file**
-    containing one commit hash. Let's prove it (and see whether your
-    guess was right).
+    A folder? A snapshot? A diff? Commit to a guess, then continue.
 
     ### The starter repo
 
-    A small `myproject/` calculator repo has already been built for you —
-    two commits on `main`, one on a `feature-divide` branch. Drop into it by looking at the git graph on the right and running:
+    A `myproject/` calculator repo has been set up for you — two commits
+    on `main`, one on `feature-divide`. Drop in and view the history:
 
     ```bash
     git log --all --oneline --graph --decorate
     ```
 
-
-    You should see three commits arranged across `main` and
-    `feature-divide`. **Compare the terminal output with the git graph
-    panel on the right** — they show the same history. The panel updates
-    live as you run commands; use it throughout this step to confirm your
-    mental model matches what Git actually records.
+    The git-graph panel on the right shows the same history and updates
+    live as you run commands.
 
     ### Task 1: Look at the branch pointer files
-
-    **Predict first:** 
-    `.git/refs/heads/main` is your local representation of the main branch. 
-    What do you expect is inside the file? A sequence of commits? A snapshot of the files? A compressed diff? 
-    Give it a guess and then run:
 
     ```bash
     cat .git/refs/heads/main
     cat .git/refs/heads/feature-divide
     ```
 
-    Each file is **one line** containing the commit ID (SHA hash) of the commit that
-    branch points to. Branches are not folders, not lists of commits — they are **single-line text files**. Creating
-    one is very lightweight, simple, and fast. It's just writing a few bytes into a file. (How did
-    your prediction compare to what you actually saw?)
+    Each file is a single line: the commit SHA the branch points at. A
+    branch isn't a copy of your project — it's a 41-byte text file. That's
+    why creating one is instant.
 
-    Now inspect `HEAD` the pointer to your currently checked-out version of the repo:
+    Now look at `HEAD`:
 
     ```bash
     cat .git/HEAD
     ```
 
-    You see `ref: refs/heads/main`. `HEAD` is a **symbolic reference** —
-    a pointer to another pointer:
+    You see `ref: refs/heads/main` — `HEAD` is a pointer to a pointer.
+    `git commit` rewrites the branch file; `HEAD` follows automatically.
 
     ```gitgraph
     @startuml
@@ -161,45 +66,25 @@ steps:
     @enduml
     ```
 
-    This indirection is why `git commit` can move the branch forward
-    without touching `HEAD` itself: the branch pointer file is rewritten,
-    and `HEAD` dereferences to the new commit automatically.
-
     ### Task 2: Detach HEAD
-
-    Sometimes you need to inspect an old commit without being on a branch.
-    The `--detach` flag lets you do this:
 
     ```bash
     git switch --detach HEAD~1
     cat .git/HEAD
     ```
-    (Side note: This is equivalent to the older command `git checkout HEAD~1`. However, the `--detach` flag is more explicit about the intent to leave a branch).
 
-    Now `.git/HEAD` contains a **raw SHA hash** instead of a branch
-    reference. This is **detached HEAD state**.
-    HEAD is no longer anchored to a branch pointer — it is anchored directly to a commit. 
+    `.git/HEAD` now holds a raw SHA instead of a ref. That's **detached
+    HEAD**: HEAD points at a commit directly, not via a branch. In the
+    graph panel, the HEAD label floats on a commit instead of sitting
+    next to `main`.
 
-    **Look at the git graph panel on the right.** The HEAD label should now
-    float directly on a commit node rather than sitting next to the
-    `main` branch name. That visual is the exact picture of what
-    "detached" means: HEAD is anchored to a commit, not to a branch pointer.
+    **Warning:** commits made in this state are anchored to no branch.
+    When you `git switch` away, they become orphaned and `git gc`
+    eventually prunes them.
 
-    > Think of it as visiting a museum archive. You can pull out any
-    > document and read it. But if you leave scribbled notes on a desk
-    > without labelling which room they belong to, the archive staff have
-    > nowhere to file them when you walk away. `git switch -c <name>` is
-    > the label you must leave before walking away.
+    ### Task 3: Rescue orphaned work with the reflog
 
-    **Warning:** Any new commits you make in detached HEAD state are
-    **anchored to no branch**. When you `git switch` away, Git has no pointer
-    to keep them reachable — they become orphaned and are eventually
-    pruned by `git gc`.
-
-    ### Task 3: Rescue work from a detached HEAD with reflog
-
-    Let's intentionally create an orphan, then recover it — this is
-    the kind of mistake students panic about, so let's tame it.
+    Create an orphan on purpose:
 
     ```bash
     git switch --detach HEAD
@@ -209,79 +94,43 @@ steps:
     git switch main
     ```
 
-    Those detached commits are now **orphaned** — no branch points to
-    them.
+    The experimental commit is now orphaned. `git log --all --oneline`
+    won't even show it — `--all` walks refs, and nothing points at the
+    commit. The SHA is nowhere on screen.
 
-    **"Why can't I just `git checkout <sha>` the commit directly?"**
-    You could — *if* you still had the SHA. But try:
-
-    ```bash
-    git log --all --oneline
-    ```
-
-    The experimental commit does not appear. `git log --all` walks every
-    branch and tag to collect reachable commits; an orphan is reachable
-    from *no* ref, so it is invisible. The SHA is nowhere on screen.
-    You have lost the address of the very object you want to visit.
-
-    This is the exact situation `git reflog` solves. Unlike `git log`,
-    the reflog is not a commit graph traversal — it is a **local diary**
-    of every position `HEAD` has occupied, regardless of reachability.
-    Git never forgets *where HEAD has been*:
+    The reflog records every position HEAD has occupied, regardless of
+    reachability:
 
     ```bash
     git reflog
     ```
 
-    Each line has the form `<sha>  HEAD@{n}: <action>: <description>`.
-    The most recent entry (`HEAD@{0}`) is the `git switch main` you just
-    ran. The entry above it — `HEAD@{1}` — is the experimental commit.
+    Each line looks like `<sha> HEAD@{n}: <action>: <description>`.
+    `HEAD@{0}` is now; `HEAD@{1}` is one move ago (your experimental
+    commit). `HEAD@{n}` works anywhere Git expects a commit SHA.
 
-    **What is `HEAD@{1}`?** The `@{n}` suffix is **reflog syntax**.
-    It means "where this ref was *n* moves ago in the reflog." So:
-
-    | Expression   | Meaning                        |
-    |--------------|--------------------------------|
-    | `HEAD@{0}`   | where HEAD is **right now**    |
-    | `HEAD@{1}`   | where HEAD was **one move ago** |
-    | `HEAD@{2}`   | two moves ago, and so on       |
-
-    You can use `HEAD@{n}` anywhere Git expects a commit SHA — no need to
-    copy-paste the raw hash. Anchor a branch to the experimental commit:
+    Anchor a branch to the orphan:
 
     ```bash
     git branch rescued-work HEAD@{1}
     git log rescued-work --oneline
     ```
 
-    **Check the git graph panel** — `rescued-work` should now appear as a
-    new branch label pointing to your experimental commit. The "lost" commit
-    is safe again. **The reflog is your safety net for every destructive
-    operation in this tutorial.** Bookmark it.
+    The `rescued-work` label should appear in the graph panel. The
+    reflog is your safety net — you'll rely on it through the rest of
+    the tutorial.
 
-    ### Cleanup — return to main
+    ### Cleanup
 
     ```bash
     git switch main
     ```
 
-    The git-graph view on the right should now show `main`, `feature-divide`,
-    and `rescued-work` — three pointers, one shared history.
-
     ### You can now
 
-    - **Explain** why creating a branch is a millisecond operation, in
-      terms of what is physically written to disk.
-    - **Distinguish** attached HEAD from detached HEAD by inspecting
-      `.git/HEAD`.
-    - **Recover** orphaned commits using `git reflog` + `git branch
-      <name> <sha>` — your safety net for every destructive operation
-      later in this tutorial.
-
-    > **Normalize the struggle:** Every experienced Git user has
-    > panicked at "detached HEAD" at some point. You just turned that
-    > panic moment into a routine recovery. That skill transfers to
-    > rebase, reset, and every other "scary" Git operation.
+    - Explain why creating a branch is a single `fwrite`.
+    - Tell attached from detached HEAD by reading `.git/HEAD`.
+    - Recover orphaned commits with `git reflog` + `git branch`.
   solution:
     commands:
     - cd /tutorial/myproject
@@ -300,19 +149,19 @@ steps:
   - description: feature-divide branch exists
     command: cd /tutorial/myproject && git branch | grep -q 'feature-divide'
     hints:
-    - text: The `feature-divide` branch was prepared for you by setup and shouldn't need creating — `git branch` lists every local branch. If you accidentally deleted it while exploring, remember that a branch is just a 41-byte pointer file; you can recreate it at any commit with `git branch feature-divide <sha>` (use `git reflog` or `git log --all` to locate the right commit).
+    - text: 'Setup created `feature-divide` for you. If you deleted it, find its old SHA in `git reflog` and run `git branch feature-divide <sha>`.'
   - description: Currently on main branch (not detached)
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
     hints:
-    - text: '`HEAD` is still detached or pointing somewhere other than `main`. Task 2 had you detach HEAD to *look around*, but like returning from a museum archive you must re-attach HEAD to a branch pointer before leaving. Which `git switch` invocation puts HEAD back on a named branch?'
+    - text: 'HEAD is detached. Re-attach it with `git switch main`.'
       condition: 'output_contains: detached'
-    - text: 'Inspect `.git/HEAD` — if it holds a raw SHA instead of `ref: refs/heads/main`, HEAD is detached. Re-attach by switching back to the main branch (one short command).'
+    - text: 'You ended up on the wrong branch. `git switch main` puts you back.'
   - description: rescued-work branch exists and points to an experimental commit
     command: cd /tutorial/myproject && git log rescued-work --oneline 2>/dev/null | grep -qi 'experimental'
     hints:
-    - text: Before Task 3 you must first make an "orphan" experimental commit. Detach HEAD with `git switch --detach HEAD`, edit `calculator.py` (any change will do — the hint test checks for the word "experimental" in the commit message), then `git add` and `git commit` — but **stay in detached HEAD** so the commit becomes orphaned when you leave.
+    - text: 'You need to make the orphan commit first. `git switch --detach HEAD`, tweak `calculator.py`, commit with "Experimental" in the message — stay detached so it becomes orphan when you leave.'
       condition: 'output_missing: Experimental'
-    - text: The orphan commit exists (check `git reflog`), but no branch points at it yet. `git reflog` lists every position HEAD has visited — find the line for your experimental commit, copy its short SHA, and use `git branch rescued-work <sha>` to anchor the commit so it's no longer orphaned.
+    - text: 'The commit exists but no branch points at it. Grab its SHA from `git reflog`, then `git branch rescued-work <sha>`.'
   quiz:
     title: Branch Internals & Detached HEAD — Knowledge Check
     min_score: 0.8
@@ -365,57 +214,37 @@ steps:
 - title: Relative Commit Addresses & Git's Object Database
   view: git_graph
   instructions: |
-    ### Warm-up: one prediction
+    ### Predict
 
-    Imagine two separate Git repos on two separate laptops. Alice's
-    `foo.txt` contains exactly the bytes `hello world\n`. Bob's
-    `bar.txt` contains exactly the bytes `hello world\n`.
+    Alice and Bob each create a file on their own laptop, in separate
+    repos, containing exactly `hello world\n`. Does Git store it under
+    the **same SHA** in both repos?
 
-    > **Predict (yes/no/depends):** Do Alice's repo and Bob's repo
-    > internally store that content using the **same SHA-1 hash**?
+    Pick yes/no and keep your guess — we'll settle it in Task 2.
 
-    Write your guess down. We will prove the answer at the end of this
-    step. It matters more than it sounds — the answer is the
-    foundation of every efficient operation in Git.
+    > A common wrong model: *"Git stores diffs between commits."* That's
+    > how SVN works, not Git. Git stores full snapshots, deduplicated by
+    > content hash. If you carry the diff model into rebase and
+    > cherry-pick, they'll feel like magic. Drop it.
 
-    > ⚠️ **Common wrong model you may be carrying:**
-    > *"Git stores a diff between each commit — that's why it's so
-    > compact."* This is the **SVN mental model** and it is **wrong**
-    > for Git. Git stores full snapshots, deduplicated by content
-    > hash. Holding onto the diff model makes rebase, cherry-pick, and
-    > bisect feel magical and unpredictable. This step replaces it.
+    ### Task 1: Relative references
 
-    ### The address problem
+    Typing a 40-char SHA by hand is painful. Git gives you:
 
-    Every advanced Git command takes a commit as an argument.
-    Typing `a73f2d9c81...` by hand is error-prone. Git gives you two
-    better options:
+    - `HEAD~n` — n steps back along the first-parent chain
+    - `HEAD^` — same as `HEAD~1`
+    - `HEAD^2` — the *second* parent of a merge commit
 
-    1. **Relative references** — `HEAD~1`, `main~3`, `feature^2`.
-    2. **Symbolic references** — `HEAD`, branch and tag names, ranges.
-
-    ### Task 1: Practice relative references
-
-    Your `main` branch has two commits. Let's name them without copying
-    any SHA.
+    Try them:
 
     ```bash
     cd /tutorial/myproject
     git log --oneline
+    git rev-parse HEAD
+    git rev-parse HEAD~1
+    git rev-parse main
+    git rev-parse main~1
     ```
-
-    Now resolve relative references:
-
-    ```bash
-    git rev-parse HEAD        # the current commit SHA
-    git rev-parse HEAD~1      # one commit before HEAD
-    git rev-parse main        # same as HEAD right now
-    git rev-parse main~1      # same as HEAD~1
-    ```
-
-    **`BRANCH~n`** means *n steps back along the first-parent chain*.
-    **`BRANCH^`** is shorthand for `BRANCH~1`. **`BRANCH^2`** is the
-    *second parent* of a merge commit (first-parent chain ignores it).
 
     ```gitgraph
     @startuml
@@ -428,37 +257,30 @@ steps:
     @enduml
     ```
 
-    So on this history, `feature~2 = A`, `main~2 = B`, and `HEAD~1 = C`.
-
-    Try one more — how many commits back is the initial commit?
+    Jump to the root commit without typing its SHA:
 
     ```bash
-    git log --oneline | wc -l
     git rev-parse HEAD~$(($(git log --oneline | wc -l) - 1))
     ```
 
-    That last expression jumps to the root commit without typing its SHA.
+    ### Task 2: The object database
 
-    ### Task 2: Lift the hood — Git's object database
+    Everything in `.git/objects/` is one of three things:
 
-    Every commit, file, and directory you version is stored as a
-    **Git object** in `.git/objects/`. There are only three kinds:
-
-    | Object | What it stores |
+    | Object | Contents |
     |---|---|
-    | **blob** | The raw content of a file (no filename) |
-    | **tree** | A directory listing: filename → blob or sub-tree |
-    | **commit** | A tree SHA + parent SHAs + author + message |
+    | blob | raw file bytes (no filename) |
+    | tree | directory: filename → blob or sub-tree |
+    | commit | tree SHA + parent SHAs + author + message |
 
-    Everything is addressed by SHA-1 of its content — a *content-addressable
-    filesystem*. Let's settle the warm-up prediction.
+    All three are addressed by the SHA of their content. Let's settle
+    the prediction:
 
     ```bash
     echo "hello world" | git hash-object --stdin
     ```
 
-    Note the 40-character hash. Now run the **same command in a
-    fresh, unrelated repo** (simulate Bob's laptop):
+    Now the same thing in an unrelated repo:
 
     ```bash
     cd /tmp && git init -q bob-repo && cd bob-repo
@@ -466,40 +288,33 @@ steps:
     cd /tutorial/myproject
     ```
 
-    **Identical output.** That is the answer to the warm-up prediction:
-    anyone hashing the same content gets the same SHA. Git is
-    content-addressable — deduplication across repos, branches, and
-    history is automatic and free. (If your prediction was "no" or
-    "depends," this is the moment to update your mental model.)
+    Same hash. Anyone hashing the same bytes gets the same SHA — that's
+    what "content-addressable" means, and it's why dedup across branches,
+    repos, and history happens for free.
 
     ### You can now
 
-    - **Resolve** any commit without typing a SHA using `HEAD~n`,
-      `BRANCH^`, or `git rev-parse`.
-    - **Prove** that Git is snapshot-based (not diff-based) by
-      hashing identical content and seeing identical SHAs.
-
-    You have now built the mental model that the remaining 9 steps
-    all build on.
+    - Resolve commits with `HEAD~n`, `^`, and `git rev-parse`.
+    - Explain why identical content always hashes to the same SHA.
   setup_commands:
   - cd /tutorial/myproject && git switch main 2>/dev/null; true
   solution:
     commands:
     - cd /tutorial/myproject
     explanation: |
-      - **`HEAD~n`:** n commits back along the first-parent chain. `HEAD~0` is HEAD itself, `HEAD~1` is its parent, `HEAD~2` its grandparent. `HEAD^` is equivalent to `HEAD~1`. For a merge commit, `HEAD^2` accesses the *second* parent (the merged-in branch tip).
-      - **`git rev-parse`:** Converts any ref (relative, symbolic, short SHA) into a full 40-character SHA. Plumbing-level tool used internally by nearly every porcelain command.
-      - **`git hash-object`:** Computes the SHA Git would assign to content. Feeding the same bytes always produces the same hash — that is what makes Git content-addressable.
-      - **Why it matters:** Every advanced command later (rebase, cherry-pick, bisect) is just moving ref pointers across this immutable object graph. Once you see commits as *hashed snapshots*, not *edits*, nothing in Git is mysterious.
+      - `HEAD~n`: n commits back along the first-parent chain. `HEAD^` = `HEAD~1`. On a merge commit, `HEAD^2` is the second parent.
+      - `git rev-parse`: turns any ref (relative, symbolic, short SHA) into a full SHA.
+      - `git hash-object`: computes the SHA Git would assign to some bytes. Same bytes → same SHA, always.
+      - Every advanced command that follows is just moving refs across this immutable object graph.
   tests:
   - description: On main branch with calculator.py
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main' && [ -f calculator.py ]
     hints:
-    - text: You're no longer on `main`, or `calculator.py` isn't in the current directory. This step is exploration-only — no file changes required. If you wandered into detached HEAD or another branch while experimenting, `git switch main` brings you back and restores the tracked files.
+    - text: "You're not on `main`, or not inside the project. `cd /tutorial/myproject && git switch main` fixes both."
   - description: You can resolve HEAD~1 (at least 2 commits on main)
     command: cd /tutorial/myproject && git rev-parse --quiet --verify HEAD~1 >/dev/null
     hints:
-    - text: '`HEAD~1` means "one commit before HEAD", so `main` needs at least two commits. Run `git log --oneline` — if you see only one commit, history was truncated (perhaps a `git reset --hard` rewound too far). Use `git reflog` to find the earlier tip SHA and `git reset --hard <sha>` to restore it.'
+    - text: '`main` has only one commit, so `HEAD~1` can''t resolve. A stray `git reset --hard` probably trimmed history — recover the earlier tip from `git reflog`.'
   quiz:
     title: Relative Addresses & Object Database — Knowledge Check
     min_score: 0.8
@@ -560,30 +375,11 @@ steps:
 - title: Saving Work Temporarily with git stash
   view: git_graph
   instructions: |
-    ### The context-switch problem
-
-    Real development rarely lets you finish one task before another
-    demands attention. Imagine you are halfway through a feature when
-    your team lead says: **"Drop everything — there's a critical bug on
-    `main` that needs a hotfix now."**
-
-    Without `git stash`, your choices are all bad:
-
-    - **Commit half-finished work** → pollutes history.
-    - **Discard changes with `git restore`** → permanent loss.
-    - **Stay on your branch** → cannot isolate the hotfix.
-
-    `git stash` is the fourth, clean option: **temporarily set aside**
-    your work-in-progress so the working directory is clean, context-switch,
-    then **restore your work** exactly where you left off.
-
-    > ⚠️ **Anti-pattern alert:** a common novice response to "clean
-    > tree needed now" is to **delete the local folder, copy code to
-    > a text file, re-clone, paste back** (the "burning down the
-    > repo" pattern). This works but destroys atomic history, loses
-    > authorship, and you never learn the real tool. `git stash` is
-    > the professional one-command alternative — learn it once, use
-    > it forever.
+    You're halfway through a feature when a critical bug lands on `main`
+    and your lead asks for a hotfix. Committing half-finished work
+    pollutes history; `git restore` loses the work. `git stash` is the
+    clean option: shelve the WIP, clean the tree, do the hotfix, restore
+    the WIP.
 
     ```freeform
     @startuml
@@ -600,11 +396,10 @@ steps:
     @enduml
     ```
 
-    ### Task 1: You have been interrupted mid-work
+    ### Task 1: You've been interrupted mid-work
 
-    The tutorial has already set the scene for you: you're on `main`,
-    and a half-finished `power` function is sitting at the bottom of
-    `calculator.py` — exactly as if you had been pulled off mid-edit:
+    Setup has left a half-finished `power` function at the bottom of
+    `calculator.py`:
 
     ```python
 
@@ -613,9 +408,7 @@ steps:
         return a ** b
     ```
 
-    It is **modified but not committed**. Confirm Git sees the dirty
-    working tree (and note the file appears under `NOT STAGED` in the
-    Git Graph panel on the right):
+    Confirm the tree is dirty:
 
     ```bash
     cd /tutorial/myproject
@@ -625,38 +418,27 @@ steps:
 
     ### Task 2: Stash
 
-    **Predict first:** after running `git stash`, what will `git
-    status` report? Will your changes still show up as "modified"?
-    Will they be "staged"? Will the working tree be "clean"? Commit
-    to one prediction before running.
+    Predict: after `git stash`, will your changes show as modified,
+    staged, or clean?
 
     ```bash
     git stash
     git status
-    ```
-
-    The working directory is **clean** — that's the answer to the
-    prediction. The half-finished `power` function is in the stash — not
-    committed, not lost.
-
-    ```bash
     git stash list
     ```
 
-    Each entry looks like `stash@{0}: WIP on main: <hash> <message>`.
-    Internally, a stash is a **commit object** (actually two — one for
-    index, one for working tree) stored under `.git/refs/stash`.
+    The tree is clean. Each stash entry looks like `stash@{0}: WIP on
+    main: <hash> <message>`. Internally a stash is a commit (actually
+    two — one for the index, one for the working tree) under
+    `.git/refs/stash`.
 
     ### Task 3: Do the hotfix on a dedicated branch
-
-    With the tree clean, isolate the hotfix:
 
     ```bash
     git switch -c hotfix-divide-zero
     ```
 
-    Now open `calculator.py` in the editor and add this function at the
-    bottom:
+    Open `calculator.py` and append:
 
     ```python
 
@@ -667,7 +449,7 @@ steps:
         return a / b
     ```
 
-    Save it. Back in the terminal, commit and merge:
+    Commit and merge:
 
     ```bash
     git add calculator.py
@@ -677,38 +459,35 @@ steps:
     git branch -d hotfix-divide-zero
     ```
 
-    ### Task 4: Recover your stashed work
+    ### Task 4: Restore your stashed work
 
     ```bash
     git stash pop
     git status
-    git stash list    # now empty
+    git stash list    # empty
     ```
 
-    Your `power` function work-in-progress is restored — `pop` removes
-    the stash after applying. The stash list is empty.
+    `pop` restores and drops the entry.
 
-    ### Stash reference
+    ### Reference
 
     | Command | Effect |
     |---|---|
-    | `git stash` | Save tracked modifications + staged changes; clean working tree |
-    | `git stash list` | Show all stash entries (stack) |
-    | `git stash pop` | Restore the most recent stash **and** drop it |
-    | `git stash apply` | Restore the most recent stash but **keep** it |
-    | `git stash drop` | Delete the most recent stash without applying |
-    | `git stash push -m "msg"` | Save with a descriptive message |
-    | `git stash -u` | Also include **untracked** files (new files never `git add`-ed) |
+    | `git stash` | Save tracked modifications + staged changes |
+    | `git stash list` | Show the stack |
+    | `git stash pop` | Restore latest and drop it |
+    | `git stash apply` | Restore latest but keep it |
+    | `git stash drop` | Delete without applying |
+    | `git stash push -m "msg"` | Save with a message |
+    | `git stash -u` | Also include untracked files |
 
-    > **Gotcha:** Plain `git stash` ignores untracked files. A brand-new
-    > file you have never `git add`-ed stays in the working directory.
-    > Use `git stash -u` if you need to include it.
+    Plain `git stash` doesn't touch untracked files — use `-u` if you
+    need them.
 
-    ### Task 5: Finish the feature properly
+    ### Task 5: Finish the feature
 
-    Edit `calculator.py` in the editor. Finalize the `power` function
-    with proper validation, then commit with a descriptive message.
-    (The test checks for "power" in the commit message.)
+    Replace the stub in `calculator.py` with a proper version, then
+    commit with "power" in the message:
 
     ```python
     def power(a, b):
@@ -720,12 +499,9 @@ steps:
 
     ### You can now
 
-    - **Context-switch cleanly** mid-work: stash, do the urgent task,
-      pop back to where you were — without polluting history.
-    - **Distinguish** `pop` from `apply`, and know when each is
-      appropriate.
-    - **Diagnose** why `git stash` sometimes seems to "miss" a new
-      file (it was untracked; need `-u`).
+    - Stash, context-switch, and pop without polluting history.
+    - Pick `pop` vs. `apply` correctly.
+    - Remember `-u` when the change involves untracked files.
   watch_files:
   - myproject/calculator.py
   open_file: myproject/calculator.py
@@ -751,30 +527,33 @@ steps:
     - git add calculator.py
     - git diff --cached --quiet || git commit -m 'Add power function with input validation'
     explanation: |
-      - **`git stash`:** snapshots tracked modifications and staged changes into a stash commit in `.git/refs/stash`, then resets the working tree to match HEAD. Untracked files are **not** included unless you use `git stash -u`.
-      - **`git stash pop`:** applies the top stash and removes it. Conflicts surface exactly like merge conflicts — resolve them, then `git add` and commit (or drop the stash manually).
-      - **Why not just `git commit -m "WIP"`?** A WIP commit pollutes shared history if pushed. The stash is *private, local, and temporary* — no risk of shipping half-baked work.
-      - **Internal:** a stash is stored as a merge commit reachable via `refs/stash`. Its **first parent** is HEAD at stash time; its **second parent** is a commit recording the **index** state. With `git stash -u`, a **third parent** records the untracked files. This is why `git stash apply <sha>` works even on detached stashes.
+      - `git stash` snapshots tracked modifications and staged changes into a commit at `.git/refs/stash`, then resets the working tree to HEAD. Untracked files need `-u`.
+      - `git stash pop` applies and drops the top entry. Conflicts resolve like merges.
+      - Why not `git commit -m "WIP"`? A WIP commit pollutes shared history if pushed. The stash is private and local.
+      - Internally a stash is a merge commit: first parent = HEAD at stash time, second = index state. `-u` adds a third parent for untracked files.
   tests:
   - description: Stash is empty (work was popped and committed)
     command: cd /tutorial/myproject && [ $(git stash list | wc -l) -eq 0 ]
     hints:
-    - text: Run `git stash list` — something is still on the stash stack. Two common reasons you might end here accidentally. (1) You used `git stash apply` (which restores but *keeps* the entry) when you meant `git stash pop` (which removes it). (2) You never popped at all and left your WIP stashed. Either way, `git stash pop` (or `git stash drop`) clears the list.
+    - text: 'Something is still on the stash stack. `git stash apply` keeps the entry around — use `git stash pop` (or `git stash drop`) to clear it.'
   - description: calculator.py contains the safe_divide hotfix
     command: cd /tutorial/myproject && grep -q 'def safe_divide' calculator.py
     hints:
-    - text: The hotfix was committed to a temporary branch (`hotfix-divide-zero`). For `safe_divide` to appear on `main`, you must **merge** that branch back into `main` before deleting it. Re-read Task 3 — which command after `git switch main` integrates the hotfix?
+    - text: 'The hotfix is on `hotfix-divide-zero` but never reached `main`. After `git switch main`, merge it in.'
       condition: 'code_missing: def safe_divide'
-    - text: '`safe_divide` exists in `calculator.py` but the test still fails — check that you ran it *after* saving the file in the editor. A `grep` against an unsaved buffer will miss your changes.'
+    - text: '`safe_divide` is in the file but the test still fails. Did you save before running the test?'
       condition: 'code_contains: def safe_divide'
   - description: power function has been committed
     command: cd /tutorial/myproject && git log --oneline | grep -qi 'power'
     hints:
-    - text: 'After `git stash pop` your in-progress `power` function is back in the working tree — but restoring it is not the same as committing it. The test looks for the word "power" in a commit message, so you still need a two-step save: `git add calculator.py` then `git commit -m "Add power function..."`. (Pick any message that includes "power".)'
+    - text: 'Pop your stash first — `git stash pop` brings the `power` function back into the file, then commit it.'
+      condition: 'code_missing: def power'
+    - text: 'The `power` function is back in the file but never committed. `git add calculator.py && git commit -m "Add power function"`.'
+      condition: 'code_contains: def power'
   - description: Working tree is clean
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
     hints:
-    - text: '`git status` will point at whatever is dirty. Most likely causes in this step: (a) `git stash pop` produced a conflict you didn''t finish resolving, (b) you edited but didn''t commit the finalized `power` function, or (c) a merge/commit was left half-done. Clean up the specific file Git is flagging, then commit or discard.'
+    - text: '`git status` tells you what''s dirty. Usually an unresolved stash-pop conflict or an uncommitted edit — clean it up or commit it.'
   quiz:
     title: git stash — Knowledge Check
     min_score: 0.8
@@ -839,26 +618,13 @@ steps:
 - title: 'Cherry-Pick: Copy One Specific Commit'
   view: git_graph
   instructions: |
-    ### The problem
+    One commit on `experimental` also belongs on `main` — not the whole
+    branch. Merging pulls in unrelated work; copy-paste loses authorship.
+    `git cherry-pick` computes the patch of one commit against its
+    parent and replays it on HEAD, creating a new commit with the same
+    diff and message but a different SHA.
 
-    Your team lead pings you: *"The bugfix in commit `b73f...` on the
-    `experimental` branch also applies to `main`. Can you pull in just
-    that one commit — not the rest of the branch?"*
-
-    Merging the whole branch would bring in unrelated work. Copying the
-    file manually loses authorship and context. You want surgical
-    precision: **take one commit, replay it on main**.
-
-    That is `git cherry-pick`.
-
-    ### How it works
-
-    `git cherry-pick <sha>` computes the *patch* (diff) of commit
-    `<sha>` against its parent, then applies that patch on top of
-    your current HEAD — creating a **new commit** with the same
-    changes and message but a different SHA.
-
-    **Before** — `experimental` has commits `α β γ`; `main` stops at `C`:
+    **Before** — `experimental` has `α β γ`; `main` stops at `C`:
 
     ```gitgraph
     @startuml
@@ -876,7 +642,7 @@ steps:
     @enduml
     ```
 
-    **After** `git cherry-pick β` — a new commit `β'` lands on `main` carrying the same patch as `β`, while `experimental` is unchanged:
+    **After** `git cherry-pick β` — `β'` lands on `main` with the same patch; `experimental` is unchanged:
 
     ```gitgraph
     @startuml
@@ -895,85 +661,50 @@ steps:
     @enduml
     ```
 
-    The copy is a **new commit object** — same patch, new parent, new SHA,
-    same message.
+    ### Task 1: Inspect the `experimental` branch
 
-    ### Task 1: Inspect the pre-built `experimental` branch
-
-    The tutorial has already created an `experimental` branch with two
-    commits — a half-baked `experimental_multiply` (not ready), and a
-    reusable `absolute` value function you want to backport. Inspect:
+    Setup created an `experimental` branch with two commits — a
+    half-baked `experimental_multiply`, and an `absolute` value function
+    you want to backport.
 
     ```bash
     git log experimental --oneline
     git diff main experimental -- calculator.py
     ```
 
-    You want only the **second** commit on main, not the half-baked
-    one. Time to cherry-pick.
+    You want only the second commit (`Add absolute value function`).
 
-    You want only the **second** commit (`Add absolute value function`)
-    on `main`, not the half-baked experimental multiply.
-
-    ### Task 2: Return to main and cherry-pick
+    ### Task 2: Cherry-pick
 
     ```bash
     git switch main
-    git log experimental --oneline
-    ```
-
-    Copy the SHA of the `Add absolute value function` commit, then:
-
-    ```bash
-    git cherry-pick <that-sha>
-    ```
-
-    Or avoid copying the SHA entirely by using a relative reference —
-    since `Add absolute value function` is the **tip** of `experimental`:
-
-    ```bash
     git cherry-pick experimental
     ```
 
-    Now check:
+    (A branch name resolves to its tip, so you don't need to copy the
+    SHA — the tip of `experimental` is the commit you want.)
 
     ```bash
     git log --oneline
     cat calculator.py
     ```
 
-    You will see a new commit on `main` with message
-    `Add absolute value function`. Its SHA is **different** from the
-    original on `experimental`, but the patch is identical.
+    A new commit with message `Add absolute value function` is on
+    `main`. Its SHA is **different** from the original.
 
-    ### Stop and self-explain
+    ### Why is the SHA different?
 
-    Before reading the explanation below, **say out loud (or write on
-    paper) in one sentence** why the cherry-picked commit has a
-    different SHA even though it contains exactly the same patch.
-
-    …
-
-    Here is the expected answer — compare with yours:
+    Stop and answer in one sentence before reading on.
 
     > A commit's SHA is `SHA-1(tree + parent(s) + author + committer +
-    > message)`. Cherry-picking onto `main` gives the new commit a
-    > **different parent** (the tip of main, not the tip of experimental),
-    > so at least the parent component of the hash changes → new SHA.
-    > Same patch, new identity. This is consistent with Step 2's
-    > object model: commits are immutable; "moving" a commit actually
-    > creates a fresh one.
+    > message)`. Cherry-picking gives the new commit a different
+    > parent (`main`'s tip, not `experimental`'s), so the hash
+    > changes. Same patch, new identity.
 
-    If your answer matched, the object-model mental model is
-    sticking. If it did not, re-read the explanation — this pattern
-    will come back in Steps 7 and 8.
+    ### Task 3: Resolve a cherry-pick conflict
 
-    ### Task 3: Handle a cherry-pick conflict (desirable difficulty)
-
-    Cherry-picks can conflict — the patch does not apply cleanly. Let's
-    force one. Make sure you are on `main`, then in the editor change
-    the line `def add(a, b): return a + b` to a multi-line version with
-    a docstring:
+    Let's force a conflict. On `main`, change
+    `def add(a, b): return a + b` in the editor to:
 
     ```python
     def add(a, b):
@@ -981,67 +712,43 @@ steps:
         return a + b
     ```
 
-    Save, then commit:
+    Commit it:
 
     ```bash
     git add calculator.py
     git commit -m "Document add function"
     ```
 
-    Now switch to `experimental` and make a **different** change to the
-    same line. Switch first:
+    Now make a different change to the same line on `experimental`:
 
     ```bash
     git switch experimental
     ```
 
-    In the editor, change `def add(a, b): return a + b` to:
+    Change `def add(a, b): return a + b` to:
 
     ```python
     def add(a, b): return a + b  # simple addition
     ```
 
-    Save, then commit:
+    Commit:
 
     ```bash
     git add calculator.py
     git commit -m "Inline comment on add"
     ```
 
-    Attempt to cherry-pick the conflicting commit onto main:
+    Now replay the cherry-pick:
 
     ```bash
     git switch main
     git cherry-pick experimental
     ```
 
-    Git will report a conflict. Inspect:
+    Git reports a conflict. `git status` and `cat calculator.py` show
+    `<<<<<<<`, `=======`, `>>>>>>>` markers.
 
-    ```bash
-    git status
-    cat calculator.py
-    ```
-
-    You will see conflict markers `<<<<<<<`, `=======`, `>>>>>>>` in
-    the editor.
-
-    > **A reframe worth holding onto:** merge/cherry-pick conflicts
-    > are **not failures**. They are Git saying: "two valid changes
-    > touched the same lines; a human must decide how to combine
-    > them." You will see hundreds of these in your career. Each one
-    > you resolve makes the next one faster. Treat every conflict as
-    > a tiny code review you give yourself.
-
-    > ⚠️ **What not to do:** the novice panic response here is to
-    > `git cherry-pick --abort`, delete the local folder, copy the
-    > conflicting file out, re-clone, and try again. **Don't.** Git
-    > has already loaded both versions into your editor — the fix
-    > is 30 seconds of reading and typing. Taking the "burn down"
-    > shortcut once costs you 30 seconds; taking it every time costs
-    > you the ability to ever resolve a conflict.
-
-    Resolve the conflict by keeping the docstring
-    **and** the inline comment — edit in the editor so the block reads:
+    Resolve by keeping both the docstring and the comment:
 
     ```python
     def add(a, b):
@@ -1049,50 +756,34 @@ steps:
         return a + b  # simple addition
     ```
 
-    (Delete the `<<<<<<<`, `=======`, `>>>>>>>` markers as you go.)
-    Save, then complete the cherry-pick:
+    Delete the `<<<`/`===`/`>>>` markers, save, then:
 
     ```bash
     git add calculator.py
     git cherry-pick --continue
     ```
 
-    If you had wanted to bail out entirely, `git cherry-pick --abort`
-    would restore `main` to before the cherry-pick.
+    `git cherry-pick --abort` would have restored `main` instead.
 
-    ### Transfer: pick the right tool
+    ### Pick the right tool
 
-    Decide — on your own — which Git tool is best for each scenario:
-
-    1. Your teammate pushed 50 commits on a feature branch. You want
-       all of them on `main` as individual commits. **Tool?**
-    2. A CVE disclosure says a single commit on `main` has a security
-       hole. You need to apply the fix to three release branches
-       (`release-1.0`, `release-1.1`, `release-1.2`). **Tool?**
-    3. Your own feature branch has 10 messy WIP commits. Before
-       opening a PR, you want them as one clean commit. **Tool?**
+    1. 50 commits on a feature branch, all need to land on `main`. Which tool?
+    2. A CVE fix on `main` needs to go to three release branches. Which tool?
+    3. 10 messy WIP commits on your branch, clean them up into one before PR. Which tool?
 
     <details><summary>Answers</summary>
 
-    1. `git merge feature` (or `git rebase` if you want linear
-       history). Cherry-picking 50 commits one by one is laborious and
-       loses merge-base info. Cherry-pick is **surgical**, not bulk.
-    2. `git cherry-pick <fix-sha>` on each release branch. Classic
-       backport pattern — exactly what cherry-pick was built for.
-    3. `git rebase -i` with `squash`/`fixup` (Step 8). Cherry-pick
-       does not clean up the source branch — it only copies from
-       there.
+    1. `git merge` (or `git rebase`). Cherry-picking 50 commits is the wrong shape of tool.
+    2. `git cherry-pick <fix-sha>` on each release branch — classic backport.
+    3. `git rebase -i` with `squash`/`fixup` (Step 8).
 
     </details>
 
     ### You can now
 
-    - **Recognize** when cherry-pick is the right tool (one-commit
-      backport) versus the wrong tool (many-commit integration).
-    - **Resolve** a cherry-pick conflict end-to-end: inspect markers,
-      edit to merge both sides, `git add`, `git cherry-pick --continue`.
-    - **Explain** why the copied commit has a new SHA, invoking the
-      object-model reasoning from Step 2.
+    - Tell when cherry-pick fits (one-commit backport) vs. doesn't (bulk integration).
+    - Resolve a cherry-pick conflict and `--continue`.
+    - Explain why the copied commit gets a new SHA.
   watch_files:
   - myproject/calculator.py
   open_file: myproject/calculator.py
@@ -1115,36 +806,40 @@ steps:
     - git add calculator.py
     - GIT_EDITOR=true git cherry-pick --continue || git commit --no-edit
     explanation: |
-      - **Cherry-pick = patch + replay:** Git diffs the target commit against its parent, applies the diff on top of HEAD, creates a new commit. The original commit is untouched.
-      - **New SHA:** The cherry-picked commit has a different parent on main, so its content and SHA differ from the source. This is fine for isolated fixes but means `git log` will show it as "new" even though the patch is identical.
-      - **Conflicts:** When the patch does not apply cleanly, Git pauses the cherry-pick. Resolve conflicts in the working tree, `git add` the files, then `git cherry-pick --continue`. Use `--abort` to bail out and restore the pre-cherry-pick state.
-      - **Use cases:** Backporting a fix to a release branch, pulling a reviewed commit into main while leaving the rest of the branch, un-stashing one commit from a rejected pull request.
+      - Cherry-pick = patch + replay. Git diffs the target against its parent, applies that diff on HEAD, creates a new commit.
+      - The new commit has a different parent, so it gets a new SHA — same patch, new identity.
+      - On conflict, Git pauses. Fix the file, `git add`, then `git cherry-pick --continue` (or `--abort`).
+      - Typical uses: backporting a fix to release branches; pulling one reviewed commit out of a larger branch.
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
     hints:
-    - text: Cherry-picking leaves HEAD on whatever branch you ran the command from. Tasks 3 switches you to `experimental` to make a conflicting commit — return with `git switch main` before the conflict resolution, so the cherry-pick lands on the correct branch.
+    - text: "You're on the wrong branch. Cherry-pick lands on whatever branch you run it from — `git switch main` before picking."
   - description: main contains the absolute value function (cherry-picked)
     command: cd /tutorial/myproject && grep -q 'def absolute' calculator.py && git log --oneline | grep -qi 'absolute value'
     hints:
-    - text: 'The `absolute` function or its commit is missing from `main`''s history. Inspect the source first: `git log experimental --oneline` shows two commits — you want the one titled `Add absolute value function` (the **tip** of `experimental`), not the earlier experimental_multiply. Either cherry-pick it by its SHA, or use the relative reference: `git cherry-pick experimental`.'
+    - text: 'Pick the tip of `experimental` — that''s the "Add absolute value function" commit. `git cherry-pick experimental` works (a branch name resolves to its tip).'
       condition: 'code_missing: def absolute'
-    - text: The `absolute` function is in the file, but the commit title doesn't match. Cherry-pick normally preserves the source commit's message — if you overrode it, make sure the new commit message still contains the phrase "absolute value".
+    - text: 'The function is there but the commit message is missing the phrase "absolute value". Did you edit the message during cherry-pick?'
       condition: 'code_contains: def absolute'
   - description: main does NOT contain experimental_multiply
     command: cd /tutorial/myproject && ! grep -q 'def experimental_multiply' calculator.py
     hints:
-    - text: '`experimental_multiply` leaked into `main`. That happens if you merged the whole `experimental` branch or cherry-picked the wrong commit. Cherry-pick is **surgical** — it copies *one* commit. Pick only the "Add absolute value function" commit (the tip of `experimental`), not the earlier one. If the mistake already landed, `git reset --hard HEAD~1` on a clean tree rewinds it.'
+    - text: 'You picked the wrong commit (or merged the whole branch). Cherry-pick copies *one* commit — only the tip of `experimental`. If the bad commit already landed, `git reset --hard HEAD~1` undoes it.'
   - description: main includes a commit with 'Document' or 'comment' in the message
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'document|comment'
     hints:
-    - text: 'Task 3 sets up a deliberate conflict by editing `def add` on `main`. In the editor, rewrite the one-line `def add(a, b): return a + b` into a multi-line version with a `"""Return the sum of two numbers."""` docstring, then `git add calculator.py && git commit -m "Document add function"` — the message must contain "Document" or "comment".'
+    - text: 'Edit `def add` on `main` — make it multi-line with a `"""..."""` docstring — then commit with "Document" in the message. This is what creates the conflict Task 4 wants you to resolve.'
+      condition: 'code_missing: Return the sum'
+    - text: 'The docstring is there but no commit mentions "Document" or "comment" yet. `git commit -m "Document add function"`.'
+      condition: 'code_contains: Return the sum'
   - description: No unresolved conflict markers remain
     command: cd /tutorial/myproject && ! grep -E '^(<{7}|={7}|>{7})' calculator.py
     hints:
-    - text: Conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) are still present in `calculator.py`. A conflict is not a failure — Git is asking you to choose. Open the file, keep *both* the docstring **and** the inline comment (the instructions show the exact merged form), delete the three marker lines, save, then `git add calculator.py` and `git cherry-pick --continue`.
+    - text: 'Conflict markers are still in the file. Keep both the docstring and the inline comment, delete the `<<<`/`===`/`>>>` lines, save, then `git add && git cherry-pick --continue`.'
       condition: 'code_contains: <<<<<<<'
-    - text: '`git status` should say `You are currently cherry-picking commit …`. After removing markers and saving, finish with `git add calculator.py && git cherry-pick --continue`. If you want to start over instead, `git cherry-pick --abort` restores a clean main.'
+    - text: 'Cherry-pick is paused. `git add calculator.py && git cherry-pick --continue` finishes it; `git cherry-pick --abort` bails out.'
+      condition: 'output_contains: cherry-pick'
   quiz:
     title: Cherry-Pick — Knowledge Check
     min_score: 0.8
@@ -1201,65 +896,45 @@ steps:
 - title: 'git blame: Who Last Changed This Line (and Why)?'
   view: editor
   instructions: |
-    ### The forensic question
+    ### Why blame
 
-    You are reading `calculator.py` and spot a suspicious line. Before
-    ripping it out, you want to know:
+    You see a line in `calculator.py` that looks wrong. Before touching
+    it, you want the story: who wrote it, when, and what problem were
+    they solving. `git blame` gives you the commit that last touched
+    each line — the starting point for reading the *why*.
 
-    - **Who** last changed this line?
-    - **When** did they change it?
-    - **Why** did they change it — what commit message did they leave?
+    The name is misleading. In practice you use it to get *context*,
+    not to assign fault.
 
-    `git blame` answers all three. Used defensively (not accusingly!),
-    it is one of the most-used commands in professional development.
+    ### The two-step
 
-    > **Don't literally "blame":** The command is named poorly. In
-    > practice you use it to find *context* — the commit that introduced
-    > or last touched a line, so you can read its message and diff
-    > before changing or reverting the line.
+    Blame alone is noise. The workflow is:
 
-    ### The idiomatic two-step
+    1. `git blame -L <start>,<end> <file>` → get the SHA for the lines you care about.
+    2. `git show <sha>` → read the commit message and diff.
 
-    Blame by itself is noise until you use it to answer "why". The
-    real workflow is two commands:
+    ### Useful flags
 
-    1. `git blame -L <start>,<end> <file>` → find the SHA of the
-       commit that last touched the line(s) you care about.
-    2. `git show <sha>` → read the commit message and full diff. This
-       is where the *why* lives.
-
-    ### Flag reference (read once, keep handy)
-
-    | Flag | Use when |
+    | Flag | When |
     |---|---|
-    | `-L start,end` | You already know roughly which lines matter — avoids scrolling hundreds of lines |
-    | `-w` | A reformatter (`black`, `gofmt`) ran recently and is masking the real author |
-    | `-C -M` | A line was moved/copied across files — follow it back to its origin, not the last mover |
-    | `blame.ignoreRevsFile` config | Permanently skip known reformat commits on your team |
+    | `-L start,end` | Narrow to specific lines |
+    | `-w` | Skip whitespace-only changes (formatter ran) |
+    | `-C -M` | Follow moves and copies across files |
+    | `blame.ignoreRevsFile` | Permanently skip known reformat commits |
 
-    ### Task 1: A forensic mystery — find why a line exists
+    ### Task 1: Find why a line exists
 
-    Pretend you just joined this project and opened `calculator.py`.
-    You see a function that looks odd — maybe it's the `safe_divide`
-    function, or `absolute`, or `divide`. **Before you change or
-    remove it**, you need to know the story: who wrote it, when, and
-    what problem were they solving?
+    Pick a line — say line 7. Before running blame, predict:
 
-    **Predict first:** pick a specific line (e.g., the opening line
-    of `safe_divide` if present, else line 7). Guess — will `git
-    blame` on that line show:
+    - (A) Today's date? (The tutorial just built this.)
+    - (B) Years ago?
+    - (C) The same commit on every line?
 
-    - (A) Today's date? (The tutorial just built this state.)
-    - (B) A date from years ago?
-    - (C) The same commit as every other line in the file?
+    <details><summary>Answer</summary>
 
-    <details><summary>Reveal the answer</summary>
-
-    **All timestamps will be "today"** (the tutorial built them in
-    this session). What will differ is the **SHA and commit message**
-    per line — each line traces to the commit that introduced or
-    last modified it. In a real project, timestamps span months or
-    years, making blame a true archaeology tool.
+    Every timestamp will be today — the tutorial built this state
+    moments ago. What differs is the SHA and message per line. On a
+    real project, timestamps span months or years.
 
     </details>
 
@@ -1267,58 +942,42 @@ steps:
 
     ```bash
     git blame -L 7,7 calculator.py
-    # Copy the SHA from the first column, then:
+    # Copy the SHA, then:
     git show <that-sha>
     ```
 
-    You now know **who** wrote it, **when**, and **why** (from the
-    commit message and diff). That is 90% of how blame is used on real
-    teams.
+    You have the who, when, and why. That's most of how blame is used.
 
-    ### Think like a detective
+    ### The recipe
 
-    Professional `git blame` usage is always a **chain** of commands,
-    never just one call. The recipe:
+    Blame is always a chain:
 
-    1. `git blame -L <line>,<line> <file>` → narrow to the line(s)
-       of interest.
-    2. `git show <sha>` → read the commit's full message and diff to
-       understand **intent**, not just the change.
-    3. If the commit message is vague (`"fix"`, `"wip"`), fall back
-       to `git log --all --grep=<keyword>` or `git bisect` (Step 6).
-    4. If the line's last change was a reformatter, repeat with `-w`
-       to skip whitespace-only changes.
+    1. `git blame -L <line>,<line> <file>` — find the SHA.
+    2. `git show <sha>` — read message and diff for intent.
+    3. If the message is vague, `git log --all --grep=<keyword>` or fall back to `git bisect` (next step).
+    4. If the last change was a reformatter, re-run with `-w`.
 
-    Bookmark this four-step recipe. It works on every real codebase.
-
-    ### Task 2: Practice the "reformatter" defense
-
-    Compare output with and without `-w`:
+    ### Task 2: The reformatter defense
 
     ```bash
     git blame calculator.py | head
     git blame -w calculator.py | head
     ```
 
-    In this tutorial's tiny repo the two are identical — but on a
-    project where someone recently ran `black` or `prettier`, `-w`
-    would suddenly reveal the *real* last authors of every line,
-    previously masked by the formatter commit.
+    In this tiny repo they look identical. On a project where someone
+    just ran `black` or `prettier`, `-w` reveals the real authors
+    hidden behind the formatter commit.
 
-    ### GitHub visualizes blame very well
+    ### On GitHub
 
-    Every file view on GitHub has a **Blame** button — the web UI
-    shows the same data with clickable links to each commit. Useful
-    during code review in the browser.
+    Every file view has a **Blame** button — same data, clickable
+    commits. Handy during browser-based review.
 
     ### You can now
 
-    - **Chain** `git blame -L` → `git show` to answer "why does this
-      line exist?" in two commands.
-    - **Defuse** a reformatter commit that masks the real author with
-      `-w` or `blame.ignoreRevsFile`.
-    - **Recognize** when blame cannot help — bugs caused by a
-      *missing* line (see the last quiz question).
+    - Chain `git blame -L` → `git show` to answer "why does this line exist?"
+    - Work around a reformatter with `-w` or `blame.ignoreRevsFile`.
+    - Spot when blame can't help — bugs from a *missing* line (see quiz).
   setup_commands:
   - cd /tutorial/myproject && git switch main 2>/dev/null; true
   solution:
@@ -1326,28 +985,28 @@ steps:
     - cd /tutorial/myproject
     - SHA=$(git blame -L 7,7 calculator.py | awk '{print $1}' | tr -d '^') && git show $SHA
     explanation: |
-      - **`git blame <file>`:** Shows, for every line, the SHA / author / timestamp of the commit that last modified it.
-      - **`-L start,end`:** Restrict to a line range — avoids hundreds of irrelevant lines on large files.
-      - **`-w`:** Ignore whitespace-only changes so reformatting commits do not shadow the real author.
-      - **`-C -M`:** Follow moves and copies across the file; essential when a line was refactored into a new location.
-      - **Workflow:** use blame to find the SHA, then `git show <sha>` to read the full commit message and diff. That is where the *why* lives.
+      - `git blame <file>`: per-line SHA, author, timestamp of the last change.
+      - `-L start,end`: restrict to a line range.
+      - `-w`: skip whitespace-only changes so reformatters don't shadow the real author.
+      - `-C -M`: follow moves and copies across the file.
+      - Workflow: blame → `git show <sha>` for the commit message and diff. The *why* lives there.
   tests:
   - description: calculator.py exists and has at least 2 commits in its history
     command: cd /tutorial/myproject && [ -f calculator.py ] && [ $(git log --oneline -- calculator.py | wc -l) -ge 2 ]
     hints:
-    - text: This test just verifies the starting state — `calculator.py` should exist under `/tutorial/myproject` with a multi-commit history. If you're failing it, you're probably in the wrong directory or the file was deleted. `cd /tutorial/myproject` and `ls` to check.
+    - text: "You're probably not in `/tutorial/myproject`. `cd` there and check `ls calculator.py`."
   - description: Blame runs without error on calculator.py
     command: cd /tutorial/myproject && git blame calculator.py >/dev/null
     hints:
-    - text: '`git blame calculator.py` should run cleanly from `/tutorial/myproject`. An error usually means you''re in the wrong directory or passed a non-existent filename. Run `pwd` and `ls calculator.py` to verify.'
+    - text: 'Run `git blame calculator.py` from `/tutorial/myproject`. Check `pwd` — wrong directory is the usual culprit.'
   - description: Blame reports per-line SHA + author + timestamp (format check)
     command: cd /tutorial/myproject && git blame calculator.py | head -1 | grep -qE '^[\^a-f0-9]+ .* \([^)]+[0-9]+\)'
     hints:
-    - text: Plain `git blame calculator.py` (no extra flags) prints lines in the default format — each starts with a SHA, then author, then a parenthesized timestamp. If output is empty, the file has no committed content yet; check `git log -- calculator.py`.
+    - text: 'Just `git blame calculator.py` — no flags. Each line gets SHA, author, and timestamp.'
   - description: -L line-range flag works (returns output for specified range)
     command: cd /tutorial/myproject && [ -n "$(git blame -L 1,3 calculator.py 2>/dev/null)" ]
     hints:
-    - text: 'The `-L` flag restricts blame to a line range. The syntax is `-L <start>,<end>` (comma-separated, no spaces). Example: `git blame -L 1,3 calculator.py` limits output to the first three lines — very useful on large files when you already know which lines matter.'
+    - text: 'The syntax is `-L <start>,<end>` — comma, no space. E.g. `git blame -L 1,3 calculator.py`.'
   quiz:
     title: git blame — Knowledge Check
     min_score: 0.8
@@ -1360,7 +1019,7 @@ steps:
       - The remote collaborators who have access to the file
       - The diff of the most recent commit that touched the file
       correct_index: 1
-      explanation: 'Blame gives per-line provenance — the last-touching commit and author. Combined with `git show <sha>`, you see the full context: why the line was written this way.'
+      explanation: 'Blame gives per-line provenance. Pair it with `git show <sha>` for the full context.'
     - question: You need to know the commit message for line 42's last modification. Which sequence gets you there fastest?
       options:
       - '`git log calculator.py | grep 42`'
@@ -1368,7 +1027,7 @@ steps:
       - '`git diff calculator.py` to see what changed'
       - '`git status calculator.py`'
       correct_index: 1
-      explanation: '`git blame -L 42,42` restricts output to line 42 only — instant. The first column is the SHA; pipe that SHA into `git show` for the full message. This two-step recipe is idiomatic.'
+      explanation: '`-L 42,42` restricts to one line. Take the SHA from column 1 and run `git show` on it.'
     - question: A colleague recently ran `black` across the whole repository. Now `git blame` shows them as the author of every line. How do you see the *real* last-meaningful author?
       options:
       - Revert the `black` commit
@@ -1376,7 +1035,7 @@ steps:
       - Git has no way to recover this information
       - Use `git reflog` to rewind blame
       correct_index: 1
-      explanation: '`-w` ignores whitespace-only changes, hiding pure reformatting from blame. For recurring formatters, add the reformat commit SHAs to a file referenced by `blame.ignoreRevsFile` — now everyone skips them consistently.'
+      explanation: '`-w` skips whitespace-only changes. For recurring formatters, list the commit SHAs in `blame.ignoreRevsFile` so the whole team skips them.'
     - question: '**[Revisit Step 2]** When `git blame` prints a SHA for a line, what kind of object does that SHA refer to?'
       options:
       - A blob object containing just that one line
@@ -1384,7 +1043,7 @@ steps:
       - A commit object — the last one that modified that line
       - A stash entry
       correct_index: 2
-      explanation: Blame attributes lines to commits. The SHA printed is a commit SHA — run `git cat-file -t <sha>` to confirm it reports `commit`. You then use `git show <sha>` to read it.
+      explanation: Blame attributes lines to commits. Confirm with `git cat-file -t <sha>` — it reports `commit`.
     - question: When is `git blame` the **wrong** tool for finding a bug?
       options:
       - When the bug is a missing line that was never added
@@ -1392,7 +1051,7 @@ steps:
       - When you need the timestamp of a line
       - When you need the commit message behind a line
       correct_index: 0
-      explanation: Blame only tells you about *existing* lines. A bug caused by an *absent* line (e.g., forgetting to call `validate()`) leaves blame blind. For regressions introduced by a missing line, use `git bisect` (next step) or `git log -p` to scan history.
+      explanation: Blame only covers lines that exist. For a bug caused by a missing line (e.g., a forgotten `validate()` call), use `git bisect` or `git log -p`.
     - question: '**[Analyze]** Give a concrete bug where `git blame` would mislead you even though the culprit line IS in the file. Which of the following fits best?'
       options:
       - A one-character typo fixed by a teammate — blame shows the typo's original commit, not the fix
@@ -1400,7 +1059,7 @@ steps:
       - A commit that was cherry-picked to `main` from `experimental`
       - A commit that was merged via a merge commit
       correct_index: 1
-      explanation: 'Reformatter commits are the classic blame-mislead scenario. The CI bot''s commit ''last touched'' every line, so blame attributes all lines to the bot — hiding the real author who introduced the logic bug. Defense: `git blame -w` to skip whitespace-only changes, or `blame.ignoreRevsFile` to skip known reformat commits.'
+      explanation: 'Reformatters are the classic blame-mislead. The CI bot ''last touched'' every line, hiding the author who introduced the bug. Defense: `-w` or `blame.ignoreRevsFile`.'
     - question: '**[Revisit Step 3]** You are about to run `git blame` on a file. Your working directory has uncommitted changes to that file. Will blame show you the committed lines or your uncommitted edits?'
       options:
       - Your uncommitted edits — blame always reflects the current working tree
@@ -1408,73 +1067,55 @@ steps:
       - Both, merged together with conflict markers
       - Git refuses to run blame until changes are committed or stashed
       correct_index: 1
-      explanation: Blame operates on committed history. Your uncommitted edits are invisible to blame — which is usually what you want (you are trying to find who wrote the *committed* version of a line). If you want to clear uncommitted changes first to compare cleanly, `git stash` (Step 3) is a non-destructive option.
+      explanation: Blame operates on committed history. Your uncommitted edits are invisible — usually what you want. To clear them first without losing work, `git stash`.
 - title: 'git bisect: Binary Search for the Commit That Broke Things'
   view: editor
   instructions: |
     ### The scenario
 
-    It is Friday. Tests passed yesterday. Today `pytest` reports a
-    failure. You have made **~30 commits** in between. Which one broke it?
+    Tests passed yesterday. Today they fail. ~30 commits in between.
+    Which one broke it?
 
-    Reading 30 diffs by hand is slow and error-prone. `git blame` only
-    helps if you know the guilty line (you usually don't). `git log
-    --grep="fix"` is hopeful guessing.
+    Reading 30 diffs by hand is slow. `git blame` needs a guilty line
+    you don't have. `git log --grep="fix"` is guesswork.
 
-    `git bisect` runs a **binary search** across history. It needs:
+    `git bisect` binary-searches history. It needs:
 
-    1. A commit where the test **passed** (`good`).
-    2. A commit where the test **fails** (`bad`, usually HEAD).
-    3. A command (or manual judgment) to test each candidate.
+    1. A commit where the test passed (`good`).
+    2. A commit where it fails (`bad`, usually HEAD).
+    3. A way to test each candidate.
 
-    With 30 commits, it takes `log2(30) ≈ 5` tests to pinpoint the
-    exact breaking commit. Scales beautifully: 1000 commits → 10 tests.
+    30 commits → `log₂(30) ≈ 5` tests. 1000 commits → 10 tests.
 
-    ### Task 1: Inspect the broken project
+    ### Task 1: See the break
 
-    The tutorial has pre-built a regression for you to hunt:
-
-    - `test_calculator.py` — a regression test that used to pass.
-    - 5 unrelated-looking commits on top of it, **one of which
-      silently broke the `absolute` function.** Your job is to find
-      which one.
-
-    First, see the history:
+    The tutorial pre-built a regression: `test_calculator.py` that
+    used to pass, plus 5 innocuous-looking commits on top, one of
+    which silently broke `absolute`.
 
     ```bash
     git log --oneline -7
     ```
 
-    You will see commits like `Refactor: tidy docstring`, `Add unused
-    helper comment`, `Simplify absolute`, `Later tweak`, `Even later
-    tweak`.
+    You'll see messages like `Refactor: tidy docstring`, `Simplify
+    absolute`, `Later tweak`.
 
-    **Predict first (human bisect):** based on the commit messages
-    alone, which one do you suspect introduced the bug? Write it
-    down. After `git bisect` finishes, compare — did the algorithm
-    agree with your intuition?
+    **Predict:** which one looks suspect? Note your guess. After
+    bisect finishes, compare.
 
-    > **Why this matters:** in real projects, good commit messages
-    > cut debugging time in half. If every commit said "WIP" or
-    > "fix", your human bisect would be hopeless and you'd be forced
-    > to run the full 10+ automated bisect iterations. Descriptive
-    > messages let you skip half the search mentally. Pair this
-    > lesson with any future "why should I bother writing good commit
-    > messages?" moment.
+    > Good commit messages cut bisect time in half — you can often
+    > skip half the search from the messages alone. "WIP" and "fix"
+    > force you back to the full automated walk.
 
-    Now confirm the test fails:
+    Confirm the test fails:
 
     ```bash
     python3 test_calculator.py
     ```
 
-    You should see an `AssertionError` on the `absolute(-4) == 4` line —
-    proof that *something* in the last 5 commits broke it.
+    You'll see an `AssertionError` on `absolute(-4) == 4`.
 
-    ### Task 2: Run bisect manually
-
-    Start the search. Mark the current state `bad` and an earlier-known-good
-    commit `good`:
+    ### Task 2: Manual bisect
 
     ```bash
     git bisect start
@@ -1482,31 +1123,27 @@ steps:
     git bisect good HEAD~5
     ```
 
-    Git checks out a commit in the middle and prompts you. Test it:
+    Git checks out the midpoint. Test it:
 
     ```bash
     python3 test_calculator.py
     ```
 
-    Based on the result:
+    - Passes → `git bisect good`
+    - Fails → `git bisect bad`
 
-    - **Tests pass** → `git bisect good`
-    - **Tests fail** → `git bisect bad`
+    Repeat 2-3 times until Git prints the first bad commit.
 
-    Repeat 2-3 times. Git narrows the range each step. When it
-    finishes, it prints the first bad commit and its full message.
-
-    When done, always clean up:
+    Always finish with:
 
     ```bash
     git bisect reset
     ```
 
-    ### Task 3: Automate with `git bisect run`
+    ### Task 3: `git bisect run`
 
-    Manually marking good/bad is tedious. If the test script returns
-    **exit 0 on pass**, **non-zero on fail**, bisect can automate the
-    whole search:
+    If the test exits 0 on pass and non-zero on fail, bisect can
+    run itself:
 
     ```bash
     git bisect start HEAD HEAD~5
@@ -1514,16 +1151,13 @@ steps:
     git bisect reset
     ```
 
-    `git bisect run` invokes the command at each candidate commit and
-    uses the exit code to decide good/bad. It reports the culprit and
-    exits, no user input needed. This is the feature you will use on
-    real projects.
+    Git iterates, reports the culprit, exits. This is how you'll
+    use bisect in practice.
 
-    ### Task 4: Fix the bug you just found
+    ### Task 4: Fix it
 
-    Bisect pointed at the `Simplify absolute (BUG: removes negation!)`
-    commit. In the editor, open `calculator.py` and find the
-    `absolute` function. Restore its correct body:
+    Bisect points at `Simplify absolute (BUG: removes negation!)`.
+    Open `calculator.py` and restore the function:
 
     ```python
     def absolute(x):
@@ -1531,68 +1165,42 @@ steps:
         return x if x >= 0 else -x
     ```
 
-    Save, then commit the fix:
+    Commit and verify:
 
     ```bash
     git commit -am "Fix: restore negation in absolute"
-    ```
-
-    Verify the tests pass:
-
-    ```bash
     python3 test_calculator.py
     ```
 
-    You should see `all tests pass`. The regression is closed.
+    You should see `all tests pass`.
 
     ### You can now
 
-    - **Decide** whether bisect is worth it for a given regression
-      (rule of thumb: ≥ ~5 commits or slow tests → yes).
-    - **Run** an automated bisect with `git bisect start HEAD
-      <known-good>; git bisect run <cmd>` — and always end with `git
-      bisect reset`.
-    - **Recognize** scenarios where blame (Step 5) fails but bisect
-      succeeds: missing lines, behavioral regressions, deletions.
+    - Decide when bisect pays off (≥ ~5 commits or slow tests).
+    - Run an automated bisect and always clean up with `git bisect reset`.
+    - Spot where blame fails but bisect wins: missing lines, deletions, behavioral regressions.
 
-    ### Why does this work?
+    ### Why it works
 
-    Version history is (approximately) a chain of commits. If commit X
-    is bad and an ancestor Y is good, the break is somewhere on the
-    path from Y to X. Binary search halves the candidate range at each
-    step — guaranteed `O(log n)` tests to find the exact culprit.
+    If X is bad and ancestor Y is good, the break sits between them.
+    Halving the range each step is `O(log n)` — guaranteed.
 
-    > **Required properties of your test:** It must run cleanly on
-    > every historical commit. If the test was added after the
-    > regression, either use `git bisect run -- bash -c 'cp
-    > /tmp/test.py . && python3 test.py'` (restoring the modern test
-    > each iteration), or write a smaller, older-friendly regression
-    > test before you start.
+    > **Test portability:** the test has to run on every commit in
+    > the range. If the test file was added mid-range, keep it
+    > outside and restore it each iteration:
+    > `git bisect run bash -c 'cp /tmp/test.py . && python3 test.py'`.
 
-    ### Transfer: decide whether bisect is worth it
+    ### Transfer: when is bisect worth it?
 
-    Consider each scenario. Would you reach for `git bisect run`?
-    Why or why not?
-
-    1. The regression is in the last **3 commits**. Your test takes
-       **0.1 seconds** to run. Bisect or manual? **Reason.**
-    2. The regression is in the last **500 commits**. Your test takes
-       **8 minutes** to run per commit. Bisect or manual? Estimate
-       total time.
-    3. The regression test was **added yesterday** (so historical
-       commits don't even contain the test file). Does bisect still
-       work? How?
+    1. 3 commits, test runs in 0.1s — bisect or manual?
+    2. 500 commits, test runs in 8 min — estimate total time either way.
+    3. The regression test was only added yesterday. Can bisect still work?
 
     <details><summary>Answers</summary>
 
-    1. **Manual.** With 3 commits, reading diffs is instant; bisect
-       setup + 2 tests is slower. Rule of thumb: below ~5 commits,
-       skip bisect.
-    2. **Bisect.** `log₂(500) ≈ 9` tests × 8 min = ~72 min total,
-       fully automated. Manual would be 500 × 8 = 66 hours.
-    3. **Yes,** but you must keep the test outside the bisect range.
-       Copy it back at each iteration via
-       `git bisect run bash -c 'cp /tmp/test.py . && python3 test.py'`.
+    1. **Manual.** 3 commits = read the diffs. Below ~5, skip bisect.
+    2. **Bisect.** `log₂(500) ≈ 9` × 8 min = ~72 min automated. Manual is ~66 hours.
+    3. **Yes**, but keep the test outside the range and copy it in each iteration.
 
     </details>
   watch_files:
@@ -1612,30 +1220,30 @@ steps:
     - 'git commit -am ''Fix: restore negation in absolute'''
     - python3 test_calculator.py
     explanation: |
-      - **Binary search:** bisect halves the candidate range each step. `log₂(n)` tests find the exact breaking commit — 5 tests for 30 commits, 10 tests for 1000.
-      - **`git bisect start` / `bad` / `good`:** establishes the range. Git checks out the midpoint and waits for your verdict.
-      - **`git bisect run <cmd>`:** automates the search. The command runs at each candidate; exit 0 = good, non-zero = bad. Git iterates until one commit remains, prints it, and stops.
-      - **`git bisect reset`:** returns HEAD to the pre-bisect state and cleans up. **Always run this at the end**, even after `run` — otherwise you may end up on a commit in the middle of history and wonder why your code looks weird.
-      - **Test portability:** The test script must work at every commit in the range. If the test file itself was added partway through, copy it from outside the range for each iteration.
+      - Binary search halves the range each step. `log₂(n)` tests — 5 for 30 commits, 10 for 1000.
+      - `git bisect start` / `bad` / `good`: set the range. Git checks out the midpoint.
+      - `git bisect run <cmd>`: command's exit code drives the search (0 = good, non-zero = bad).
+      - `git bisect reset`: restores HEAD and clears bisect state. Always run it, even after `run`.
+      - The test must work at every commit in the range. If it was added mid-range, copy it in each iteration.
   tests:
   - description: Bisect has been cleaned up (no active bisect)
     command: cd /tutorial/myproject && [ ! -f .git/BISECT_LOG ]
     hints:
-    - text: '`.git/BISECT_LOG` still exists — bisect is paused mid-search. *Always* end bisect with `git bisect reset` (even after `git bisect run` finishes automatically), otherwise HEAD stays parked on a random historical commit. One command, always the same: `git bisect reset`.'
+    - text: 'Bisect is still running. Always finish with `git bisect reset` — even `git bisect run` leaves HEAD parked on a historical commit.'
   - description: Test file was committed
     command: cd /tutorial/myproject && git log --oneline -- test_calculator.py | grep -q '.'
     hints:
-    - text: '`test_calculator.py` isn''t in Git''s history. The setup script should have committed it — if the test is failing, the setup may not have run. Try `git add test_calculator.py && git commit -m "Add regression tests"` manually.'
+    - text: '`test_calculator.py` isn''t committed yet. `git add test_calculator.py && git commit -m "Add regression tests"`.'
   - description: At least 5 new commits exist on main
     command: cd /tutorial/myproject && [ $(git log --oneline main | wc -l) -ge 7 ]
     hints:
-    - text: Fewer than 7 commits on `main` — the 5 pre-built commits (the regression + decoys) are missing. Likely cause is that you ran `git reset --hard` to an earlier SHA during bisect confusion. Use `git reflog` to find the pre-bisect tip and `git reset --hard <sha>` to restore it before rerunning the step.
+    - text: 'History is too short — probably a `git reset --hard` during bisect confusion. Recover the pre-bisect tip from `git reflog` and reset back to it.'
   - description: The absolute function has been repaired (handles negatives, zero, and positives correctly)
     command: cd /tutorial/myproject && python3 -c "import sys; sys.path.insert(0,'.'); from calculator import absolute; assert absolute(-4) == 4 and absolute(3) == 3 and absolute(0) == 0 and absolute(-0.5) == 0.5"
     hints:
-    - text: 'The `absolute()` function is still broken. Task 4: once bisect points at the culprit commit, open `calculator.py` and replace the buggy body (`return x` / `return x  # simplification`) with the correct implementation — it should return `x` for non-negatives and `-x` for negatives. Then commit the fix.'
+    - text: 'Fix the body of `absolute` — return `x` when `x >= 0`, else `-x` — then commit.'
       condition: 'code_contains: def absolute'
-    - text: 'The `absolute` function was removed entirely. Add it back: one line of body that returns the magnitude, negating when `x < 0`. Then commit the fix.'
+    - text: '`absolute` is gone entirely. Add it back (one-line body using the sign of `x`), then commit.'
       condition: 'code_missing: def absolute'
   quiz:
     title: git bisect — Knowledge Check
@@ -1649,7 +1257,7 @@ steps:
       - ~6 — `log₂(50) ≈ 6`
       - 1 — bisect inspects all commits at once
       correct_index: 2
-      explanation: 'Binary search halves the range each test: 50 → 25 → 13 → 7 → 4 → 2 → 1. About 6 iterations. For 1000 commits, ~10 tests. This scaling is why bisect is irreplaceable on long-running projects.'
+      explanation: 'Binary search halves the range: 50 → 25 → 13 → 7 → 4 → 2 → 1. ~6 iterations. For 1000 commits, ~10.'
     - question: Which sequence correctly runs an automated bisect?
       options:
       - '`git bisect start; git bisect run <cmd>`'
@@ -1657,7 +1265,7 @@ steps:
       - '`git bisect run <cmd> HEAD HEAD~50`'
       - '`git bisect <cmd>`'
       correct_index: 1
-      explanation: You must tell bisect the boundaries first — `bad` (usually HEAD) and a known-good earlier commit. Only then can `run` automate. The command's exit code (0 = good, nonzero = bad) drives the search.
+      explanation: Bisect needs boundaries first — `bad` (usually HEAD) and a known-good earlier commit. Then `run` uses the command's exit code to drive the search.
     - question: You ran `git bisect run` successfully. What must you do afterwards?
       options:
       - Nothing — bisect cleans itself up
@@ -1665,7 +1273,7 @@ steps:
       - '`git stash` to preserve bisect state'
       - Push the result to the remote
       correct_index: 1
-      explanation: '`git bisect reset` is non-negotiable. It restores HEAD to where you started and removes bisect''s temporary refs. Skipping it leaves HEAD on a random historical commit — a common cause of ''why is my code weird?'' panic.'
+      explanation: '`git bisect reset` restores HEAD and clears bisect''s refs. Skip it and HEAD stays on some historical commit — a classic "why does my code look wrong?" moment.'
     - question: Which test property is **required** for `git bisect run` to work?
       options:
       - The test must produce JSON output
@@ -1673,7 +1281,7 @@ steps:
       - The test must be written in Python
       - The test must only exist in the latest commit
       correct_index: 1
-      explanation: 'Bisect uses the exit code as its oracle. Also critical: the test must actually run at every historical commit — if the test file was added mid-range, older commits will fail to even find the test, confusing bisect. Use `git bisect run -- bash -c ''cp /tmp/test.py . && python3 test.py''` to work around this.'
+      explanation: 'Exit code is the oracle. The test also has to run at every commit — if it was added mid-range, copy it in each iteration with `git bisect run bash -c ''cp /tmp/test.py . && python3 test.py''`.'
     - question: '**[Revisit Step 1]** In the middle of a manual bisect, Git leaves HEAD at a historical commit while you decide good/bad. What HEAD state are you in, and why is that OK?'
       options:
       - Detached HEAD — and it is safe because bisect manages it; `git bisect reset` restores you to the starting branch afterwards
@@ -1681,7 +1289,7 @@ steps:
       - Detached HEAD — and any `git commit` you make here will corrupt history
       - Attached to `main` — bisect only moves the working tree, not HEAD
       correct_index: 0
-      explanation: During bisect, HEAD is detached at whichever historical commit Git picked as midpoint. That is fine because bisect's internal refs (`BISECT_HEAD`, `refs/bisect/*`) track progress. `git bisect reset` restores the pre-bisect HEAD. Same detached-HEAD concept as Step 1 — just used in service of a search.
+      explanation: HEAD is detached at the current midpoint. Bisect's internal refs (`BISECT_HEAD`, `refs/bisect/*`) track progress; `git bisect reset` restores the pre-bisect HEAD.
     - question: '**[Revisit Step 5]** A bug appears because a line that *used to exist* was deleted. Which tool finds the deletion commit?'
       options:
       - '`git blame` — it shows every line''s author'
@@ -1689,40 +1297,30 @@ steps:
       - '`git log --grep=''delete''` — it finds commits with ''delete'' in the message'
       - '`git cherry-pick --find-deletion`'
       correct_index: 1
-      explanation: 'Blame only attributes *existing* lines. A deletion is invisible to blame (the line isn''t there!). Bisect operates on *behavior*, not lines: if the test failed after commit X and passed at commit X-1, X is the culprit, regardless of whether X added, modified, or deleted code.'
+      explanation: 'Blame only sees existing lines — a deleted line is invisible. Bisect operates on behavior: if X fails and X-1 passes, X is the culprit, whatever it did.'
 - title: 'Rebase: Integrate Changes Without a Merge Commit'
   view: git_graph
   instructions: |
-    > ⚠️ **Common wrong model you may be carrying:**
-    > *"`git rebase` edits the old commits in place — that is why it's
-    > destructive."* **Wrong.** Commits are immutable (Step 2 — that
-    > is not negotiable). Rebase creates **brand-new** commits with
-    > the same patches and moves the branch pointer. The "old" commits
-    > stay in `.git/objects` and are recoverable via `git reflog`.
-    > Once you see this, rebase stops being scary.
+    > **Wrong model to unlearn:** *"rebase edits old commits in place,
+    > that's why it's destructive."* Commits are immutable (Step 2).
+    > Rebase creates **new** commits with the same patches and moves
+    > the branch pointer. The old commits stay in `.git/objects` and
+    > `git reflog` can bring them back.
 
-    ### Mental model: the video-editor timeline cut
+    ### Mental model
 
-    Think of rebase like a video editor:
-    - Select the clips (commits) unique to your feature.
-    - Cut them out.
-    - Move the playhead to the tip of `main`.
-    - Paste the clips, one by one, onto the new location.
-
-    Git literally does this: each cut-and-pasted clip is a new commit
-    object with the same content but a new parent, hence a new SHA.
-    The original clips still exist in the archive (`reflog`) — you
-    just watch the *new* timeline now.
+    Like a video editor: pick the clips unique to your feature, cut
+    them, move the playhead to `main`, paste them in order. Each
+    pasted clip is a new commit with the same content but a new
+    parent — so a new SHA. The originals stay in the archive.
 
     ### The merge-commit noise problem
 
-    You have been working on `feature-sqrt` for a day. Meanwhile, `main`
-    has received 3 other commits. A plain `git merge main` into your
-    feature branch produces a merge commit with two parents — visible
-    forever in `git log --graph`.
+    `feature-sqrt` sits a day behind; `main` has 3 new commits. A
+    plain `git merge main` leaves a merge commit with two parents,
+    visible forever in `git log --graph`.
 
-    For short, linear features, many teams find merge commits noisy.
-    They prefer history that reads as a **straight line**:
+    For short, linear features, many teams prefer a straight line:
 
     **Before rebase** — `feature` branched off `main` at `B`; `main` has since moved to `D`:
 
@@ -1758,79 +1356,55 @@ steps:
     @enduml
     ```
 
-    `git rebase main` on the feature branch **replays** `α, β, γ` on
-    top of the new `main` tip, producing new commits `α', β', γ'` with
-    the same patches but different parents (and therefore different
-    SHAs).
+    `git rebase main` replays `α, β, γ` on top of the new `main`
+    tip as new commits `α', β', γ'` — same patches, new parents,
+    new SHAs.
 
-    > **Key insight:** rebase does **not** modify commits. Commits are
-    > immutable (recall Step 2: SHA = hash of content + parents). Rebase
-    > creates *brand-new* commits with the same patches, and moves the
-    > branch pointer to the new tip. The old commits are still in the
-    > object database — recoverable via reflog.
+    ### Task 1: Inspect the divergence
 
-    ### Task 1: Inspect the pre-built divergence
+    The tutorial already set up:
 
-    The tutorial has set up the scenario for you:
-
-    - `feature-sqrt` branch — contains one commit adding a
-      `square_root` function.
-    - `main` branch — has two newer commits (`Bump version notes`,
-      `Add identity helper`) made *after* `feature-sqrt` was created.
-
-    The two branches now diverge. See it:
+    - `feature-sqrt` — one commit adding `square_root`.
+    - `main` — two newer commits (`Bump version notes`, `Add identity helper`) added after the branch point.
 
     ```bash
     git log --all --oneline --graph --decorate
     ```
 
-    You should see `feature-sqrt` diverging from `main` — two parallel
-    lines on the graph.
+    Two parallel lines.
 
     ### Task 3: Rebase feature-sqrt onto main
 
-    Switch to the feature branch. **Predict before rebasing:** how
-    many commits will be on `feature-sqrt` after the rebase? How many
-    *parents* will its tip commit have? (Trick question — think back
-    to the basic tutorial's merge-commit structure.)
+    **Predict:** how many commits on `feature-sqrt` after rebase?
+    How many parents on its tip? (Hint: unlike a merge.)
 
     ```bash
     git switch feature-sqrt
     git rebase main
     ```
 
-    Check the log:
-
     ```bash
     git log --all --oneline --graph --decorate
     ```
 
-    **Linear history restored.** `feature-sqrt` now sits on top of
-    the latest `main`. Its tip commit has **one** parent, not two —
-    no merge commit anywhere.
+    Linear history. `feature-sqrt` sits on top of `main`. Tip commit
+    has one parent.
 
-    ### Stop and self-explain
+    ### Self-explain
 
-    Before reading on, **explain in one sentence** why the rebased
-    commit on `feature-sqrt` has a *different* SHA than it did 10
-    seconds ago, even though its patch is byte-identical.
+    In one sentence, why does the rebased commit have a different
+    SHA even though the patch is byte-identical?
 
     …
 
-    > Expected answer: "Rebase replays the commit on top of a new
-    > parent (the current tip of `main`, not the old branch point).
-    > A commit's SHA hashes its parent reference, so a different
-    > parent ⇒ a different SHA. Commits are immutable — rebase
-    > doesn't modify; it creates new ones." Same object-model
-    > reasoning you used in Step 4.
+    > A commit's SHA hashes its parent. New parent (tip of `main`),
+    > new SHA. Same object-model reasoning as Step 4.
 
-    `git reflog` still has the pre-rebase SHA — your rescue route
-    if anything goes wrong.
+    `git reflog` still has the pre-rebase SHA if you need it.
 
-    ### Task 4: Fast-forward merge into main
+    ### Task 4: Fast-forward into main
 
-    Because `feature-sqrt` is now a strict extension of `main`, a merge
-    is trivial — no merge commit is even needed:
+    `feature-sqrt` is now a strict extension of `main`:
 
     ```bash
     git switch main
@@ -1838,17 +1412,12 @@ steps:
     git branch -d feature-sqrt
     ```
 
-    Final graph: one linear line of history. No diamond, no merge noise.
+    One linear line. No diamond.
 
-    ### Task 5: Rebase through a conflict (desirable difficulty)
+    ### Task 5: Rebase through a conflict
 
-    That rebase was clean — Git applied the patch and moved on. In
-    real life, rebases conflict when upstream touched the same lines
-    your branch did. Let's produce one deliberately so you see
-    `git rebase --continue` once before you need it for real.
-
-    Start a new branch from *before* the identity commit, and add a
-    competing line at the same location:
+    That rebase was clean. Real rebases conflict when both sides
+    touched the same lines. Let's cause one.
 
     ```bash
     git switch -c feature-trailer main~1
@@ -1856,121 +1425,84 @@ steps:
     git commit -am 'Add trailer comment at end of file'
     ```
 
-    Now rebase onto the newer `main` (which added `identity` at the
-    same spot):
+    Rebase onto the newer `main` (which added `identity` at the same
+    spot):
 
     ```bash
     git rebase main
     ```
 
-    Git pauses: **CONFLICT** — both sides appended to the end of the
-    file. This is the normal case, not a failure. Inspect:
+    CONFLICT — both sides appended to the file. This is normal.
 
     ```bash
     git status
-    cat calculator.py   # <<<<<<< HEAD, =======, >>>>>>> markers
+    cat calculator.py   # <<<<<<<, =======, >>>>>>> markers
     ```
 
-    Resolve by keeping **both** lines — edit `calculator.py` so the
-    end contains the `identity` helper *and* your trailer comment.
-    Delete the three marker lines (`<<<<<<<`, `=======`, `>>>>>>>`).
-    Save. Then tell Git the conflict is resolved:
+    Keep both lines. Remove the marker lines. Then:
 
     ```bash
     git add calculator.py
     git rebase --continue
     ```
 
-    Git finishes. Clean up the now-unneeded branch:
+    Clean up:
 
     ```bash
     git switch main
     git branch -D feature-trailer
     ```
 
-    > **The sentence to remember:** a rebase conflict uses the *same*
-    > markers and the *same* `git add` as a merge conflict (basic
-    > tutorial Step 11). The only difference is you finalize with
-    > `git rebase --continue` instead of `git commit`. If you can
-    > resolve one, you can resolve the other — the mechanics are
-    > identical; only the ceremony differs.
+    > A rebase conflict uses the same markers and same `git add` as a
+    > merge conflict. The only difference: you finish with
+    > `git rebase --continue`, not `git commit`.
 
-    > **If you panic:** `git rebase --abort` at any point restores
-    > the pre-rebase state. Same safety net as `git merge --abort`
-    > from the basic tutorial.
+    > **Panic button:** `git rebase --abort` restores the pre-rebase
+    > state.
 
     ### When to rebase vs merge
 
     | Situation | Prefer |
     |---|---|
-    | Short feature branch (hours–days) | **Rebase** — keeps history linear |
-    | Long-lived integration branch | **Merge** — preserves the actual merge event |
-    | Branch has been **pushed and others are using it** | **Merge** — rebasing rewrites SHAs and breaks collaborators |
-    | PR review is complete and ready to land | Depends on team — some teams enforce rebase, others enforce merge |
+    | Short feature branch | Rebase |
+    | Long-lived integration branch | Merge |
+    | Branch pushed and shared | Merge — rebasing rewrites SHAs |
+    | PR review complete | Team convention |
 
-    > **The cardinal rule of rebase:** only rebase commits that exist
-    > only on your local machine or on a feature branch **only you**
-    > are working on. Rewriting shared history breaks other people's
-    > branches.
+    > **Cardinal rule:** only rebase branches that are local or
+    > exclusively yours. Rewriting shared history breaks collaborators.
 
-    ### Why the cardinal rule exists — the concrete failure mode
+    ### Why the rule exists
 
-    Research on professional Git usage (Isomöttönen & Cochez) shows
-    that conflating *local* and *remote* history is the single most
-    common source of serious Git accidents in industry. Walk through
-    the scenario concretely:
+    1. You and Alice both pull `shared-feature` at `abc123`.
+    2. You rebase locally — tip is now `xyz789`.
+    3. You `git push --force`. Remote has `xyz789`; `abc123` is orphaned.
+    4. Alice pulls. Git reports divergence.
+    5. Her pull merges and reintroduces the duplicated patches under two SHAs.
 
-    1. You and Alice both pull `shared-feature` at commit `abc123`.
-    2. You rebase locally — your tip is now a new commit `xyz789`
-       (same patch, different SHA).
-    3. You `git push --force`. The remote now has `xyz789`; `abc123`
-       is orphaned on the server.
-    4. Alice pulls. Git says *"your local branch and the remote have
-       diverged"* — because her local still has `abc123`, but the
-       remote now has `xyz789`.
-    5. Alice's pull creates a messy merge that reintroduces the
-       duplicated patches (one under each SHA).
+    The fix is social, not technical: don't rebase what others share.
+    For public branches, `git revert` instead.
 
-    Every push of a rewritten branch exports this problem to your
-    whole team. **The fix is social, not technical:** never rebase
-    branches others share. For public/shared branches, use `git
-    revert` (non-destructive anti-commit) instead.
+    ### Transfer: rebase or merge?
 
-    ### Transfer: choose between rebase and merge
-
-    For each scenario, decide: rebase or merge? Justify in one line.
-
-    1. Your feature branch is 3 commits old, no one else has pulled
-       it, and you want to open a PR. Upstream `main` has moved.
-       **Rebase or merge?**
-    2. You and two teammates have all been pushing to `shared-demo`.
-       Your local branch has diverged from the remote. You need to
-       integrate. **Rebase or merge?**
-    3. A long-lived `release-2.0` branch has absorbed 200 commits from
-       `main` over 6 months. Integration time. **Rebase or merge?**
+    1. 3-commit feature branch, private, pre-PR. `main` moved.
+    2. Shared `shared-demo`. Your local diverged from the remote.
+    3. `release-2.0`, 200 commits absorbed from `main` over 6 months.
 
     <details><summary>Answers</summary>
 
-    1. **Rebase.** Short, private, pre-PR cleanup — textbook fit.
-    2. **Merge.** Shared branch with others who hold old SHAs —
-       rebasing would force-push and devastate their branches.
-    3. **Merge.** A 200-commit rebase is conflict-hell and destroys
-       the real branch topology that tells the story of the release.
+    1. **Rebase.** Short, private, pre-PR.
+    2. **Merge.** Shared branch — rebase would force-push and break teammates.
+    3. **Merge.** 200-commit rebase is conflict hell and destroys the release's real topology.
 
     </details>
 
     ### You can now
 
-    - **Explain** the video-editor analogy of rebase and why it
-      produces new SHAs.
-    - **Choose** rebase for short local branches, merge for shared or
-      long-lived branches.
-    - **Resolve** a rebase conflict with the same marker-edit + `git
-      add` recipe as a merge conflict, finishing with `git rebase
-      --continue` instead of `git commit`.
-    - **Recover** from a bad rebase with `git reflog` + `git reset
-      --hard` (same safety net as Step 1's detached-HEAD rescue),
-      or bail out cleanly with `git rebase --abort`.
+    - Explain why rebase produces new SHAs.
+    - Choose rebase for short private branches, merge for shared or long-lived ones.
+    - Resolve a rebase conflict with `git add` + `git rebase --continue`.
+    - Recover from a bad rebase with `git reflog` + `git reset --hard`, or bail with `git rebase --abort`.
   setup_commands:
   - "cd /tutorial/myproject\ngit rebase --abort 2>/dev/null\ngit switch -q main 2>/dev/null\nHAS_SQRT=0\nHAS_IDENTITY=0\ngit log feature-sqrt --oneline 2>/dev/null | grep -q 'Add square_root function' && HAS_SQRT=1\ngit log main --oneline 2>/dev/null | grep -q 'Add identity helper' && HAS_IDENTITY=1\nif [ $HAS_SQRT = 1 ] && [ $HAS_IDENTITY = 1 ]; then\n  exit 0\nfi\ngit branch -D feature-sqrt 2>/dev/null\nif git log main --oneline | grep -q 'Add identity helper'; then\n  git reset --hard HEAD~2 2>/dev/null\nfi\ngit switch -qc feature-sqrt\nprintf '\\nimport math\\ndef square_root(x):\\n    \"\"\"Return the square root of x; raises ValueError if negative.\"\"\"\\n    if x < 0:\\n        raise ValueError(\"Cannot take sqrt of negative\")\\n    return math.sqrt(x)\\n' >> calculator.py\ngit commit -qam 'Add square_root function'\ngit switch -q main\necho '# version 1.1 notes' >> calculator.py\ngit commit -qam 'Bump version notes'\necho 'def identity(x): return x' >> calculator.py\ngit commit -qam 'Add identity helper'\n"
   solution:
@@ -1988,35 +1520,34 @@ steps:
     - git switch main
     - git branch -D feature-trailer 2>/dev/null; true
     explanation: |
-      - **Rebase = replay:** Git takes the commits on your branch that are not on the target (`feature-sqrt` commits not on `main`), computes their patches, resets the branch pointer to the target tip, and replays each patch as a *new* commit on top.
-      - **New SHAs:** Because each replayed commit has a new parent, its SHA is different. Old commits remain in `.git/objects` and `git reflog` — nothing is ever truly lost, but anyone who fetched the old SHAs sees divergence.
-      - **Fast-forward merge:** After a successful rebase, the feature branch is a strict extension of main. `git merge feature-sqrt` on main simply moves the main pointer forward — no merge commit.
-      - **Rebase conflicts (Task 5):** When upstream and your branch touched the same lines, rebase pauses at the first problem commit. Resolution is identical to a merge conflict — edit the file, remove markers, `git add`, then `git rebase --continue` (*not* `git commit`). `git rebase --abort` bails out at any point.
-      - **The rule:** rebase only local/private branches. Rewriting pushed history requires `--force-with-lease` and annoys everyone who already pulled.
+      - Rebase = replay. Git computes the patches of commits unique to your branch, resets the branch to the target tip, and applies each patch as a new commit.
+      - New parents → new SHAs. Old commits stay in `.git/objects` and `git reflog`.
+      - After rebase the branch is a linear extension of main, so `git merge` fast-forwards without a merge commit.
+      - Rebase conflicts use the same markers and `git add` as merge conflicts — finish with `git rebase --continue`, not `git commit`. `--abort` bails.
+      - Only rebase branches that are yours alone. Rewriting pushed history breaks anyone holding the old SHAs.
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
     hints:
-    - text: Finish this step on `main`. Tasks 3 and 5 have you switch to feature branches temporarily; after the last cleanup command (`git branch -D feature-trailer`) make sure HEAD is back on `main` with `git switch main`.
+    - text: 'Finish on `main`. After the cleanup, `git switch main`.'
   - description: feature-sqrt branch was merged and deleted
     command: cd /tutorial/myproject && ! git branch | grep -q 'feature-sqrt'
     hints:
-    - text: '`feature-sqrt` is still in `git branch`. After rebasing and fast-forward-merging it into `main`, the branch pointer is redundant — remove it with `git branch -d feature-sqrt` (lowercase `d` works because the commits are now reachable from main).'
+    - text: 'The branch is still there. Once the commits are on `main`, `git branch -d feature-sqrt` removes the pointer.'
   - description: square_root function is on main
     command: cd /tutorial/myproject && grep -q 'def square_root' calculator.py && git log --oneline main | grep -qi 'square_root'
     hints:
-    - text: The `square_root` commit never made it onto `main`. The workflow is two moves, in order. (1) `git switch feature-sqrt && git rebase main` replays the feature commit on top of main. (2) `git switch main && git merge feature-sqrt` fast-forwards main up to the rebased tip. Skipping step 2 leaves `main` unchanged.
+    - text: "Two moves: `git switch feature-sqrt && git rebase main`, then `git switch main && git merge feature-sqrt`. Skip the second and `main` doesn't advance."
   - description: History is linear (no merge commit for feature-sqrt)
     command: cd /tutorial/myproject && [ $(git log --merges --oneline main | grep -ci 'Merge branch.*feature-sqrt') -eq 0 ]
     hints:
-    - text: A merge commit for `feature-sqrt` exists on `main` — meaning you merged **before** rebasing (or forced a non-ff merge). Rebase linearizes *first*, so a subsequent merge is a fast-forward (no merge commit). If you have a merge commit now, `git reset --hard <pre-merge-sha>` (find it with `git reflog`), then rebase and merge in the correct order.
+    - text: "You merged before rebasing, so you got a merge commit. Rebase first → then a fast-forward merge (no merge commit). Undo via `git reflog` + `git reset --hard`."
   - description: No rebase is in progress and no conflict markers remain (Task 5 resolved)
     command: cd /tutorial/myproject && [ ! -d .git/rebase-merge ] && [ ! -d .git/rebase-apply ] && ! grep -E '^(<{7}|={7}|>{7})' calculator.py
     hints:
-    - text: Conflict markers remain in `calculator.py`. Task 5 deliberately creates a conflict. Open the file, keep *both* the `identity` helper **and** the trailer comment, delete the three marker lines (`<<<<<<<`, `=======`, `>>>>>>>`), then `git add calculator.py`.
-      condition: 'code_contains: <<<<<<<'
-    - text: A rebase is paused. After staging the resolved file, finish with `git rebase --continue` — **not** `git commit` (that is the most common mid-rebase reflex mistake). To bail out instead, `git rebase --abort` restores the pre-rebase state.
-      condition: 'output_contains: rebase'
+    - text: 'Conflict markers still in the file. Keep both the `identity` helper and the trailer comment, delete the `<<<`/`===`/`>>>` lines, then `git add calculator.py && git rebase --continue`.'
+    - text: "Rebase is paused. Use `git rebase --continue` after staging — not `git commit`. Or `git rebase --abort` to bail out."
+      condition: 'output_contains: rebase in progress'
   quiz:
     title: Rebase — Knowledge Check
     min_score: 0.8
@@ -2029,7 +1560,7 @@ steps:
       - Merges `main` into `feature-sqrt` with a merge commit
       - Deletes `main` and renames `feature-sqrt` to `main`
       correct_index: 1
-      explanation: 'Rebase rewrites the branch: feature-sqrt''s unique commits become *new* commits on top of main. This linearizes history but changes SHAs — so never rebase pushed branches others are using.'
+      explanation: Rebase replays feature-sqrt's unique commits as new commits on top of main. Linear history, new SHAs — don't do it on shared branches.
     - question: After rebasing, why does the rebased commit have a **different SHA** than before?
       options:
       - Git chooses a new SHA for clarity
@@ -2037,7 +1568,7 @@ steps:
       - Rebase encrypts the commit
       - Rebase changes the commit message
       correct_index: 1
-      explanation: 'Step 2 again: `SHA(commit) = SHA-1(tree + parent(s) + author + committer + message)`. Change the parent → new SHA. Same patch, new identity.'
+      explanation: '`SHA = hash(tree + parents + author + committer + message)`. New parent → new SHA. Same patch, new identity.'
     - question: When is `git rebase` a **bad** idea?
       options:
       - On a personal feature branch that only you have checked out
@@ -2045,7 +1576,7 @@ steps:
       - On a public/shared branch that teammates have already pulled
       - To linearize history before a fast-forward merge
       correct_index: 2
-      explanation: Rebase rewrites history. If others have the old SHAs, their branches will diverge and they will get ugly conflicts. Stick to merge for anything pushed and shared, rebase for local linearization.
+      explanation: Rebase rewrites history. If others hold the old SHAs, their branches diverge. Merge for shared branches, rebase for local cleanup.
     - question: '**[Revisit Step 1]** You rebased `feature-sqrt` and realized it broke everything. Before pushing. How do you recover the pre-rebase state?'
       options:
       - It is gone — rebase is permanent
@@ -2053,7 +1584,7 @@ steps:
       - '`git stash pop` to retrieve the old commits'
       - '`git clone` a fresh copy of the repo'
       correct_index: 1
-      explanation: Rebase is only 'destructive' in the sense of changing branch pointers — the original commits remain in `.git/objects` until garbage collection. `git reflog` records every HEAD position including the pre-rebase tip; `git reset --hard` restores it. Your safety net, earned in Step 1.
+      explanation: Original commits stay in `.git/objects` until garbage collection. `git reflog` records every HEAD position, `git reset --hard` restores the pre-rebase tip.
     - question: After rebasing a feature onto `main`, you run `git merge feature` on `main`. What happens?
       options:
       - A merge commit with two parents is created
@@ -2061,7 +1592,7 @@ steps:
       - The rebase is reversed
       - Git reports an error
       correct_index: 1
-      explanation: 'After rebase, feature is a strict linear extension of main. The merge reduces to just advancing the main pointer (fast-forward). This is the whole reason many teams rebase before merging: clean, linear history.'
+      explanation: After rebase, feature is a strict extension of main. The merge just advances the main pointer — fast-forward, no merge commit. That's the whole point.
     - question: Which statements about rebase are true? (Select all that apply)
       type: multiple
       options:
@@ -2073,7 +1604,7 @@ steps:
       - 0
       - 1
       - 3
-      explanation: Rebase applies each patch in turn and can conflict at any of them — you resolve, `git add`, `git rebase --continue`. `--abort` restores the pre-rebase state. Rebase does **not** push anything; that is a separate `git push` step (often needing `--force-with-lease` on rebased branches, which is where collaborator pain happens).
+      explanation: Rebase applies patches one at a time and can conflict at any. Resolve, `git add`, `git rebase --continue`. `--abort` restores the pre-rebase state. Rebase doesn't push — that's a separate step, usually needing `--force-with-lease`.
     - question: '**[Revisit Step 4]** You had two choices for bringing a colleague''s single fix into `main`: cherry-pick or rebase. Both create new commits with new SHAs. What is the key difference in intent?'
       options:
       - Cherry-pick copies *one* commit onto HEAD; rebase moves *all* of a branch's unique commits onto a new base — they differ in scope, not mechanism
@@ -2081,7 +1612,7 @@ steps:
       - Cherry-pick requires the commit to be on a branch; rebase does not
       - They are identical aliases
       correct_index: 0
-      explanation: 'Under the hood they use the same machinery — patch out, replay on new parent, new SHA. The difference is *scope*: cherry-pick = one commit, rebase = a series. Step 4''s cherry-pick and Step 7''s rebase are the same technique at different scales.'
+      explanation: 'Same machinery — patch out, replay on new parent, new SHA. The difference is scope: cherry-pick = one commit, rebase = a series.'
     - question: '**[Revisit Step 2]** During rebase, a conflict halts you mid-stream. `git reflog` at this moment shows many entries. Which entry do you want to `git reset --hard` to if you decide to abort manually instead of using `git rebase --abort`?'
       options:
       - The most recent `HEAD@{0}` entry
@@ -2089,7 +1620,7 @@ steps:
       - The very oldest reflog entry
       - Any entry — they all point to the same commit
       correct_index: 1
-      explanation: Reflog logs every HEAD movement. The pre-rebase position is typically labeled `checkout` or the last `commit` before the `rebase` entries. That SHA is the pre-rebase branch tip — the safe rescue point. This is the Step 1 reflog safety net applied to rebase.
+      explanation: Reflog logs every HEAD move. The pre-rebase position is usually the `checkout` or last `commit` entry before the `rebase` ones — that SHA is the rescue point.
     - question: '**[Revisit basic tutorial Step 11]** You edit a conflicted file during a `git rebase`, remove the `<<<<<<<` / `=======` / `>>>>>>>` markers, and run `git add`. What is the **next** command to finalize this one commit of the rebase?'
       options:
       - '`git commit` — same as finishing a merge'
@@ -2097,14 +1628,13 @@ steps:
       - '`git merge --continue`'
       - '`git push`'
       correct_index: 1
-      explanation: A rebase conflict uses the *same* markers and the *same* `git add` step as a merge conflict (basic tutorial Step 11). The *only* difference is the final verb — `git rebase --continue` tells Git to replay the remaining commits, which `git commit` would not. Running `git commit` by reflex here often leaves the rebase half-done. `git rebase --abort` at any point restores the pre-rebase state.
+      explanation: A rebase conflict uses the same markers and same `git add` as a merge conflict. Only the final verb changes — `git rebase --continue` resumes the replay; `git commit` leaves the rebase half-done.
 - title: 'Interactive Rebase: Edit, Squash, Reorder, Drop'
   view: git_graph
   instructions: |
-    ### Your history is a draft until you push
+    ### History is a draft until you push
 
-    Sitting on your feature branch, you have 5 commits. Looking at them,
-    the history is embarrassing:
+    Five commits on your feature branch:
 
     ```
     * f3e2d1c  More typo fixes
@@ -2114,31 +1644,26 @@ steps:
     * 4e5d6c1  WIP
     ```
 
-    Nobody wants to review that. Before opening a pull request, you
-    clean it up into something like:
+    Nobody wants to review that. Before opening a PR, clean it up to:
 
     ```
     * a9f8e7d  Add power function with full input validation
     ```
 
-    `git rebase -i` (interactive) is the tool.
+    `git rebase -i` does this.
 
-    ### Doctor Strange warning sign
+    ### Warning sign
 
-    `git rebase -i` **rewrites commits**. Commits are immutable objects,
-    so technically what happens is: Git creates new commits with new
-    SHAs and moves the branch pointer. The old commits are still in
-    `.git/objects` (recoverable via `reflog`).
+    Interactive rebase rewrites commits — new SHAs. Old commits stay
+    in `.git/objects` and `git reflog`.
 
-    > **The safe zone**: only run interactive rebase on commits that
-    > (a) exist only on your machine, OR (b) exist on a feature branch
-    > that **only you** work on. Rewriting pushed commits devastates
-    > teammates — their branches will conflict horrendously on next pull.
+    > **Safe zone:** only rebase commits that are local, or on a
+    > branch only you work on. Rewriting pushed commits devastates
+    > teammates.
 
     ### How the editor works
 
-    When you run `git rebase -i HEAD~N`, Git opens an editor with
-    something like:
+    `git rebase -i HEAD~N` opens a todo list:
 
     ```
     pick 4e5d6c1 WIP
@@ -2147,177 +1672,116 @@ steps:
     pick 8a1c4b5 Fix typo
     pick f3e2d1c More typo fixes
 
-    # Commands:
-    # p, pick   = use commit as-is
-    # r, reword = use commit, but edit the message
-    # e, edit   = use commit, but pause for amending
-    # s, squash = use commit, but meld into the previous commit (combine messages)
-    # f, fixup  = like squash but DISCARD this commit's log message
-    # d, drop   = remove the commit
-    # b, break  = stop and let me run commands, then `git rebase --continue`
+    # p, pick   = use as-is
+    # r, reword = edit message
+    # e, edit   = pause for amending
+    # s, squash = meld into previous (combine messages)
+    # f, fixup  = squash but drop this message
+    # d, drop   = remove
+    # b, break  = stop, continue later
     ```
 
-    You edit this list (any text editor), save and close. Git replays
-    according to your instructions.
+    Edit, save, close. Git replays accordingly.
 
-    ### Task 1: Inspect the pre-built messy history
+    ### Task 1: See the mess
 
-    The tutorial has created a `refactor-power` branch with four
-    embarrassing commits (`WIP`, `Fix typo`, `Fix typo again`, `More
-    typo fixes`) — the kind of history you would never want reviewers
-    to see. Inspect it:
+    The tutorial set up `refactor-power` with four ugly commits.
 
     ```bash
     git log --oneline -5
     ```
 
-    Four ugly commits — a perfect target for interactive rebase.
+    ### Task 2: Squash without opening an editor
 
-    ### Task 2: Interactive rebase — without opening an editor
-
-    In a real terminal, `git rebase -i HEAD~4` opens your `$EDITOR`.
-    Inside this VM, we use `GIT_SEQUENCE_EDITOR` to script the edit
-    non-interactively. (Everything below happens as one command.)
-
-    Squash the four messy commits into one with a good message:
+    In a real terminal, `git rebase -i HEAD~4` opens `$EDITOR`. Here
+    we script it with `GIT_SEQUENCE_EDITOR`:
 
     ```bash
     GIT_SEQUENCE_EDITOR="sed -i '2,4s/^pick/squash/'" git rebase -i HEAD~4
     ```
 
-    What this does:
-    - Tells Git: "use sed to rewrite the rebase todo list — change
-      lines 2–4 from `pick` to `squash`".
-    - Git replays the first commit as-is, then melds commits 2, 3, 4
-      into it, opening a message editor.
-
-    Git then opens an editor for the combined commit message. Override
-    the message too:
+    This rewrites lines 2–4 of the todo list from `pick` to `squash`.
+    Git replays commit 1 as-is, melds 2–4 into it, then opens a
+    message editor. Override the combined message:
 
     ```bash
-    # In a real terminal you'd edit the message. Here we set it directly:
     git commit --amend -m "Refactor: cleanup notes in calculator.py"
     ```
-
-    Check the log:
 
     ```bash
     git log --oneline -3
     ```
 
-    Four commits became one. The remaining history is clean.
+    Four commits → one.
 
     ### Task 3: Drop a bad commit
 
-    Make two more commits — one of them accidentally leaks a secret.
+    Make two commits — the first leaks a secret:
 
-    **Bad commit — append this line to `calculator.py` in the editor:**
+    **Bad — append to `calculator.py`:**
     ```
     SECRET_API_KEY=oops
     ```
-    Save.
-    Commit: `git commit -am "Accidentally add secret (should be dropped)"`
+    `git commit -am "Accidentally add secret (should be dropped)"`
 
-    **Good commit — append this line below the secret:**
+    **Good — append below:**
     ```python
     def placeholder(): pass
     ```
-    Save.
-    Commit: `git commit -am "Add placeholder function"`
+    `git commit -am "Add placeholder function"`
 
-    Now drop the secret-leaking commit, keep the others:
+    Drop the bad one:
 
     ```bash
     GIT_SEQUENCE_EDITOR="sed -i '1s/^pick/drop/'" git rebase -i HEAD~2
     ```
 
-    The first (older) of the two commits is dropped. Verify the
-    secret is gone:
+    Verify:
 
     ```bash
     git log --oneline -5
     grep SECRET_API_KEY calculator.py || echo "secret is gone"
     ```
 
-    ### Task 3b: Rescue the "dropped" commit — prove the safety net
+    ### Task 3b: Rescue the dropped commit
 
-    You just dropped a commit from history. **Dropped ≠ deleted.** The
-    commit object still exists in `.git/objects` (Step 2 again —
-    commits are immutable, rebase only moves ref pointers). Prove it:
+    Dropped ≠ deleted. The object still exists:
 
     ```bash
     git reflog -n 10
     ```
 
-    Find the reflog entry with message `Accidentally add secret
-    (should be dropped)` — it has the SHA of the "dropped" commit.
-    Use that SHA to create a backup branch pointing at it:
+    Find the `Accidentally add secret` entry. Point a branch at it:
 
     ```bash
-    # Replace <sha> with the SHA you just saw in reflog
     SECRET_SHA=$(git reflog | grep -m1 'Accidentally add secret' | awk '{print $1}')
     git branch secret-backup $SECRET_SHA
     git log secret-backup --oneline
     ```
 
-    The "deleted" commit is fully recoverable. You now have a branch
-    `secret-backup` anchoring it.
+    Fully recoverable.
 
-    > **Meta-lesson:** every destructive Git operation is survivable
-    > as long as `git reflog` has a record of HEAD's position before
-    > the operation. This is why `git reset --hard`, `git rebase`,
-    > and `git branch -D` are all less scary than they sound —
-    > **as long as you act before the reflog entry and its objects
-    > are garbage-collected**.
+    > Every destructive Git operation is survivable as long as reflog
+    > holds the pre-op position and GC hasn't pruned the objects.
 
-    > ⚠️ **Real-world secret handling — don't confuse the lessons.**
-    > We rescued the dropped commit to *demonstrate the reflog safety
-    > net*, which is the point of this step. In production, the exact
-    > opposite is true: if you ever commit a real credential, `drop`
-    > + `rescue-onto-a-branch` would leave the secret in **both**
-    > `secret-backup` **and** reflog — *more* copies, not fewer. The
-    > real response for a leaked credential is two-part:
+    > ⚠️ **Real secrets:** this drill demonstrates reflog; it is not a
+    > leak-response playbook. If you actually leak a credential:
     >
-    > 1. **Rotate the credential immediately** (assume it is
-    >    compromised the moment it entered Git — even unpushed, even
-    >    reflog-only).
-    > 2. **Scrub history** with `git filter-repo` (or BFG Repo
-    >    Cleaner), then force-push the cleaned history and ask
-    >    collaborators to re-clone.
+    > 1. Rotate the credential immediately — assume it's compromised.
+    > 2. Scrub history with `git filter-repo` (or BFG), force-push, re-clone on every machine.
     >
-    > The basic tutorial's `.gitignore` step makes the same point:
-    > `.gitignore` prevents *future* tracking; it cannot retroactively
-    > remove anything. Keep the mental models separate — **rescue
-    > drills** use reflog to make destructive commands less scary;
-    > **secret incidents** require credential rotation and history
-    > rewriting. Don't apply the drill recipe to the incident.
+    > `.gitignore` prevents future tracking; it doesn't remove the past.
 
-    ### Task 4: Reword a commit message — you decide
+    ### Task 4: Reword a message — you decide
 
-    Interactive rebase can edit messages without altering content
-    using the `reword` action. Your goal: rename the tip commit's
-    message to something like `Refactor: cleanup notes and placeholder`.
+    Goal: change the tip commit's message to `Refactor: cleanup notes
+    and placeholder`.
 
-    In a real terminal, you would run `git rebase -i HEAD~2`, an
-    editor would open showing:
+    In a real terminal, `git rebase -i HEAD~2`, change `pick` to
+    `reword`, save, then rewrite the message when the second editor
+    opens.
 
-    ```
-    pick <sha1> Accidentally add secret (should be dropped)  # if not dropped
-    pick <sha2> Add placeholder function
-    ```
-
-    …and you would change the second line's `pick` to `reword`, save,
-    then edit the new message when the second editor opens.
-
-    **Inside this VM, we script the two editors via
-    `GIT_SEQUENCE_EDITOR` (for the todo list) and `GIT_EDITOR` (for
-    the message).** This time, you decide which action to use —
-    figure it out from the reference table below.
-
-    <details><summary>Hint (expand if stuck)</summary>
-
-    Change the first line's action from `pick` to `reword`. Then the
-    second editor lets you rewrite the message.
+    <details><summary>Scripted version</summary>
 
     ```bash
     GIT_SEQUENCE_EDITOR="sed -i '1s/^pick/reword/'" \
@@ -2327,82 +1791,59 @@ steps:
 
     </details>
 
-    Check the result:
-
     ```bash
     git log --oneline -3
     ```
 
-    ### Rebase todo list reference
+    ### Todo list reference
 
     | Command | Effect |
     |---|---|
-    | `pick` | Use commit as-is (default) |
-    | `reword` (`r`) | Keep commit, open editor to edit message |
-    | `edit` (`e`) | Pause at commit so you can `git commit --amend` or add fixes |
-    | `squash` (`s`) | Meld into previous commit — opens editor to combine messages |
-    | `fixup` (`f`) | Like squash, but discard this commit's message |
-    | `drop` (`d`) | Remove the commit entirely |
-    | `break` (`b`) | Stop here; resume later with `git rebase --continue` |
-    | `exec <cmd>` | Run a shell command between steps (e.g., `exec pytest`) |
+    | `pick` | Use as-is |
+    | `reword` | Keep content, edit message |
+    | `edit` | Pause for amend or fixes |
+    | `squash` | Meld into previous, combine messages |
+    | `fixup` | Squash, drop this message |
+    | `drop` | Remove |
+    | `break` | Stop; resume with `--continue` |
+    | `exec <cmd>` | Run shell command between steps |
 
-    ### When NOT to use interactive rebase
+    ### When not to use it
 
-    - On commits that are already pushed and being used by others
-    - When you are not sure what you are doing **and** have no reflog
-      safety net (always verify `reflog` is recording — it is, by default)
-    - When the history is about to be merged with `--squash` anyway
-      (redundant effort)
+    - On pushed commits others are using.
+    - When you'd squash-merge the whole branch anyway — redundant.
 
-    ### The force-push disaster (cautionary scenario)
+    ### The force-push disaster
 
-    You rebased `shared-feature` locally. Rebase complete, history
-    clean. You push:
+    You rebased `shared-feature` locally, then:
 
     ```bash
     git push               # rejected — remote has commits you don't
-    git push --force       # "works" — remote is overwritten
+    git push --force       # "works"
     ```
 
-    Monday morning, three teammates report their local `shared-feature`
-    is "broken": every pull creates hundreds of conflict markers.
-    What happened?
+    Monday, three teammates report hundreds of conflict markers on
+    pull. Their local branches hold the old SHAs; the remote has
+    new SHAs for the same patches. Git can't reconcile.
 
-    - Their local branches still hold the **old SHAs** you rebased away.
-    - The remote now has your **new SHAs** for the same patches.
-    - Git sees this as two branches that both have the same changes
-      twice — pull can't cleanly merge.
+    Recovery: each teammate `git reset --hard origin/shared-feature`,
+    then re-apply anything in flight. Real outage.
 
-    This is a real outage. The fix requires each teammate to
-    `git reset --hard origin/shared-feature` (throwing away any local
-    work they had), then re-apply anything they had in flight.
+    ### The shared-history alternative: `git revert`
 
-    ### The public-history alternative: `git revert`
+    - `git revert <sha>` creates a new commit that negates the bad one.
+    - History grows, but no SHAs change — no force-push.
 
-    If a commit already reached shared history and you want to "undo"
-    it, do **not** rebase-drop. Use `git revert <sha>` instead:
-
-    - `git revert` creates a new **anti-matter commit** that
-      negates the bad commit's changes.
-    - History grows (you now have both the bad commit and the
-      revert), but no SHAs change — no force-push, no collaborator
-      pain.
-
-    Rule of thumb:
-    - **Local, unpushed commits** → rebase -i is fine (as in this step)
-    - **Shared, pushed commits** → always revert, never rebase
+    - Local, unpushed → rebase -i is fine.
+    - Shared, pushed → revert, never rebase.
 
     ### You can now
 
-    - **Squash** multiple messy commits into one clean commit before
-      opening a PR.
-    - **Drop** a commit that accidentally leaked a secret (and then
-      recover it from reflog if needed).
-    - **Reword** commit messages retroactively without altering
-      content.
-    - **Choose** the right verb (`pick`/`reword`/`squash`/`fixup`/`drop`)
-      for a given rewriting goal, instead of memorizing one recipe.
-    - **Trust** `git reflog` as your reversal path for any mistake.
+    - Squash messy commits before a PR.
+    - Drop a commit (and recover it from reflog).
+    - Reword messages retroactively.
+    - Pick the right verb (`pick`/`reword`/`squash`/`fixup`/`drop`/`edit`/`break`) for the goal.
+    - Trust `git reflog` as the reversal path.
   watch_files:
   - myproject/calculator.py
   open_file: myproject/calculator.py
@@ -2419,33 +1860,33 @@ steps:
     - SECRET_SHA=$(git reflog | grep -m1 'Accidentally add secret' | awk '{print $1}') && git branch secret-backup $SECRET_SHA
     - 'GIT_SEQUENCE_EDITOR="sed -i ''1s/^pick/reword/''" GIT_EDITOR="sed -i ''1s/.*/Refactor: cleanup notes and placeholder/''" git rebase -i HEAD~2 || true'
     explanation: |
-      - **`git rebase -i HEAD~N`:** opens the todo list for the last N commits. You mark each with `pick`, `reword`, `squash`, `fixup`, `edit`, `drop`, `break`, or `exec`.
-      - **`squash` vs `fixup`:** both meld with the previous commit. `squash` combines messages (editor opens); `fixup` silently drops the squashed commit's message. Use `fixup` for tiny typos, `squash` when the message has information worth keeping.
-      - **`drop`:** deletes the commit from history. Useful for removing accidentally-committed secrets, debug prints, or experiments that did not pan out. The dropped commit remains in reflog for recovery.
-      - **`reword`:** edits the message without touching content. Fixes typos in commit messages retroactively.
-      - **Recovery:** the pre-rebase SHA is always in `git reflog`. `git reset --hard HEAD@{1}` (or the relevant reflog entry) restores the branch exactly.
+      - `git rebase -i HEAD~N` opens the todo list for the last N commits. Mark each with `pick`, `reword`, `squash`, `fixup`, `edit`, `drop`, `break`, or `exec`.
+      - `squash` combines messages (editor opens). `fixup` silently drops the squashed message — use for tiny typos.
+      - `drop` removes the commit. Dropped commits stay in reflog.
+      - `reword` edits the message without touching content.
+      - Recovery: pre-rebase SHA lives in `git reflog`. `git reset --hard HEAD@{1}` restores it.
   tests:
   - description: On refactor-power branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/refactor-power'
     hints:
-    - text: 'Interactive rebase rewrites the *currently checked-out* branch. This step operates on `refactor-power`: `git switch refactor-power` before running any `rebase -i`.'
+    - text: '`rebase -i` rewrites the current branch. `git switch refactor-power` first.'
   - description: Secret was dropped from the active branch (SECRET_API_KEY not in calculator.py)
     command: cd /tutorial/myproject && ! grep -q 'SECRET_API_KEY' calculator.py
     hints:
-    - text: '`SECRET_API_KEY` is still in `calculator.py`. Task 3 asks you to *drop* the commit that added it. Run `git rebase -i HEAD~2` and change the secret-commit''s action from `pick` to `drop` — in the VM you''d script that with `GIT_SEQUENCE_EDITOR="sed -i ''1s/^pick/drop/''" git rebase -i HEAD~2`.'
+    - text: '`SECRET_API_KEY` is still there. Drop the commit that added it during `rebase -i HEAD~2` (change `pick` → `drop`). Scripted: `GIT_SEQUENCE_EDITOR="sed -i ''1s/^pick/drop/''" git rebase -i HEAD~2`.'
       condition: 'code_contains: SECRET_API_KEY'
   - description: Secret-commit is gone from branch history
     command: cd /tutorial/myproject && ! git log --oneline | grep -qi 'Accidentally add secret'
     hints:
-    - text: 'The "Accidentally add secret" commit is still in history. `git log --oneline -5` — if it''s there, your rebase didn''t mark that commit as `drop`. Re-run the rebase, double-check which line you''re changing (the sed index), and make sure the verb is `drop` (or `d`), not `fixup`/`squash`.'
+    - text: 'The secret commit is still in `git log`. Re-run the rebase and make sure the verb is `drop` (or `d`), not `fixup`/`squash` — and check your sed line index.'
   - description: secret-backup branch rescued the 'dropped' commit via reflog (proves reflog safety net)
     command: cd /tutorial/myproject && git log secret-backup --oneline 2>/dev/null | grep -qi 'Accidentally add secret'
     hints:
-    - text: 'Dropped ≠ deleted. Run `git reflog -n 10` and look for the reflog line whose message is "Accidentally add secret" — the first column is the short SHA. Anchor it as a branch: `git branch secret-backup <sha>`. This is the Task 3b demonstration that the reflog can rescue anything rebase throws away.'
+    - text: 'Dropped ≠ deleted. Find the "Accidentally add secret" line in `git reflog -n 10`, grab the SHA, then `git branch secret-backup <sha>`.'
   - description: The 4 messy WIP/typo commits were squashed into fewer commits
     command: cd /tutorial/myproject && [ $(git log --oneline refactor-power | grep -ciE '(WIP|Fix typo|More typo)') -le 1 ]
     hints:
-    - text: 'The four WIP/typo commits still appear in `git log` — the Task 2 squash didn''t happen. Run `git rebase -i HEAD~4`; in the todo list that opens, change lines 2–4 (everything *after* the oldest commit) from `pick` to `squash` (or `fixup`). The scripted form in the VM: `GIT_SEQUENCE_EDITOR="sed -i ''2,4s/^pick/squash/''" git rebase -i HEAD~4`.'
+    - text: 'The WIP commits are still in `git log`. `git rebase -i HEAD~4` and change lines 2–4 from `pick` to `squash`. Scripted: `GIT_SEQUENCE_EDITOR="sed -i ''2,4s/^pick/squash/''" git rebase -i HEAD~4`.'
   quiz:
     title: Interactive Rebase — Knowledge Check
     min_score: 0.8
@@ -2458,7 +1899,7 @@ steps:
       - '`squash`'
       - '`drop`'
       correct_index: 1
-      explanation: '`reword` keeps the commit content identical but opens the editor to change the message. `pick` is no-op, `squash` melds into the previous commit, `drop` deletes it.'
+      explanation: '`reword` keeps content, opens the editor for the message. `pick` is a no-op, `squash` melds, `drop` deletes.'
     - question: What is the difference between `squash` and `fixup`?
       options:
       - '`squash` combines messages (editor opens); `fixup` silently discards the squashed commit''s message'
@@ -2466,7 +1907,7 @@ steps:
       - '`fixup` can only be used on merge commits'
       - They are identical
       correct_index: 0
-      explanation: Both meld into the previous commit. `squash` opens the editor so you can combine messages; `fixup` just drops the squashed commit's message. Use `fixup` for trivial typos, `squash` when both messages are meaningful.
+      explanation: Both meld into the previous commit. `squash` combines messages; `fixup` drops the squashed one. Use `fixup` for trivial typos.
     - question: You just ran `git rebase -i HEAD~3` and realized you dropped a commit you needed. Can you recover it?
       options:
       - No — dropped commits are permanently deleted
@@ -2474,7 +1915,7 @@ steps:
       - Only by running `git rebase --undo`
       - Only if you had pushed the commit
       correct_index: 1
-      explanation: Dropped commits remain in `.git/objects` until garbage collection prunes them. `git reflog` is the bookmark that lets you find them. `git reset --hard <reflog-sha>` restores the exact pre-rebase state. **This is the safety net.** Always verify it works once before a high-stakes rebase.
+      explanation: Dropped commits stay in `.git/objects` until garbage collection. `git reflog` shows the pre-rebase SHA, `git reset --hard` restores it.
     - question: '**[Revisit Step 2]** After an interactive rebase, the rewritten commits have new SHAs even if their patches are identical. Why?'
       options:
       - Interactive rebase randomly generates SHAs
@@ -2482,7 +1923,7 @@ steps:
       - Interactive rebase encrypts commits
       - Git renames the commits for clarity
       correct_index: 1
-      explanation: 'Same answer as for simple rebase: different parent → different SHA. The object model does not allow ''editing'' a commit — all that changes is which commit the branch pointer references.'
+      explanation: 'Different parent → different SHA. Commits aren''t edited — the branch pointer moves to a new commit.'
     - question: Which of these is the **most dangerous** use of interactive rebase?
       options:
       - On a local branch to squash WIP commits before opening a PR
@@ -2490,7 +1931,7 @@ steps:
       - On `main` of a shared repository used by 10 teammates, to drop a week-old commit
       - On a personal experiment branch that nobody else has cloned
       correct_index: 2
-      explanation: Rewriting shared history is the nuclear option. Everyone who fetched the old commits now has a conflicting local copy of main; their pulls fail spectacularly. For public history, use `git revert` (which creates a new *anti-matter* commit) instead. Reserve interactive rebase for local cleanup.
+      explanation: Rewriting shared history breaks everyone holding the old SHAs. For public history, `git revert` instead — it creates a negating commit without changing SHAs.
     - question: You want to split one giant commit into three smaller ones during interactive rebase. Which action lets you do that?
       options:
       - '`pick`'
@@ -2498,7 +1939,7 @@ steps:
       - '`edit` — pauses at the commit so you can `git reset HEAD~`, stage smaller pieces, and commit each separately'
       - '`reword`'
       correct_index: 2
-      explanation: '`edit` pauses rebase at that commit with HEAD there. You then `git reset HEAD~` (un-commit but keep changes staged/unstaged), split the changes into multiple `git add` + `git commit` cycles, and finally `git rebase --continue`. The original one commit is replaced by your new sequence.'
+      explanation: '`edit` pauses at that commit. `git reset HEAD~` to un-commit while keeping the changes, split with `git add` + `git commit`, then `git rebase --continue`.'
     - question: '**[Revisit Step 1]** In Task 3b you ''rescued'' a dropped commit. In terms of the object database, what did `git branch secret-backup <sha>` actually do?'
       options:
       - It copied the dropped commit from `.git/trash` back into `.git/objects`
@@ -2506,7 +1947,7 @@ steps:
       - It recreated the commit from the reflog's textual record
       - It undid the rebase
       correct_index: 1
-      explanation: Same mechanic as Step 1's rescued-work branch. The dropped commit was never deleted — only unreferenced. Creating a branch (one 41-byte file) re-anchors it as reachable. Now `git gc` won't prune it. This is the same reflog + branch recipe, applied to a different scenario (rebase-drop vs detached-HEAD-orphan).
+      explanation: The commit wasn't deleted, just unreferenced. Creating a branch (one 41-byte ref file) re-anchors it as reachable, so `git gc` won't prune it.
     - question: '**[Revisit Step 4]** You are about to interactive-rebase a branch. You have uncommitted edits you want to keep but not carry through the rebase. Safest workflow?'
       options:
       - Commit them as WIP then rebase — they will survive
@@ -2514,39 +1955,33 @@ steps:
       - Run rebase with `--ignore-uncommitted`
       - Git rebase will refuse to start if you have uncommitted changes, so nothing to worry about
       correct_index: 1
-      explanation: 'Rebase refuses to start with dirty working tree — so Git is already stopping you. Stash is the clean pattern: preserve the work-in-progress (Step 3), do the rebase, pop the stash onto the rebased branch. This composes tools across steps — recognizing when two tools work together is the mark of Git fluency.'
+      explanation: 'Rebase refuses to start with a dirty working tree. Stash, rebase, then pop the stash onto the rebased branch.'
 - title: 'Squash Merge: Collapse a Feature Into a Single Commit'
   view: git_graph
   instructions: |
-    > ⚠️ **Common wrong model you may be carrying:**
-    > *"`git merge --squash feature` deletes the feature branch and
-    > rewrites its commits."* **Wrong.** `--squash` doesn't touch the
-    > feature branch. It only takes the cumulative diff and stages it
-    > on your *current* branch. The feature's individual commits remain
-    > exactly where they were. This is the single most common
-    > misconception about squash merge — notice if you were holding it.
+    > **Wrong model to unlearn:** *"`--squash` deletes the feature
+    > branch and rewrites its commits."* It doesn't. `--squash` just
+    > stages the cumulative diff on the current branch; the feature
+    > branch is untouched.
 
     ### The goal
 
-    Your feature branch has 7 commits — useful while developing, but on
-    `main` you want **one clean commit** per feature. This is the
-    default on many GitHub-based teams (the green "Squash and merge"
-    button on a PR).
+    Your feature branch has 7 commits. On `main`, you want one clean
+    commit per feature — the "Squash and merge" button on GitHub PRs.
 
-    Three ways to get there:
+    Three options:
 
-    | Method | Resulting history | When |
+    | Method | Main's history | When |
     |---|---|---|
-    | `git merge feature` | Merge commit (2 parents) preserving branch | Long-lived branches, preserving merge context |
-    | `git rebase feature` (on main) | Linear, each commit preserved | Short features, keeping individual commits |
-    | `git merge --squash feature` | **One new commit** on main, branch history discarded | You want feature = single commit |
+    | `git merge feature` | Merge commit (2 parents) | Long-lived branches |
+    | `git rebase` + merge | Linear, all commits preserved | Short features, individual commits matter |
+    | `git merge --squash feature` | One new commit | You want feature = single commit |
 
-    ### How squash merge works
+    ### How it works
 
-    `git merge --squash feature` takes the cumulative patch of all
-    commits on `feature` (not on `main`) and stages it as a single
-    change. You then `git commit` with a message describing the feature
-    as a whole.
+    `git merge --squash feature` takes the cumulative patch of the
+    feature's commits (relative to the merge base) and stages it. You
+    then `git commit` with a fresh message.
 
     **Before** — feature work lives on its own branch:
 
@@ -2581,29 +2016,23 @@ steps:
     @enduml
     ```
 
-    Feature branch is untouched; main gets one commit that contains
-    all of the feature's changes combined.
+    Feature branch is untouched; main gets one commit with the
+    combined changes.
 
-    ### Task 1: Inspect the pre-built feature branch
+    ### Task 1: Inspect the branch
 
-    The tutorial has set up a `feature-stats` branch with three
-    independent commits — `mean`, `variance`, `stddev` — building one
-    statistics feature. Inspect:
+    `feature-stats` has three commits — `mean`, `variance`, `stddev`.
 
     ```bash
     git log feature-stats --oneline -5
     git diff main feature-stats -- calculator.py | head -40
     ```
 
-    Three focused commits. You now want to land this as **one**
-    commit on main rather than three.
+    ### Task 2: Squash-merge
 
-    ### Task 2: Squash-merge into main
-
-    **Predict first:** after `git merge --squash feature-stats`, will
-    there be a new commit on `main`? Will the feature branch be
-    deleted? Will the working tree be clean? Commit to three
-    yes/no predictions.
+    **Predict:** after `git merge --squash feature-stats`, will there
+    be a new commit on main? Will feature-stats be deleted? Will the
+    working tree be clean?
 
     ```bash
     git switch main
@@ -2611,75 +2040,57 @@ steps:
     git status
     ```
 
-    Surprising answers, if you didn't guess them: **no new commit
-    yet** (you must still run `git commit`), **feature branch
-    untouched**, **working tree dirty with staged changes** (the
-    combined diff is sitting in the index).
-
-    Finalize with a commit message describing the whole feature:
+    Answers: no new commit yet (you still run `git commit`), feature
+    branch untouched, working tree has staged changes.
 
     ```bash
-    git status
     git commit -m "Add descriptive statistics module (mean, variance, stddev)"
     ```
 
-    ### Task 3: Inspect the result
+    ### Task 3: Inspect
 
     ```bash
     git log --oneline main
     git log --all --oneline --graph
     ```
 
-    Main has **one** new commit for the entire feature. The original
-    three commits on `feature-stats` are still there (for reference or
-    bisect), but they are not merged into main.
+    One new commit on main. The original three live on `feature-stats`.
 
-    Clean up the feature branch since main has the work now:
+    Clean up:
 
     ```bash
-    git branch -D feature-stats      # -D (force) because not ff-merged
+    git branch -D feature-stats      # -D because not ff-merged
     ```
 
-    > **Trade-off:** squash merge loses individual commit granularity
-    > on main. If a bug is introduced in one of the three sub-features,
-    > `git bisect` on main can only narrow it down to "the whole
-    > feature", not to which of the three internal commits caused it.
-    > Teams value this trade-off differently.
+    > **Trade-off:** squash loses intra-feature granularity. `git
+    > bisect` on main narrows to "the whole feature", not which
+    > internal commit caused the bug.
 
-    ### Comparison: three merge strategies on the same history
+    ### Comparison
 
-    | Command | main commit graph |
+    | Command | Main's graph |
     |---|---|
-    | `git merge feature` | `A ── B ── C ── M` where `M` has two parents |
-    | `git rebase main` on feature, then `git merge feature` on main | `A ── B ── C ── α' ── β' ── γ'` (linear) |
-    | `git merge --squash feature; git commit` | `A ── B ── C ── αβγ` (one new commit) |
+    | `git merge feature` | `A ── B ── C ── M` (M has 2 parents) |
+    | Rebase + merge | `A ── B ── C ── α' ── β' ── γ'` |
+    | `git merge --squash feature; git commit` | `A ── B ── C ── αβγ` |
 
-    ### Stop and self-explain
+    ### Self-explain
 
-    Before moving on, **write or say in one sentence**: why is the
-    feature branch's last commit `γ` **not** a parent of the new
-    squash commit, even though the squash commit contains `γ`'s
-    changes?
+    In one sentence: why isn't `γ` a parent of the squash commit,
+    even though the squash commit contains `γ`'s changes?
 
     …
 
-    > Expected answer: "`git merge --squash` only takes the
-    > *cumulative diff* and stages it. The resulting commit's parent
-    > is whatever HEAD was before the squash (the tip of `main`). No
-    > reference is stored to `γ`'s commit object — which is why the
-    > feature branch's history is **invisible** to `git log main`
-    > afterwards, and why `git bisect` on `main` cannot drill into
-    > the feature." Same object-model logic: commits store explicit
-    > parent references; `--squash` deliberately omits them.
+    > `--squash` stages only the cumulative diff. The new commit's
+    > parent is the prior HEAD of main. No reference to `γ` is
+    > stored, so `git log main` never shows the feature's history
+    > and `git bisect` can't drill into it.
 
     ### You can now
 
-    - **Choose** squash vs rebase vs merge based on how you want
-      `main`'s history to read.
-    - **Anticipate** the trade-off: squash gives clean main-history
-      but loses `git bisect` precision *within* a feature.
-    - **Recover** individual feature commits if needed — they still
-      exist on the (pre-delete) feature branch and in reflog.
+    - Choose squash vs rebase vs merge based on how you want main to read.
+    - Anticipate the trade-off — clean history, less bisect precision.
+    - Recover individual commits from the feature branch or reflog if you need them.
   setup_commands:
   - "cd /tutorial/myproject\ngit merge --abort 2>/dev/null\ngit switch -q main 2>/dev/null\nif git log feature-stats --oneline 2>/dev/null | grep -q 'Add stddev function'; then\n  exit 0\nfi\ngit branch -D feature-stats 2>/dev/null\ngit switch -qc feature-stats\nprintf '\\ndef mean(values):\\n    return sum(values) / len(values)\\n' >> calculator.py\ngit commit -qam 'Add mean function'\nprintf '\\ndef variance(values):\\n    m = mean(values)\\n    return sum((x - m) ** 2 for x in values) / len(values)\\n' >> calculator.py\ngit commit -qam 'Add variance function'\nprintf '\\nimport math as _math\\ndef stddev(values):\\n    return _math.sqrt(variance(values))\\n' >> calculator.py\ngit commit -qam 'Add stddev function'\ngit switch -q main\n"
   solution:
@@ -2689,26 +2100,26 @@ steps:
     - git commit -m 'Add descriptive statistics module (mean, variance, stddev)'
     - git branch -D feature-stats
     explanation: |
-      - **`git merge --squash <branch>`:** applies the cumulative diff of `<branch>` vs main's merge base, stages it, but **does not commit**. You then `git commit` with a fresh message. Main gains one commit; `<branch>` is untouched.
-      - **One commit per feature:** main's history reads cleanly (one commit = one feature). Trade-off: you lose fine-grained intra-feature history, making `git bisect` less precise within the feature.
-      - **Branch cleanup:** after a squash merge, the feature branch was *not* ff-merged in Git's eyes (its commits are not on main — only a new combined commit is). Use `git branch -D` (capital D, force) to delete it.
+      - `git merge --squash <branch>` stages the cumulative diff but doesn't commit. You supply a fresh message. Main gets one commit, `<branch>` is untouched.
+      - Main reads cleanly (one commit per feature). Trade-off: `git bisect` on main can't drill into the feature.
+      - The feature's commits aren't on main from Git's perspective, so `git branch -d` refuses. Use `-D` to force-delete.
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
     hints:
-    - text: End this step on `main`. The squash merge is performed *from* `main` (that's why you `git switch main` before running it). If you're still on `feature-stats`, `git switch main` and redo the merge.
+    - text: 'End on `main`. Squash merge runs *from* `main` — `git switch main` first.'
   - description: feature-stats branch has been deleted
     command: cd /tutorial/myproject && ! git branch | grep -q 'feature-stats'
     hints:
-    - text: '`feature-stats` is still listed by `git branch`. Squash merge does **not** mark the feature branch as merged in Git''s eyes — its individual commits are not on main (only a new combined commit is). That means plain `git branch -d feature-stats` will refuse. Force it with capital-D: `git branch -D feature-stats`.'
+    - text: "Squash merge doesn't make Git consider `feature-stats` merged — its original commits aren't on `main`. Plain `-d` refuses; use `git branch -D feature-stats`."
   - description: mean, variance, and stddev are on main
     command: cd /tutorial/myproject && grep -q 'def mean' calculator.py && grep -q 'def variance' calculator.py && grep -q 'def stddev' calculator.py
     hints:
-    - text: 'One or more of `mean`/`variance`/`stddev` is missing from `calculator.py` on `main`. Unlike regular `git merge`, `git merge --squash` only **stages** the combined diff — it does **not** create a commit for you. After the squash, run `git status` (you should see staged changes), then `git commit -m "..."` to record them.'
+    - text: '`git merge --squash` only *stages* the diff — it doesn''t commit. After the squash, `git commit -m "..."` to land the combined commit.'
   - description: The three feature commits are NOT in main's history (only one combined commit)
     command: cd /tutorial/myproject && [ $(git log --oneline main | grep -ciE 'Add (mean|variance|stddev) function') -eq 0 ]
     hints:
-    - text: '`main`''s log shows the feature''s individual commits — meaning you did a plain `git merge` (which preserves history) or a rebase, not a `--squash`. The goal of this step is *one* combined commit on main. Undo with `git reset --hard <pre-merge-sha>` (from reflog), then use `git merge --squash feature-stats` followed by `git commit`.'
+    - text: "The individual feature commits are on `main` — you did a plain merge or rebase, not `--squash`. Rewind with `git reset --hard` (from reflog) and redo with `git merge --squash feature-stats && git commit`."
   quiz:
     title: Squash Merge — Knowledge Check
     min_score: 0.8
@@ -2721,7 +2132,7 @@ steps:
       - Deletes the feature branch
       - Rebases the feature onto main
       correct_index: 1
-      explanation: Squash stages a combined patch but does not commit — you supply the message. The result is *one* new commit on main containing all of the feature's changes; the feature's individual commits never appear on main.
+      explanation: Squash stages a combined patch without committing. You supply the message. Main ends up with one new commit; the feature's individual commits never land.
     - question: After `git merge --squash feature; git commit`, what is true of the feature branch?
       options:
       - It no longer exists — squash deleted it
@@ -2729,7 +2140,7 @@ steps:
       - It points at the new squash commit on main
       - Its commits have been rewritten
       correct_index: 1
-      explanation: Squash merge does not touch the feature branch. It is still there with its full history. To delete it after squashing, use `git branch -D feature` (force, because it is not ff-merged by Git's definition).
+      explanation: Squash leaves the feature branch alone. Delete it with `git branch -D feature` — plain `-d` refuses because Git doesn't see it as merged.
     - question: '**[Compare with Step 7]** You have a 3-commit feature. You merge it three ways. Which output is correct?'
       options:
       - plain `merge` → 1 new commit on main; `rebase + merge` → 3 new commits on main; `--squash + commit` → 3 new commits on main
@@ -2737,7 +2148,7 @@ steps:
       - plain `merge` → 1 merge commit with 2 parents; `rebase + merge` → 3 replayed commits on main (linear, ff); `--squash + commit` → 1 new commit on main
       - All three approaches produce identical history
       correct_index: 2
-      explanation: Plain merge = 1 merge commit (2 parents). Rebase linearizes so merge ff-forwards 3 commits. Squash collapses the 3 into 1 new commit. Team preference decides which is right for the project.
+      explanation: Plain merge = 1 merge commit (2 parents). Rebase + merge = 3 replayed commits, linear. Squash = 1 new commit. Pick per team preference.
     - question: Why might a team **reject** squash merge as a default policy?
       options:
       - It forces a merge commit which they dislike
@@ -2745,7 +2156,7 @@ steps:
       - Git rejects squash merges on `main`
       - It requires a paid GitHub subscription
       correct_index: 1
-      explanation: With squash, `git bisect` can only narrow to 'this whole feature', not to which intermediate commit caused the regression. Intermediate authors also disappear from main's history. Some teams prefer rebase/merge for richer history.
+      explanation: Squash makes `git bisect` on main stop at "this whole feature", not the internal commit that broke things. Intermediate authors also disappear.
     - question: You squash-merged `feature-stats` into main. The next day you discover one of the three internal commits had a bug. How do you fix only that part?
       options:
       - Git tracks internal commits automatically — run `git revert --internal <sha>`
@@ -2753,7 +2164,7 @@ steps:
       - Use `git bisect run` to revert automatically
       - Delete main and re-merge with `git merge --no-squash`
       correct_index: 1
-      explanation: Squash hides internal granularity on main. But the original commits still exist where the feature branch was (or via reflog). You can cherry-pick a fix or write a small revert patch on main. This is the classic squash trade-off — convenience on main, less surgical control later.
+      explanation: Squash hides internal granularity on main, but the originals live on the feature branch (or in reflog). Cherry-pick a fix or write a targeted revert on main.
     - question: '**[Revisit Step 6]** A regression is reported on `main` three months after a feature was **squash-merged** in. `git bisect` on `main` narrows the culprit to the squash commit. What is your next move?'
       options:
       - Declare the feature author guilty and revert the whole squash commit
@@ -2761,7 +2172,7 @@ steps:
       - Bisect is unreliable after squash — read every line of the squash commit's diff
       - Re-run bisect with `--squash-aware`
       correct_index: 1
-      explanation: Squash flattens *main's* history, not the feature branch's. The fine-grained commits are still preserved on the feature branch (assuming you didn't delete it) and in reflog. Bisect on the feature branch pinpoints the exact internal commit. This is the strongest argument for keeping merged feature branches for a while, not deleting them immediately.
+      explanation: Squash flattens main, not the feature branch. Bisect on the feature branch (or its reflog) pinpoints the exact internal commit — a good argument for keeping merged feature branches for a while.
     - question: '**[Revisit Step 2]** After `git merge --squash feature; git commit`, the new squash commit on main is a Git commit object like any other. What are its **parents**?'
       options:
       - 'Two parents: the tip of main and the tip of feature (like a merge commit)'
@@ -2769,47 +2180,36 @@ steps:
       - 'One parent: the tip of main (before the squash). The feature branch tip is NOT a parent — that is what makes it a squash rather than a merge'
       - Zero parents — squash commits are parentless root commits
       correct_index: 2
-      explanation: 'A squash commit has exactly one parent: the prior HEAD of the branch you ran `merge --squash` on. The feature branch tip is not referenced as a parent — which is why `git log main` shows a clean linear history and why `git bisect` on main cannot drill into the feature. Same object-model: the commit records exactly the parents it was given, nothing more.'
+      explanation: 'A squash commit has exactly one parent: prior HEAD of main. The feature tip isn''t referenced, which is why main''s log stays linear and bisect can''t drill in.'
 - title: 'Git Submodules: Add & Clone'
   view: editor
   instructions: |
-    > ⚠️ **Common wrong model you may be carrying:**
-    > *"A submodule copies the library's files into my repo, so my
-    > repo ends up storing two copies of everything."* **Wrong.** The
-    > outer repo stores **one 40-char SHA** (plus a URL in
-    > `.gitmodules`). That is enough — the content lives in the
-    > submodule's own object database. No duplication. Same
-    > snapshot-identity idea as Step 2.
+    > **Wrong model to unlearn:** *"a submodule copies the library's
+    > files into my repo."* It doesn't. The outer repo stores a
+    > 40-char SHA plus a URL in `.gitmodules`. The content lives in
+    > the submodule's own object database.
 
-    ### Mental model: a library subscription
+    ### Mental model: a subscription
 
-    Think of a submodule like **subscribing to a specific edition
-    (version) of a library**:
+    You're subscribing to a specific edition of a library:
 
-    - You don't photocopy the library book into your own bookshelf
-      (no file duplication).
-    - You write down the **book title + edition number** (`.gitmodules`
-      URL + pinned SHA).
+    - No photocopy of the book in your bookshelf.
+    - You write down the title + edition (`.gitmodules` URL + pinned SHA).
     - Anyone with your note can fetch the same edition.
-    - To upgrade, you edit the edition number — not the book.
+    - To upgrade, change the edition — not the book.
 
-    The "edition number" is the commit SHA. The "book" is the
-    submodule's Git repository, hosted elsewhere.
+    Edition = commit SHA. Book = the submodule's repo.
 
     ### The problem
 
-    Your main application depends on a shared library your team
-    maintains in a separate repository (e.g., `math-utils`). You want:
+    Your app depends on a shared library (e.g., `math-utils`). You want:
 
-    1. The library's source available in your project's working tree.
-    2. The ability to **pin a specific version** (commit) of the library.
-    3. To upgrade the library independently — without duplicating its
-       code into your main repo.
+    1. Its source in your working tree.
+    2. A pinned version.
+    3. Upgrades on your schedule, no duplication in your repo.
 
-    `git submodule` solves this. Internally, it is surprisingly simple:
-    your main repo stores **a pointer to a specific commit** in the
-    submodule's repo, plus a `.gitmodules` config file describing where
-    to fetch it.
+    `git submodule` gives you a pointer to a commit plus a config file
+    describing where to fetch it.
 
     ### On-disk layout
 
@@ -2828,21 +2228,15 @@ steps:
     @enduml
     ```
 
-    In main-repo, `vendor/math-utils` is tracked as a special "gitlink"
-    entry — essentially a file that says "check out commit `abc123` of
-    the math-utils repo here."
+    `vendor/math-utils` is tracked as a "gitlink" entry — a reference
+    that says "check out commit `abc123` of the math-utils repo here."
 
-    ### Task 1: Inspect the pre-built "remote" library
+    ### Task 1: Inspect the "remote"
 
-    The tutorial has prepared a tiny `math-utils` library as if it
-    were hosted on GitHub:
+    The tutorial prepared a tiny `math-utils` as if hosted on GitHub:
 
-    - `/tutorial/math-utils-src/` — the "upstream" working repo (one
-      commit with `double` and `triple` functions).
-    - `/tutorial/math-utils.git` — a bare clone that acts as the
-      remote URL your main project will reference.
-
-    Inspect:
+    - `/tutorial/math-utils-src/` — upstream working repo with `double` and `triple`.
+    - `/tutorial/math-utils.git` — a bare clone acting as the remote URL.
 
     ```bash
     ls /tutorial/math-utils-src
@@ -2850,11 +2244,9 @@ steps:
     ls /tutorial/math-utils.git
     ```
 
-    In real life `math-utils.git` would be
-    `https://github.com/example/math-utils.git`. Here it is a local
-    path — same semantics for `git clone`.
+    In real life this would be an HTTPS URL. Same semantics.
 
-    ### Task 2: Add the submodule to your main project
+    ### Task 2: Add the submodule
 
     ```bash
     cd /tutorial/myproject
@@ -2862,22 +2254,17 @@ steps:
     git submodule add /tutorial/math-utils.git vendor/math-utils
     ```
 
-    Inspect what changed:
-
     ```bash
     ls vendor/math-utils
     git status
     ```
 
-    You should see *two* new entries in `git status`: `.gitmodules` and
-    `vendor/math-utils`. The latter is the special gitlink pointer;
-    the former is the plain-text config file Git just created for you.
+    Two new entries: `.gitmodules` (plain-text config) and
+    `vendor/math-utils` (the gitlink pointer).
 
     ### Open `.gitmodules` in the editor
 
-    **Don't `cat` it in the terminal — open it in the Monaco editor
-    on the right.** Click `.gitmodules` in the file tree (or use
-    File → Open). You will see something like:
+    Click `.gitmodules` in the file tree. You'll see:
 
     ```ini
     [submodule "vendor/math-utils"]
@@ -2885,55 +2272,42 @@ steps:
             url = /tutorial/math-utils.git
     ```
 
-    **Inspect it closely. Answer these before moving on:**
+    Before moving on:
 
-    1. How many lines? (Is it a "big complicated config" or a "tiny
-       stanza"?)
-    2. Where is the URL you passed to `git submodule add`? Is the
-       pinned **commit SHA** stored in this file?
-    3. What would break if you deleted this file?
+    1. How many lines per submodule?
+    2. Is the pinned commit SHA in this file?
+    3. What breaks if you delete it?
 
-    <details><summary>Reveal answers</summary>
+    <details><summary>Answers</summary>
 
-    1. **Three lines per submodule** (a header + `path` + `url`). If
-       you add three submodules, the file grows to 9 lines. `.gitmodules`
-       is tiny by design — it only contains what teammates need to
-       *fetch* each submodule.
-    2. **URL yes, pinned SHA no.** The SHA lives in the outer tree
-       as a gitlink (`git ls-files -s vendor/math-utils` — see
-       below). `.gitmodules` answers "*where* can I fetch this"; the
-       tree answers "*which commit* do I check out". Two independent
-       pieces of information.
-    3. **Teammates could not clone your submodules.** Without
-       `.gitmodules`, `git clone --recursive` and `git submodule
-       update --init` would not know any URLs to fetch from. The
-       gitlink would still point at a SHA, but Git would have no
-       way to retrieve the commit. `.gitmodules` is the
-       **subscription directory**; the gitlink is the **edition
-       selection**.
+    1. Three lines — header + `path` + `url`. Tiny by design.
+    2. **No.** The URL is here; the pinned SHA lives in the outer
+       tree as a gitlink. `.gitmodules` says *where* to fetch; the
+       tree says *which commit*.
+    3. Teammates couldn't fetch the submodule — `git submodule
+       update --init` wouldn't know any URL.
 
     </details>
 
-    Now look at the gitlink in the terminal:
+    Look at the gitlink:
 
     ```bash
     git ls-files -s vendor/math-utils
     ```
 
-    The output starts with `160000` — a special mode meaning "this is a
-    submodule gitlink, not a regular file". The SHA after it is the
-    **submodule's current commit SHA** that your main repo pins.
+    The `160000` mode marks a submodule gitlink. The SHA is the
+    pinned commit.
 
-    Commit both the `.gitmodules` config and the gitlink pointer:
+    Commit both:
 
     ```bash
     git commit -m "Add math-utils submodule at v0.1.0"
     ```
 
-    ### Task 3: Clone a repo with submodules
+    ### Task 3: Recursive clone
 
-    A colleague cloning your main repo needs `--recursive` or they get
-    an empty submodule folder. Simulate that:
+    A colleague cloning without `--recursive` gets an empty
+    submodule folder. Simulate:
 
     ```bash
     cd /tutorial
@@ -2941,29 +2315,21 @@ steps:
     ls colleague-clone/vendor/math-utils
     ```
 
-    The colleague's clone has the submodule content at the correct
-    pinned commit. Without `--recursive`, `vendor/math-utils/` would
-    exist but be empty until they ran `git submodule update --init`.
+    Without `--recursive`, `vendor/math-utils/` stays empty until
+    `git submodule update --init`.
 
-    ### Summary so far
+    ### Summary
 
-    You have added a submodule and cloned it recursively. The outer
-    repo now stores: (1) a `.gitmodules` entry with the URL, (2) one
-    40-char pinned SHA. That is the entire "subscription record" —
-    no file duplication, consistent with the Step 2 object model.
+    The outer repo stores (1) a `.gitmodules` entry with the URL and
+    (2) one 40-char pinned SHA. No file duplication.
 
-    **Upgrade** and **resync** are the subjects of the next step.
+    Upgrade and resync come next step.
 
     ### You can now
 
-    - **Add** a submodule to an existing repo with `git submodule add
-      <url> <path>`.
-    - **Clone** a repo that uses submodules correctly with `git clone
-      --recursive` (or recover after a plain clone with `git
-      submodule update --init --recursive`).
-    - **Recognize** the gitlink's `160000` mode and the `.gitmodules`
-      file — the two structural differences between a regular file
-      and a submodule.
+    - Add a submodule with `git submodule add <url> <path>`.
+    - Clone with `--recursive`, or recover with `git submodule update --init --recursive`.
+    - Spot the `160000` gitlink mode and `.gitmodules` — the two things that distinguish a submodule from a regular file.
   setup_commands:
   - "cd /tutorial/myproject && git switch -q main 2>/dev/null\nif [ -d /tutorial/math-utils.git ] && git --git-dir=/tutorial/math-utils.git log --oneline 2>/dev/null | grep -q 'Initial utils' && [ -x /tutorial/publish-math-utils-v0.2.sh ]; then\n  exit 0\nfi\nrm -rf /tutorial/math-utils-src /tutorial/math-utils.git /tutorial/colleague-clone\nmkdir -p /tutorial/math-utils-src\ncd /tutorial/math-utils-src\ngit init -q\nprintf 'def double(x):\\n    return x * 2\\n\\ndef triple(x):\\n    return x * 3\\n' > utils.py\ngit add utils.py\ngit commit -qm 'Initial utils'\ncd /tutorial\ngit clone -q --bare math-utils-src math-utils.git\n# Install the \"upstream publishes v0.2\" helper.\ncat > /tutorial/publish-math-utils-v0.2.sh << 'SCRIPT'\n#!/bin/bash\nset -e\ncd /tutorial/math-utils-src\nif grep -q 'def quadruple' utils.py; then\n  echo 'upstream math-utils already at v0.2'\n  exit 0\nfi\nprintf '\\ndef quadruple(x):\\n    return x * 4\\n' >> utils.py\ngit commit -qam 'Add quadruple'\n# Push to the bare 'remote' so submodule fetch sees it\nBR=$(git rev-parse --abbrev-ref HEAD)\ngit push -q /tutorial/math-utils.git $BR:$BR 2>/dev/null || \\\n  git push -q /tutorial/math-utils.git HEAD:master 2>/dev/null || \\\n  git push -q /tutorial/math-utils.git HEAD:main 2>/dev/null || true\necho 'upstream math-utils is now at v0.2 (adds quadruple)'\nSCRIPT\nchmod +x /tutorial/publish-math-utils-v0.2.sh\n"
   solution:
@@ -2973,30 +2339,30 @@ steps:
     - git commit -m 'Add math-utils submodule at v0.1.0'
     - cd /tutorial && git clone --recursive myproject colleague-clone
     explanation: |
-      - **`git submodule add <url> <path>`:** Clones the URL into the path AND creates a `.gitmodules` entry describing that submodule (its path + URL). Both the `.gitmodules` file and the gitlink pointer must be committed.
-      - **Gitlink vs regular file:** a submodule entry has Git mode `160000` (instead of `100644` for a regular file). Its content is not bytes — it is a 40-char commit SHA indicating *which commit* of the submodule's repo should be checked out here.
-      - **`git clone --recursive`:** Clones the outer repo and all submodules in one command. Forgetting this leaves empty submodule folders until `git submodule update --init --recursive`.
+      - `git submodule add <url> <path>`: clones the URL and creates a `.gitmodules` entry. Commit both the file and the gitlink.
+      - Gitlink vs regular file: mode `160000` instead of `100644`. The entry's content is a 40-char commit SHA, not bytes.
+      - `git clone --recursive`: clones the outer repo and all submodules in one go. Forgetting it leaves empty folders until `git submodule update --init --recursive`.
   tests:
   - description: myproject has a math-utils submodule
     command: cd /tutorial/myproject && [ -f .gitmodules ] && grep -q 'math-utils' .gitmodules
     hints:
-    - text: '`.gitmodules` is missing or doesn''t reference math-utils. Run `git submodule add /tutorial/math-utils.git vendor/math-utils` from inside `/tutorial/myproject` — that one command creates the `.gitmodules` entry and clones the submodule at `vendor/math-utils`.'
+    - text: 'Run `git submodule add /tutorial/math-utils.git vendor/math-utils` from `/tutorial/myproject`. That one command creates `.gitmodules` and clones the submodule.'
   - description: .gitmodules has been committed
     command: cd /tutorial/myproject && git log --oneline -- .gitmodules | grep -q '.'
     hints:
-    - text: '`.gitmodules` exists in your working tree but isn''t in the repo''s history yet. `git submodule add` only **stages** the file; you still need `git commit -m "Add math-utils submodule"` to record it. Without that commit, a teammate cloning your repo won''t know the submodule exists.'
+    - text: '`.gitmodules` is staged but not committed. `git commit -m "Add math-utils submodule"` — otherwise teammates won''t see it.'
   - description: Submodule content is checked out
     command: '[ -f /tutorial/myproject/vendor/math-utils/utils.py ]'
     hints:
-    - text: '`vendor/math-utils/utils.py` is missing. `git submodule add` normally clones the submodule content for you. If the directory is empty, run `git submodule update --init --recursive` to populate it from the pinned SHA.'
+    - text: 'Submodule directory is empty. `git submodule update --init --recursive` populates it from the pinned SHA.'
   - description: vendor/math-utils is tracked as a gitlink (mode 160000)
     command: cd /tutorial/myproject && git ls-files -s vendor/math-utils | grep -q '^160000'
     hints:
-    - text: '`vendor/math-utils` is tracked as regular files instead of a gitlink. This happens if you manually `git add`-ed the submodule''s files instead of using `git submodule add`. Remove the path (`git rm -rf --cached vendor/math-utils`) and re-add it with `git submodule add /tutorial/math-utils.git vendor/math-utils`.'
+    - text: "You `git add`-ed the submodule's files directly, so it's tracked as regular files. Undo with `git rm -rf --cached vendor/math-utils`, then `git submodule add /tutorial/math-utils.git vendor/math-utils`."
   - description: colleague-clone was created successfully with its submodule populated
     command: '[ -f /tutorial/colleague-clone/vendor/math-utils/utils.py ]'
     hints:
-    - text: '`colleague-clone/vendor/math-utils/` is empty (or the directory doesn''t exist). Plain `git clone` records the submodule entry but does **not** fetch its content. Use `git clone --recursive /tutorial/myproject colleague-clone`, or after a plain clone, `cd colleague-clone && git submodule update --init --recursive`.'
+    - text: "Plain `git clone` doesn't fetch submodule content. Either `git clone --recursive ...` or run `git submodule update --init --recursive` inside the clone."
   quiz:
     title: Git Submodules — Knowledge Check
     min_score: 0.8
@@ -3009,7 +2375,7 @@ steps:
       - Nothing — submodules are purely a runtime concept
       - A symbolic link to the submodule's directory
       correct_index: 1
-      explanation: The outer repo stores ONE SHA per submodule (the pinned commit) plus a `.gitmodules` entry for the URL. The submodule's working files are checked out in the submodule path; its git data (objects, refs, HEAD) lives in the outer repo's `.git/modules/<name>/` — the submodule directory itself contains only a `.git` text file (a "gitfile") pointing there, NOT a full `.git/` directory.
+      explanation: The outer repo stores one SHA per submodule plus a `.gitmodules` URL. The submodule's git data lives in `.git/modules/<name>/`; the submodule directory only has a `.git` text file (gitfile) pointing there.
     - question: A teammate clones your repo normally with `git clone <url>`. What do they see at the submodule path?
       options:
       - The submodule's full contents, checked out automatically
@@ -3017,7 +2383,7 @@ steps:
       - An error preventing the clone from finishing
       - A warning but the content downloads lazily on first access
       correct_index: 1
-      explanation: Plain `git clone` records the submodule entries but does not fetch their content. The folder exists but is empty. `git clone --recursive <url>` or `git submodule update --init --recursive` after the fact populates it.
+      explanation: Plain `git clone` records the submodule entries without fetching their content. Use `--recursive`, or run `git submodule update --init --recursive` after.
     - question: Which statements about submodules are true? (Select all that apply)
       type: multiple
       options:
@@ -3029,7 +2395,7 @@ steps:
       - 0
       - 1
       - 3
-      explanation: The outer repo stores only a pinned SHA (gitlink, mode 160000) and a `.gitmodules` entry — not file copies. The submodule is a genuine nested repo.
+      explanation: Outer repo stores a pinned SHA (gitlink, mode 160000) and a `.gitmodules` entry — no file copies. The submodule is a real nested repo.
     - question: '**[Synthesis — revisits Steps 1, 2]** Why is it internally consistent that a submodule is ''just a pinned commit SHA''?'
       options:
       - Because every Git object is ultimately addressed by a SHA (blobs, trees, commits), the outer repo only needs to point at the submodule's commit SHA to uniquely identify its entire snapshot — no file duplication needed
@@ -3037,7 +2403,7 @@ steps:
       - Because submodules are always read-only
       - Because Git stores submodules separately in a proprietary database
       correct_index: 0
-      explanation: Back to the object model (Step 2). A commit SHA uniquely identifies a whole-project snapshot (commit → tree → blobs). Pinning a commit SHA is enough to reconstruct the submodule's entire content. No file duplication is necessary — exactly the same property that makes branches cheap (Step 1).
+      explanation: A commit SHA identifies a full snapshot (commit → tree → blobs). Pinning that SHA is enough to reconstruct the submodule's content — same property that makes branches cheap.
     - question: '**[Revisit Step 7]** A submodule''s pinned SHA is 40 characters, just like a regular commit SHA. In terms of Git objects, what kind of object does it point to?'
       options:
       - A blob object
@@ -3045,57 +2411,50 @@ steps:
       - A commit object — in the submodule's separate repository's object database
       - A tag object
       correct_index: 2
-      explanation: A gitlink pins a *commit* SHA — which (via the commit's tree and blobs) uniquely determines the submodule's entire file state. The commit lives in the submodule's `.git/objects/`, not the outer repo's. This is exactly the same commit-SHA-as-snapshot-identity property rebase relies on (Step 7) and that makes the whole object model coherent.
+      explanation: A gitlink pins a commit SHA, which determines the submodule's full file state via its tree and blobs. The commit lives in the submodule's `.git/objects/`.
   watch_files:
   - myproject/.gitmodules
   open_file: myproject/.gitmodules
 - title: 'Updating Submodules: Upstream Bumps & Resync'
   view: editor
   instructions: |
-    You added a submodule in Step 10 and pinned v0.1. Now the
-    upstream library team publishes v0.2 with a new `quadruple`
-    function. You need to:
+    You pinned v0.1 in Step 10. Upstream just published v0.2 with a
+    new `quadruple`. You need to:
 
     1. Fetch the new version inside the submodule.
     2. Bump the pinned SHA in the outer repo.
-    3. Understand what happens to a teammate who pulls your change.
+    3. Know what breaks for a teammate who pulls.
 
-    Plus: what happens when your submodule working directory has
-    "drifted" from the pinned SHA — how you force-sync it back.
+    Plus: how to force-sync a submodule that drifted off the pinned SHA.
 
     ### Task 1: Upstream publishes v0.2
 
-    Simulate the upstream library team publishing v0.2. The tutorial
-    provides a helper script — run it (the upstream team's work, not
-    yours):
+    The tutorial ships a helper that simulates the upstream team:
 
     ```bash
     /tutorial/publish-math-utils-v0.2.sh
     ```
 
-    The script commits a `quadruple` function in the upstream repo
-    and pushes it to the remote `math-utils.git`. Confirm the remote
-    now has two commits:
+    Confirm the remote now has two commits:
 
     ```bash
     git --git-dir=/tutorial/math-utils.git log --oneline --all
     ```
 
-    **Predict:** before running any submodule commands, what does
-    your **outer repo's** `git status` say? Anything about `vendor/math-utils`?
+    **Predict:** before doing anything in your repo, what does `git
+    status` say about `vendor/math-utils`?
 
     ```bash
     cd /tutorial/myproject
     git status
     ```
 
-    Nothing has changed yet — the upstream push doesn't automatically
-    propagate to your checked-out submodule. You must opt in.
+    Nothing — upstream pushes don't reach into your submodule
+    automatically.
 
-    ### Task 2: Fetch and check out the new version inside the submodule
+    ### Task 2: Fetch and check out the new commit
 
-    Remember: a submodule is a nested Git repo. To fetch new commits,
-    use normal `git` commands **inside** the submodule:
+    A submodule is a nested Git repo. Use normal `git` inside it:
 
     ```bash
     cd /tutorial/myproject/vendor/math-utils
@@ -3103,7 +2462,7 @@ steps:
     git checkout origin/HEAD
     ```
 
-    Back in the outer repo, see what Git notices:
+    Back in the outer repo:
 
     ```bash
     cd /tutorial/myproject
@@ -3111,38 +2470,28 @@ steps:
     git diff vendor/math-utils
     ```
 
-    You will see something like:
-
     ```
     modified:   vendor/math-utils (new commits)
 
-    Subproject commit abc123...  ← old (pinned) commit
-    Subproject commit def456...  ← new (checked-out) commit
+    Subproject commit abc123...  ← old pinned
+    Subproject commit def456...  ← new checked-out
     ```
 
-    That one-line diff is the entire thing the outer repo can say
-    about the submodule's change: "the pinned SHA is now this SHA
-    instead of that SHA." **The outer repo does not track the line-level
-    diff** — that lives in the submodule's own object database.
+    That one-line diff is all the outer repo records. The line-level
+    diff lives in the submodule's objects.
 
-    ### Task 3: Bump the pinned SHA in the outer repo
-
-    The upstream version is fetched, but your main repo still *pins*
-    the old SHA. To officially "bump the version":
+    ### Task 3: Bump the pinned SHA
 
     ```bash
     git add vendor/math-utils
     git commit -m "Bump math-utils to v0.2.0 (adds quadruple)"
     ```
 
-    Now `git log main --oneline` shows a commit that just bumps the
-    pinned SHA. In the library-subscription analogy, you changed the
-    edition number in your bookshelf log.
+    In subscription terms: you changed the edition number.
 
-    ### Task 4: The "teammate forgot submodule update" trap
+    ### Task 4: The "forgot submodule update" trap
 
-    Here is the most common submodule pain point. Imagine your teammate
-    pulls your change:
+    Teammate pulls your change:
 
     ```bash
     cd /tutorial/colleague-clone
@@ -3150,31 +2499,28 @@ steps:
     cat vendor/math-utils/utils.py
     ```
 
-    They have the new *pinned SHA* in their outer repo's tree — but
-    **their submodule working directory is still at v0.1**. If their
-    code imports `quadruple`, it will fail with a `NameError`,
-    because the file on disk does not have it yet.
+    Their outer tree has the new pinned SHA, but their submodule
+    working directory is still at v0.1. Code that imports
+    `quadruple` fails with `NameError`.
 
-    The fix is one command:
+    Fix:
 
     ```bash
     git submodule update --init --recursive
     cat vendor/math-utils/utils.py
     ```
 
-    Now `quadruple` is present. This command clones missing submodules
-    and forces each submodule's working directory to match the outer
-    repo's pinned SHA — the **deterministic state**.
+    This command clones missing submodules and snaps each one's
+    working directory to the outer repo's pinned SHA.
 
-    > **Rule of thumb:** after every `git pull` that may have touched
-    > submodule paths, run `git submodule update --init --recursive`.
-    > Or set `git config submodule.recurse true` so pull does it
-    > automatically.
+    > After any `git pull` that might touch submodule paths, run
+    > `git submodule update --init --recursive`. Or set
+    > `git config submodule.recurse true` once.
 
     ### Task 5: Force-resync a drifted submodule
 
-    Simulate a teammate who experimentally checked out an old commit
-    inside the submodule and forgot to come back:
+    Simulate drift — teammate checked out an old commit inside the
+    submodule:
 
     ```bash
     cd /tutorial/colleague-clone/vendor/math-utils
@@ -3183,29 +2529,21 @@ steps:
     git status
     ```
 
-    The outer repo says `modified: vendor/math-utils (new commits)`
-    because the checked-out SHA no longer matches the pinned one.
-    One command restores determinism:
+    Outer says `modified: vendor/math-utils (new commits)`. Fix:
 
     ```bash
     git submodule update --init --recursive
     git status
     ```
 
-    Clean again — the submodule is back at the pinned SHA the outer
-    repo expected. Same command works whether the submodule was
-    never initialized, partially fetched, or drifted.
+    Clean. Same command works whether the submodule was uninitialized,
+    half-fetched, or drifted.
 
     ### You can now
 
-    - **Upgrade** a submodule to a new upstream commit with the
-      two-step dance: `fetch`/`checkout` inside submodule, then
-      `git add`/`commit` outside.
-    - **Diagnose** and fix the classic "teammate forgot submodule
-      update" failure — add `git submodule update --init --recursive`
-      to your post-pull muscle memory.
-    - **Force-resync** any submodule to the outer repo's pinned SHA
-      regardless of how it drifted.
+    - Upgrade a submodule: fetch/checkout inside, `git add`/commit outside.
+    - Diagnose the "teammate forgot submodule update" failure — add `--recursive` to your post-pull habit.
+    - Force-resync any submodule to the outer repo's pinned SHA.
   setup_commands:
   - "cd /tutorial/myproject\ngit switch -q main 2>/dev/null\nif [ ! -f .gitmodules ] || ! grep -q math-utils .gitmodules 2>/dev/null; then\n  git submodule add -f /tutorial/math-utils.git vendor/math-utils 2>/dev/null\n  git commit -qm 'Add math-utils submodule at v0.1.0' 2>/dev/null\nfi\nif [ ! -d /tutorial/colleague-clone ]; then\n  (cd /tutorial && git clone -q --recursive myproject colleague-clone 2>/dev/null)\nfi\ngit submodule update --init --recursive 2>/dev/null\n"
   solution:
@@ -3219,26 +2557,26 @@ steps:
     - cd /tutorial/colleague-clone/vendor/math-utils && git checkout HEAD~1
     - cd /tutorial/colleague-clone && git submodule update --init --recursive
     explanation: |
-      - **Two-step upgrade:** Inside the submodule, `git fetch && git checkout origin/HEAD` moves the submodule's HEAD to the new upstream commit. Outside, `git add <submodule-path> && git commit` records the new pinned SHA in the outer repo. Skipping the outer step means the upgrade is local to you and never reaches teammates.
-      - **Why outer `git pull` does NOT auto-update submodules:** pull updates the *pinned SHA* (because that is what the tree records) but does not touch submodule working directories. Teammates must run `git submodule update --init --recursive` (or configure `submodule.recurse=true`) to actually reflect the new pinned SHA on disk.
-      - **`git submodule update --init --recursive`:** the deterministic-state command. Clones missing submodules, forces every submodule's HEAD to the pinned SHA. The cure for every "my submodule is in a weird state" moment.
+      - Two-step upgrade: inside the submodule, `git fetch && git checkout origin/HEAD`; outside, `git add <path> && git commit`. Skip the outer step and the upgrade never reaches teammates.
+      - Outer `git pull` updates the pinned SHA in the tree but doesn't touch submodule working directories. Teammates run `git submodule update --init --recursive` (or set `submodule.recurse=true`).
+      - `git submodule update --init --recursive` snaps every submodule to its pinned SHA — the one-shot fix for any weird submodule state.
   tests:
   - description: Submodule working directory has the new quadruple function
     command: grep -q 'def quadruple' /tutorial/myproject/vendor/math-utils/utils.py
     hints:
-    - text: 'The `quadruple` function isn''t in the submodule''s working directory. Inside the submodule, run `git fetch && git checkout origin/HEAD` — the submodule is a nested Git repo, and normal `git` commands run **inside** it to move its HEAD. The outer repo''s `git pull` does *not* update submodule working directories automatically.'
+    - text: 'The submodule is a nested repo — you have to `cd` into it. `cd vendor/math-utils && git fetch && git checkout origin/HEAD`. The outer repo''s `git pull` won''t move the submodule for you.'
   - description: Outer repo has a commit bumping the submodule SHA
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'bump|v0.2|quadruple'
     hints:
-    - text: Upgrading a submodule takes **two** actions — you only did half. After checking out the new commit inside `vendor/math-utils`, cd back to `/tutorial/myproject` and run `git add vendor/math-utils && git commit -m "Bump math-utils to v0.2"`. The outer commit records the new pinned SHA; without it, the upgrade never reaches teammates.
+    - text: "Two steps, not one. After checking out the new commit *inside* the submodule, `cd ..` and `git add vendor/math-utils && git commit -m \"Bump math-utils to v0.2\"` in the outer repo. That second commit is what teammates see."
   - description: Outer repo is clean (no pending submodule modifications)
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
     hints:
-    - text: '`git status` in `/tutorial/myproject` will tell you exactly what''s dirty. Two likely culprits: (a) you checked out a new SHA inside the submodule but never `git add`-ed it in the outer repo, or (b) you have staged but uncommitted changes. Commit the bump (or `git submodule update` to reset if you changed your mind).'
+    - text: '`git status` names what''s dirty. Usually: you checked out a new SHA inside the submodule but never committed the bump in the outer repo.'
   - description: Remote (math-utils.git) has the new upstream commit
     command: git --git-dir=/tutorial/math-utils.git log --oneline --all | grep -qi 'quadruple'
     hints:
-    - text: The upstream library hasn't published v0.2 yet. Task 1 asks you to run `/tutorial/publish-math-utils-v0.2.sh` — that helper simulates the upstream team committing `quadruple` and pushing it to the "remote" bare repo. Run it once before proceeding.
+    - text: 'Upstream hasn''t published v0.2 yet. Run `/tutorial/publish-math-utils-v0.2.sh` once — that helper simulates the upstream push.'
   quiz:
     title: Updating Submodules — Knowledge Check
     min_score: 0.8
@@ -3251,7 +2589,7 @@ steps:
       - Their Git is too old
       - The `.gitmodules` file is corrupt
       correct_index: 1
-      explanation: Classic trap. `git pull` on the outer repo updates the **pinned SHA in the tree** but does NOT touch the submodule working directory. They need `git submodule update --init --recursive` to actually reflect the new SHA on disk. Configure `git config submodule.recurse true` to make pull do this automatically.
+      explanation: Classic trap. `git pull` updates the pinned SHA in the tree but doesn't touch the submodule's working directory. `git submodule update --init --recursive` (or `submodule.recurse=true`) reflects it on disk.
     - question: Upgrading a submodule requires how many `git commit` calls in total (inside + outside)?
       options:
       - Zero — `git submodule update` commits for you
@@ -3259,7 +2597,7 @@ steps:
       - Two — if the submodule itself needed new commits (e.g., you wrote a patch inside it), commit there first; then the outer repo commit bumps the SHA. If the new upstream commit already exists, only the outer commit is needed.
       - Three — submodule, `.gitmodules`, and outer tree
       correct_index: 2
-      explanation: The answer depends on whether *you* are authoring the upgrade (write code inside submodule → commit inside → push → commit outside) or just pulling in upstream work (checkout new commit inside → commit outside). In either case the outer commit is mandatory — that is the SHA bump.
+      explanation: 'Authoring an upgrade — commit inside → push → commit outside. Pulling in upstream — checkout new commit inside → commit outside. The outer commit is always the SHA bump.'
     - question: '`git status` in the outer repo shows `modified: vendor/math-utils (new commits)`. What does it mean?'
       options:
       - The `.gitmodules` file has been edited
@@ -3267,7 +2605,7 @@ steps:
       - The submodule is broken
       - Git is about to garbage-collect the submodule
       correct_index: 1
-      explanation: 'The outer repo compares the pinned SHA with the submodule''s actual HEAD. Mismatch → `new commits`. Fix: `git add <path>` + commit to pin the new SHA, or `git submodule update` to snap the submodule back to the pinned SHA.'
+      explanation: 'Outer repo compares pinned SHA against actual HEAD. Mismatch → `new commits`. Fix: `git add <path>` + commit to pin the new SHA, or `git submodule update` to snap back.'
     - question: '**[Revisit Step 1]** Why doesn''t `git pull` automatically update submodule working directories — what Git principle is respected by this design?'
       options:
       - Pull is inherently broken for submodules
@@ -3275,7 +2613,7 @@ steps:
       - Pull is always read-only
       - It would violate the SHA-1 collision resistance guarantee
       correct_index: 1
-      explanation: 'Git keeps the outer/inner repo boundary strict: an outer `pull` updates the pinned SHA (a fact about the outer tree) but does not reach into the inner repo and rewrite its HEAD. You must explicitly say `git submodule update`. Same conservative-HEAD-movement philosophy that makes detached-HEAD-with-uncommitted-changes impossible.'
+      explanation: 'Outer/inner boundary is strict: an outer `pull` updates the pinned SHA but doesn''t rewrite the inner repo''s HEAD. You opt in explicitly with `git submodule update`.'
     - question: '**[Revisit Step 2]** The outer repo''s diff for a submodule change is always just one line: `-Subproject commit <old>` / `+Subproject commit <new>`. Why is that enough?'
       options:
       - Git is being lazy
@@ -3283,7 +2621,7 @@ steps:
       - Because Git compresses submodule diffs
       - Because submodules don't actually change content
       correct_index: 1
-      explanation: Step 2's object-model insight applied again. A commit SHA resolves to a deterministic snapshot. Pinning a new SHA is, by construction, equivalent to changing the entire content — no further diff data is needed in the outer commit. Minimum information, maximum fidelity.
+      explanation: A commit SHA resolves to a deterministic snapshot. Pinning a new SHA is, by construction, equivalent to changing all the content — no extra diff data needed.
     - question: '**[Evaluate]** A teammate says: ''After every `git pull` I always run `git submodule update --init --recursive`, even on repos without submodules. Paranoia, or sensible?'''
       options:
       - Waste of time — it does nothing on repos without submodules
@@ -3291,59 +2629,47 @@ steps:
       - Harmful — it can corrupt non-submodule repos
       - Only useful on teams larger than 10 people
       correct_index: 1
-      explanation: 'The command is safe on any repo. Running it unconditionally is a cheap habit that prevents the most common submodule bug (stale working dir). Equivalent hardening: `git config --global submodule.recurse true` to make pull/checkout do it automatically.'
+      explanation: 'Safe on any repo, no-op where there are no submodules. Cheap habit, prevents the classic stale-working-dir bug. Equivalent: `git config --global submodule.recurse true`.'
 - title: 'Submodule Internals: What ''Content Changed'' Means'
   view: editor
   instructions: |
-    ### The confusing situation
+    ### The confusion
 
-    You `cd` into `vendor/math-utils`, fix a bug, run `git status`
-    back in the outer repo, and see:
+    You `cd` into `vendor/math-utils`, edit a file, come back, and
+    `git status` says:
 
     ```
     modified:   vendor/math-utils (modified content)
     ```
 
-    Or sometimes:
+    or
 
     ```
     modified:   vendor/math-utils (new commits)
     ```
 
-    What do those two messages actually mean? And why does `git diff`
-    on a submodule print lines like `Subproject commit abc123...`
-    instead of a real diff?
+    What do these mean, and why does `git diff` on a submodule only
+    print `Subproject commit abc123...`?
 
-    This step pulls the submodule concept apart one more time so you
-    can **reason from first principles** whenever you see that status
-    line.
+    ### The model
 
-    ### The mental model
+    The outer repo stores one thing per submodule (plus `.gitmodules`):
+    the pinned commit SHA.
 
-    The outer repo stores **exactly one thing** about each submodule
-    (in addition to the `.gitmodules` entry): the **pinned commit SHA**.
-
-    Every time you run `git status` in the outer repo, Git compares
-    two SHAs:
+    `git status` in the outer repo compares two SHAs:
 
     ```
-    SHA pinned by outer tree          vs      SHA at submodule's current HEAD
-        (the "gitlink" 160000 entry)                 (what's actually checked out)
+    SHA pinned by outer tree  vs  SHA at submodule's HEAD
     ```
 
-    - **SHAs match** → submodule is clean from the outer repo's view.
-    - **SHAs differ because submodule made commits** →
-      `modified: vendor/... (new commits)`
-    - **Submodule has uncommitted working-tree changes (dirty
-      working directory)** → `modified: vendor/... (modified content)`
-    - **Both** → both messages together.
+    - Match → clean.
+    - Submodule committed → `new commits`.
+    - Submodule working tree dirty → `modified content`.
+    - Both → both messages.
 
-    Nothing else can cause "modified" on a submodule gitlink.
+    Nothing else can mark a submodule "modified".
 
-    ### Task 1: See a clean starting state
-
-    Ensure you are on main with the submodule cloned from Step 10. If
-    you jumped straight here, the setup has already wired everything up.
+    ### Task 1: Clean state
 
     ```bash
     cd /tutorial/myproject
@@ -3351,15 +2677,12 @@ steps:
     git submodule status
     ```
 
-    `git submodule status` shows, for each submodule, the pinned SHA,
-    the path, and the current checked-out branch/tag. No prefix
-    character means clean. `+` means checked-out commit differs from
-    pinned. `-` means submodule is not initialized.
+    `git submodule status` prints each submodule's pinned SHA. No
+    prefix = clean; `+` = HEAD differs from pinned; `-` = not initialized.
 
-    ### Task 2: Make an uncommitted change **inside** the submodule
+    ### Task 2: Uncommitted change inside the submodule
 
-    Open `vendor/math-utils/utils.py` in the editor (top-right). Add
-    this function at the bottom:
+    Open `vendor/math-utils/utils.py` in the editor. Append:
 
     ```python
 
@@ -3367,90 +2690,67 @@ steps:
         return x / 2
     ```
 
-    Save. Check the outer repo:
+    Save. Outer repo:
 
     ```bash
     cd /tutorial/myproject
     git status
     ```
 
-    You now see:
-
     ```
     modified:   vendor/math-utils (modified content)
     ```
 
-    This **does not mean** Git tracks that new line. It means:
-    the submodule's working directory is dirty. The outer repo only
-    knows "the submodule directory doesn't match its own HEAD". It
-    does not store or commit the inner changes.
-
-    Also try:
+    This doesn't mean the outer repo tracks the new line — it only
+    knows the submodule's working tree doesn't match its HEAD.
 
     ```bash
     git diff vendor/math-utils
     ```
 
-    You will see **no diff** (or a short submodule summary, depending
-    on Git version). The outer repo cannot show a real line-level diff
-    for a submodule — it only knows about the pinned SHA.
+    No diff (or a short summary). The outer repo can't show line-level
+    diffs for submodules.
 
-    To see the actual content diff, cd into the submodule:
+    For the real diff:
 
     ```bash
     cd vendor/math-utils
     git diff
     ```
 
-    That is a normal `git diff` in the submodule's own repo.
-
-    ### Task 3: Commit the change **inside** the submodule
-
-    In the submodule, stage and commit:
+    ### Task 3: Commit inside the submodule
 
     ```bash
-    # still inside vendor/math-utils
+    # inside vendor/math-utils
     git add utils.py
     git commit -m "Add halve helper"
     ```
 
-    ### Task 3b: Try to share it — and watch it fail
-
-    You made and committed a change inside the submodule. Seems
-    complete? **Try to push it**:
+    ### Task 3b: Try to push — watch it fail
 
     ```bash
     # still inside vendor/math-utils
     git push
     ```
 
-    **Predict the error before you run.** What will Git complain about?
+    **Predict the error before running.**
 
-    You will likely see either:
+    You'll see one of:
 
     - `fatal: The current branch ... has no upstream branch`, or
-    - `fatal: You are not currently on a branch` (if the submodule is
-      in detached HEAD — the default after `git submodule update`).
+    - `fatal: You are not currently on a branch` (detached HEAD — the default after `git submodule update`).
 
-    **This is the most common submodule footgun in the wild.** You
-    made the inner commit, you believe you published it — but the
-    submodule was in detached HEAD (Step 1!) so the commit has no
-    branch and cannot be pushed, OR the branch has no upstream.
+    Classic footgun: you committed, you think you're done, but
+    detached HEAD means there's no branch to push.
 
-    The fix: check out a proper branch inside the submodule before
-    committing:
+    Fix — check out a branch first:
 
     ```bash
     # inside vendor/math-utils
     git switch -c update-halve 2>/dev/null || git switch update-halve
-    git log --oneline -2     # your commit is on this branch now
-    # Push would work now:
-    # git push -u origin update-halve
+    git log --oneline -2
+    # git push -u origin update-halve   (works in a real setup)
     ```
-
-    (We can't actually push to the bare repo in this tutorial without
-    extra setup, but you now see why the push failed and how to
-    recover. This is a *core* submodule skill.)
 
     Back in the outer repo:
 
@@ -3459,25 +2759,16 @@ steps:
     git status
     ```
 
-    The outer-repo message changes to:
+    The message flips:
 
     ```
     modified:   vendor/math-utils (new commits)
     ```
 
-    **"Modified content" became "new commits"** — because the
-    submodule's working tree is now clean (you committed), but its
-    HEAD moved to a new SHA that does not match the outer repo's
-    pinned SHA.
+    The submodule's working tree is clean now, but its HEAD is a new
+    SHA that doesn't match the outer pin.
 
-    At this point the outer repo has **not yet recorded the new
-    submodule SHA**. Your main branch is still pinning the *old*
-    commit.
-
-    ### Task 4: Bump the pinned SHA in the outer repo
-
-    To "publish" the new submodule commit to teammates, commit the
-    gitlink update in the outer repo:
+    ### Task 4: Bump the pinned SHA
 
     ```bash
     git add vendor/math-utils
@@ -3485,149 +2776,98 @@ steps:
     git status
     ```
 
-    `git status` reports clean. `git log -1 -p vendor/math-utils`
-    shows the single line that changed — the gitlink SHA.
+    `git log -1 -p vendor/math-utils` shows one line — the gitlink SHA.
 
-    ### Stop and self-explain
+    ### Self-explain
 
-    Before reading on, **explain aloud** why this specific sequence
-    of events is required to share a submodule change with teammates:
+    Why does sharing a submodule change need this exact sequence?
 
     1. Check out a branch inside the submodule.
     2. Commit inside the submodule.
-    3. Push the submodule branch to its remote.
-    4. `git add <submodule-path>` in the outer repo.
+    3. Push the submodule branch.
+    4. `git add <path>` in the outer repo.
     5. Commit in the outer repo.
     6. Push the outer repo.
 
-    Which steps, if skipped, lead to what failure mode?
+    Which step, if skipped, fails how?
 
     …
 
-    > Expected answer outline:
-    > - Skip (1) → detached HEAD, cannot push (this task's failure!).
+    > - Skip (1) → detached HEAD, can't push.
     > - Skip (2) → nothing to share.
-    > - Skip (3) → teammate's `submodule update` can fetch nothing
-    >   because the SHA is not on the remote.
-    > - Skip (4)/(5) → outer repo still pins the old SHA; teammate
-    >   pulls no change.
-    > - Skip (6) → the bump never reaches teammates.
-    >
-    > Every one of these is a real failure mode people hit on
-    > real teams. Memorizing the six-step ceremony is the cost of
-    > using submodules.
+    > - Skip (3) → teammate's `submodule update` can't fetch the SHA.
+    > - Skip (4)/(5) → outer repo still pins the old SHA.
+    > - Skip (6) → the bump never leaves your machine.
 
     ```bash
     git log -1 -p vendor/math-utils
     ```
-
-    You see something like:
 
     ```
     -Subproject commit <old-sha>
     +Subproject commit <new-sha>
     ```
 
-    That is the entire diff the outer repo stores for a submodule
-    bump: one line, the SHA. Everything else lives inside the
-    submodule's own object database.
+    One line. Everything else lives in the submodule's objects.
 
-    ### Task 5: Reset a submodule back to the pinned SHA
-
-    What if a teammate clones your repo and their submodule folder
-    somehow drifts (they experimented, forgot to commit, etc.)? The
-    outer repo's pinned SHA is the deterministic truth. Force the
-    submodule back to it:
+    ### Task 5: Reset a drifted submodule
 
     ```bash
     git submodule update --init --recursive
     ```
 
-    Or more aggressively if the submodule has local changes:
+    Add `--force` if the submodule has local changes you want to drop.
 
-    ```bash
-    git submodule update --init --recursive --force
-    ```
-
-    This resets every submodule's HEAD to exactly the SHA stored in
-    the outer tree. `git status` in the outer repo then reports
-    clean.
-
-    ### The three ways to exit a "modified" state
+    ### The three "modified" states
 
     | Message | Meaning | Fix |
     |---|---|---|
-    | `modified content` | submodule working tree is dirty | commit or discard inside the submodule |
-    | `new commits` | submodule HEAD ≠ pinned SHA | `git add <path>` + commit (to bump) OR `git submodule update` (to reset) |
-    | both | working tree dirty *and* unrecorded commits | same — resolve each layer |
-
-    Those are the only three states. Memorizing them removes 90% of
-    the submodule confusion you will see in practice.
+    | `modified content` | submodule working tree is dirty | commit or discard inside |
+    | `new commits` | submodule HEAD ≠ pinned SHA | `git add <path>` + commit, OR `git submodule update` |
+    | both | both | resolve each layer |
 
     ### You can now
 
-    - **Distinguish** `modified content` from `new commits` just from
-      `git status`, and pick the correct fix for each.
-    - **Execute** the six-step "publish a submodule change" ceremony
-      without missing the detached-HEAD-before-committing trap.
-    - **Resync** a submodule to its pinned SHA deterministically with
-      `git submodule update --init --recursive`.
-    - **Reason from first principles** whenever a submodule confuses
-      you: the outer repo tracks one SHA; the inner repo is a full
-      Git repo; the two are independent.
+    - Tell `modified content` from `new commits` and pick the right fix.
+    - Run the six-step publish without falling into detached-HEAD.
+    - Resync any submodule with `git submodule update --init --recursive`.
+    - Reason from first principles: outer stores one SHA, inner is a full repo, they're independent.
 
-    ### Normalize the struggle
+    Submodules are genuinely harder than anything else here. Senior
+    engineers mis-handle them all the time. The recipes in this step
+    cover most real-world cases — bookmark it.
 
-    Submodules genuinely are harder than anything else in this
-    tutorial. If they felt confusing, you are in good company — even
-    senior engineers mis-handle them. The recipes here (two-step
-    publish, `submodule update --init --recursive`, the three
-    status messages) cover 95% of real-world submodule work. Bookmark
-    this step.
+    ### 📇 Submodule survival card
 
-    ### 📇 Submodule survival card — copy this somewhere you'll find it
+    **Outer repo stores per submodule:** one pinned SHA (gitlink, mode
+    `160000`) + a `.gitmodules` URL. That's it.
 
-    If you take one artifact away from this tutorial, let it be this.
-    Print it, pin it, paste it into your team wiki.
+    **Three submodule status states:**
 
-    **The outer repo stores exactly one thing per submodule:** a
-    pinned commit SHA (gitlink, mode `160000`) plus a `.gitmodules`
-    entry with the URL. Everything else lives in the submodule's own
-    Git repo.
-
-    **The three `git status` states for a submodule path:**
-
-    | Message | What it means | What to do |
+    | Message | Meaning | Do |
     |---|---|---|
-    | *(nothing)* | submodule HEAD matches the pinned SHA, working tree clean | nothing — you're in sync |
-    | `modified content` | submodule working tree is dirty | `cd` in; commit or discard |
-    | `new commits` | submodule HEAD ≠ pinned SHA | `git add <path>` + commit (to bump), OR `git submodule update` (to reset) |
+    | *(nothing)* | HEAD matches pinned SHA, tree clean | nothing |
+    | `modified content` | submodule tree dirty | `cd` in; commit or discard |
+    | `new commits` | HEAD ≠ pinned SHA | `git add <path>` + commit to bump, OR `git submodule update` to reset |
 
-    **Publishing a submodule change — the six-step ceremony:**
+    **Publishing a submodule change:**
 
-    1. `cd` into the submodule; check out a **branch** (not
-       detached HEAD). Skipping this = the Task 3b push failure.
-    2. Commit inside the submodule.
-    3. `git push` the submodule branch to its remote. Skipping
-       this = teammates can't fetch the SHA you pin.
-    4. `cd` back to the outer repo; `git add <submodule-path>`.
-    5. `git commit` in the outer repo. Skipping 4-5 = outer repo
-       still pins the old SHA; teammates see no change.
-    6. `git push` the outer repo. Skipping this = the bump never
-       leaves your machine.
+    1. Inside: check out a branch (not detached HEAD).
+    2. Commit inside.
+    3. Push the submodule branch.
+    4. Outside: `git add <path>`.
+    5. Commit outside.
+    6. Push the outer repo.
 
-    **The one command that fixes 95% of "my submodule is weird"
-    moments:**
+    **The one command:**
 
     ```bash
     git submodule update --init --recursive
     ```
 
-    This force-resyncs every submodule's HEAD to the outer repo's
-    pinned SHA. Safe to run unconditionally after any `git pull`.
-    Add `--force` if a submodule has local changes you want to
-    discard. Set `git config --global submodule.recurse true` to
-    make `git pull` and `git checkout` do this automatically.
+    Safe to run after any `git pull`. Add `--force` to discard local
+    submodule changes. `git config --global submodule.recurse true`
+    makes `pull`/`checkout` do this automatically.
   watch_files:
   - myproject/vendor/math-utils/utils.py
   open_file: myproject/vendor/math-utils/utils.py
@@ -3640,31 +2880,33 @@ steps:
     - 'cd /tutorial/myproject && git add vendor/math-utils && git commit -m ''Bump math-utils: add halve helper'''
     - cd /tutorial/myproject && git submodule update --init --recursive
     explanation: |
-      - **`modified: <path> (modified content)`:** the submodule's working directory is dirty — untracked or unstaged changes inside the submodule. The outer repo cannot show the diff; you must `cd` into the submodule to see it with plain `git diff`.
-      - **`modified: <path> (new commits)`:** the submodule's HEAD has moved to a new commit, but the outer repo still points at the old pinned SHA. Resolve by either `git add <path>` + commit (to bump) or `git submodule update` (to reset the submodule back to the pinned SHA).
-      - **The outer diff for a submodule is always just one line:** `-Subproject commit <old>` / `+Subproject commit <new>`. That is the only thing the outer repo records about a submodule change — two 40-char SHAs.
-      - **`git submodule update --init --recursive`:** deterministic reset. Every submodule is forced back to the SHA the outer tree pins. Run after every `git pull` that touches submodule-tracked paths.
+      - `modified content`: submodule's working tree is dirty. The outer repo can't show the diff — `cd` in and run `git diff`.
+      - `new commits`: submodule HEAD ≠ pinned SHA. Fix with `git add <path>` + commit (to bump) or `git submodule update` (to reset).
+      - The outer diff for a submodule is one line: `-Subproject commit <old>` / `+Subproject commit <new>`.
+      - `git submodule update --init --recursive` forces every submodule back to its pinned SHA. Run after any pull that touches submodule paths.
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
     hints:
-    - text: Finish this step in the outer repo on `main`. If you cd'd into `vendor/math-utils` for Tasks 2–3 and never returned, `cd /tutorial/myproject` and `git switch main`.
+    - text: "You're probably still inside the submodule. `cd /tutorial/myproject && git switch main`."
   - description: Submodule contains a halve helper
     command: cd /tutorial/myproject && grep -q 'def halve' vendor/math-utils/utils.py
     hints:
-    - text: '`def halve` isn''t in the submodule''s `utils.py`. Open `vendor/math-utils/utils.py` in the editor (the file tree lists it) and append the two-line `def halve(x): return x / 2` function — then save. Edits go in the submodule''s *file*, not in any other file.'
+    - text: "Edit `vendor/math-utils/utils.py` — append `def halve(x): return x / 2` and save. The edit goes in the submodule's file, not anywhere else."
+      condition: 'code_missing: def halve'
   - description: Submodule's inner commit for halve exists
     command: cd /tutorial/myproject/vendor/math-utils && git log --oneline | grep -qi 'halve'
     hints:
-    - text: 'You edited the submodule file but never committed it *inside* the submodule. A submodule is a nested Git repo — it has its own staging area and history. `cd vendor/math-utils && git add utils.py && git commit -m "Add halve helper"`. Only then will the inner repo record the change.'
+    - text: "You edited the file but never committed *inside* the submodule. A submodule has its own history: `cd vendor/math-utils && git add utils.py && git commit -m \"Add halve helper\"`."
+      condition: 'code_contains: def halve'
   - description: Outer repo has a commit that bumps the submodule SHA
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'bump|halve'
     hints:
-    - text: 'The inner commit exists, but the outer repo still pins the **old** SHA. Go back to the outer repo (`cd /tutorial/myproject`) and run `git add vendor/math-utils && git commit -m "Bump math-utils: add halve helper"`. This outer commit is how teammates see the new version.'
+    - text: "The outer repo still pins the old SHA. `cd /tutorial/myproject && git add vendor/math-utils && git commit -m 'Bump math-utils: add halve helper'`."
   - description: Outer repo is clean (no pending submodule modifications)
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
     hints:
-    - text: '`git status` in the outer repo will name the dirty path. The most common end-state here is "modified: vendor/math-utils (new commits)" — meaning the inner commit exists but the outer SHA bump commit is missing. Complete the two-step publish: inner commit first, then outer `git add` + commit.'
+    - text: 'Usually it''s `modified: vendor/math-utils (new commits)` — the inner commit landed but the outer bump commit is missing. Finish it.'
   quiz:
     title: Submodule Internals — Knowledge Check
     min_score: 0.8
@@ -3677,7 +2919,7 @@ steps:
       - The `.gitmodules` file was edited
       - The submodule's remote has new commits
       correct_index: 1
-      explanation: '`modified content` specifically means: the submodule working tree is dirty — files inside are unstaged or untracked. The HEAD may still match the pinned SHA. Running `git status` *inside* the submodule will show the dirty files.'
+      explanation: '`modified content` = submodule working tree is dirty. HEAD may still match the pinned SHA. `cd` in and run `git status` to see what changed.'
     - question: 'You see `modified: vendor/math-utils (new commits)` in the outer `git status`. What caused it?'
       options:
       - A file inside the submodule was edited but not committed
@@ -3685,7 +2927,7 @@ steps:
       - The outer repo's branch pointer moved
       - The submodule is corrupted
       correct_index: 1
-      explanation: '`new commits` means: inside the submodule, HEAD advanced (someone committed, or checked out a different SHA). The outer repo still records the OLD pinned SHA, so it flags the divergence. Fix: `git add <path>` + commit to bump the pinned SHA, or `git submodule update` to reset the submodule back to the pinned SHA.'
+      explanation: 'Submodule HEAD moved off the pinned SHA. `git add <path>` + commit to bump the pin, or `git submodule update` to snap back.'
     - question: You run `git diff vendor/math-utils` in the outer repo after making and committing a change in the submodule. What do you see?
       options:
       - A full line-by-line diff of what changed inside the submodule
@@ -3693,7 +2935,7 @@ steps:
       - An error message
       - The diff of `.gitmodules`
       correct_index: 1
-      explanation: The outer repo's diff for a submodule path is always the gitlink SHA change — one line. To see content-level diffs, `cd` into the submodule and run plain `git diff` there. Two repos, two diff domains.
+      explanation: 'The outer repo only records the gitlink SHA change — one line. For content-level diffs, `cd` into the submodule and run `git diff` there.'
     - question: Which commands reset a submodule's working directory and HEAD to exactly the SHA the outer repo pins?
       options:
       - '`git submodule update --init --recursive` (and `--force` if local changes)'
@@ -3701,7 +2943,7 @@ steps:
       - '`git reset --hard` in the outer repo'
       - '`rm -rf vendor/math-utils && git clone`'
       correct_index: 0
-      explanation: '`git submodule update --init --recursive` is the deterministic reset. It clones missing submodules and checks out each one at the outer tree''s pinned SHA. `git reset --hard` in the outer repo does NOT affect submodule working directories — Git treats them as separate repos.'
+      explanation: '`update --init --recursive` clones anything missing and checks every submodule out at its pinned SHA. `git reset --hard` in the outer repo ignores submodule working trees — they''re separate repos.'
     - question: '**[Revisit Step 2]** Why is it consistent that the outer repo records ONLY a pinned SHA for each submodule — not the submodule''s files?'
       options:
       - Because file content inside a submodule is always confidential
@@ -3709,7 +2951,7 @@ steps:
       - Because submodules are always read-only
       - Because Git uses a separate database for submodules
       correct_index: 1
-      explanation: Same object-model insight as Step 2. A commit SHA points at a tree that points at blobs — one SHA resolves to a deterministic snapshot. Storing the SHA is equivalent to storing the files. No duplication is needed.
+      explanation: 'A commit SHA → tree → blobs resolves to exactly one snapshot, so pinning the SHA is equivalent to storing the files. Anything else would duplicate content.'
     - question: '**[Evaluate]** You edited `vendor/math-utils/utils.py` and saved. Your teammate pulls your branch and sees a clean `git status`. Why didn''t your edit get to them?'
       options:
       - Git hid the change because it was inside a submodule
@@ -3717,7 +2959,7 @@ steps:
       - Your teammate's Git is out of date
       - Submodules never sync changes between collaborators
       correct_index: 1
-      explanation: 'An edit to a submodule file affects only your working tree until you perform the two-step commit: (1) commit inside the submodule and push its new commit to the submodule''s remote, (2) `git add <path>` + commit in the outer repo to bump the pinned SHA. Skip either step and the change never reaches teammates.'
+      explanation: 'Shared history only carries the change if you (1) commit + push inside the submodule, AND (2) `git add <path>` + commit the SHA bump in the outer repo. Skip either step and teammates see nothing.'
     - question: '**[Revisit Step 1]** You edit a file inside a submodule, run `git add && git commit` inside the submodule, then `git push`. Git errors with something like `fatal: You are not currently on a branch`. What Step-1 concept explains this?'
       options:
       - Detached HEAD — `git submodule update` normally checks out submodules in detached HEAD at the pinned SHA. Commits there are orphaned relative to any branch; push needs a branch
@@ -3725,7 +2967,7 @@ steps:
       - Missing upstream
       - Submodules are read-only by default
       correct_index: 0
-      explanation: 'After `git submodule update`, submodules are in detached HEAD at the pinned SHA (because that''s what the outer tree specified — no branch context). Any commit you make there is anchored to nothing. Fix: `git switch -c <branch>` inside the submodule **before** committing. Same detached-HEAD pattern as Step 1, encountered in a submodule setting.'
+      explanation: '`git submodule update` leaves the submodule in detached HEAD at the pinned SHA. Commits there are orphaned. `git switch -c <branch>` inside the submodule *before* committing.'
     - question: '**[Revisit Step 7]** You ran `git rebase main` inside a submodule and rewrote three of its commits. The outer repo''s `git status` says `modified: vendor/math-utils (new commits)`. Is anything wrong with this?'
       options:
       - No issue — rebase inside a submodule is business as usual
@@ -3733,62 +2975,48 @@ steps:
       - Git prevents rebase inside submodules
       - Rebase deletes the submodule
       correct_index: 1
-      explanation: 'A submodule is a real Git repo — rebase works there exactly as in Step 7/8. The complication is that the outer repo may still pin the pre-rebase SHAs; if those weren''t pushed, teammates checking out old outer-repo commits will fail to fetch them (`fatal: reference is not a tree`). Same cardinal rule: rebase only unpushed/local history.'
+      explanation: 'A submodule is a real repo — rebase works there. But the outer repo may still pin the pre-rebase SHAs; if those are gone, teammates on old outer commits fail to fetch (`fatal: reference is not a tree`). Same rule as Step 7: rebase only unpublished history.'
 - title: 'Capstone: On-Call Debugging Under Pressure'
   view: git_graph
   instructions: |
-    ### The scenario — no hand-holding this time
+    ### The scenario
 
-    You're the on-call engineer. A teammate paged you: **the
-    `absolute` function in `calculator.py` is producing wrong answers
-    on `main`**, CI is red, and they don't know which of the last
-    handful of commits caused it. They've also left you a dirty
+    You're on call. A teammate paged you: `absolute()` in
+    `calculator.py` is wrong on `main`, CI is red, and nobody knows
+    which of the recent commits broke it. They also left a dirty
     working tree with an unrelated in-progress note.
 
     **Your job**, in order:
 
-    1. **Shelve** the unrelated in-progress note so your tree is
-       clean for investigation.
-    2. **Find** the exact commit that introduced the bug, using a
-       binary search across the recent history.
-    3. **Read** the culprit commit's message and diff so you
-       understand *what the author was trying to do* before you
-       touch their code.
-    4. **Fix** the bug on a dedicated branch. It's fine (expected,
-       even) to make a couple of messy WIP commits as you iterate.
-    5. **Clean up** your fix branch so it lands on `main` as one
-       focused commit — no WIP noise.
-    6. **Merge** the fix into `main`.
-    7. **Restore** the in-progress note you shelved in step 1.
-    8. **Verify** you could still recover any of the commits you
-       rewrote — the safety net has to actually work.
+    1. **Shelve** the unrelated note so your tree is clean.
+    2. **Find** the culprit commit via binary search.
+    3. **Read** the commit's message and diff — understand the
+       author's intent before touching their code.
+    4. **Fix** on a dedicated branch. Messy WIP commits are fine.
+    5. **Clean up** the branch so it lands on `main` as one commit.
+    6. **Merge** into `main`.
+    7. **Restore** the shelved note.
+    8. **Verify** the reflog still has your pre-cleanup commits.
 
-    You already know every command you need. No new material. This
-    step exists to prove you can **choose** and **compose** the
-    right tools under pressure, not just execute them when told.
+    No new commands. The point is to **choose** and **compose** the
+    right tool under pressure.
 
-    > **Style expectation.** Real on-call work is not a list of
-    > commands with commentary — it is a loop of *read state →
-    > decide → act → re-read state*. Run `git status`, `git log
-    > --oneline --graph --all`, and `git reflog` *between* your
-    > actions. They are your dashboard. If you feel lost, your first
-    > move is always to re-read the state, not to guess.
+    > Work the loop: *read state → decide → act → re-read state*.
+    > `git status`, `git log --oneline --graph --all`, and
+    > `git reflog` are your dashboard. Lost? Re-read state first.
 
     ### The state you're walking into
 
-    The setup has prepared `/tutorial/myproject` with:
+    `/tutorial/myproject` has:
 
-    - A `test_calculator.py` whose `absolute(-4) == 4` assertion
-      currently **fails**.
-    - `~6` recent commits on `main` — somewhere among them the
-      regression lives.
-    - A dirty working tree: an unrelated `# TODO: add clamp helper`
-      note has been appended to `calculator.py` and is **not yet
-      committed**. That note is unrelated to the bug — it must
-      survive this session intact.
+    - `test_calculator.py` with a failing `absolute(-4) == 4`
+      assertion.
+    - `~6` recent commits on `main` — the regression is in one.
+    - A dirty working tree: a `# TODO: add clamp helper` note in
+      `calculator.py`, uncommitted. Unrelated to the bug; must
+      survive intact.
 
-    Start by reading state. These commands are your eyes; run them
-    whenever you want:
+    Start by reading state:
 
     ```bash
     cd /tutorial/myproject
@@ -3797,104 +3025,75 @@ steps:
     python3 test_calculator.py
     ```
 
-    ### Hints — expand only after you've tried
+    ### Hints — open only after you've tried
 
-    Each hint corresponds to one task above. Try the task first; open
-    the hint only if you get stuck for more than a minute. Generation
-    effect is real — a minute of struggling primes the learning.
+    One hint per task. Try for a minute before opening.
 
     <details><summary>Hint — Task 1 (shelve uncommitted work)</summary>
 
-    Step 3. One command, noun form. The working tree must be
-    **clean** for bisect to move HEAD around safely.
+    Step 3. One command, noun form. Bisect needs a clean tree.
     </details>
 
     <details><summary>Hint — Task 2 (find the culprit)</summary>
 
-    Step 6. You want the automated version so you don't mark
-    good/bad by hand. The test script exits 0 on pass, non-zero on
-    fail — feed it to the right subcommand. Don't forget to
-    **reset** afterward or HEAD stays on a random historical
-    commit.
+    Step 6. Use the automated variant — the test script exits 0 on
+    pass, non-zero on fail. Reset when done or HEAD stays on a
+    historical commit.
     </details>
 
     <details><summary>Hint — Task 3 (read the culprit's intent)</summary>
 
-    Step 5 gave you a two-command chain. `git blame` alone is noise;
-    pair it with `git show <sha>` to read the commit message and
-    full diff. Target the line of `absolute` that looks wrong.
+    Step 5. `git blame` → `git show <sha>` for the message and diff.
+    Focus on the line of `absolute` that looks wrong.
     </details>
 
     <details><summary>Hint — Task 4 (fix on a branch, messily)</summary>
 
-    Step 8 showed you that messy intermediate commits are fine as
-    long as you clean them before sharing. Branch from `main`, make
-    at least two commits (any real workflow would), and get
-    `test_calculator.py` passing.
+    Step 8. Branch from `main`, make at least two commits, get the
+    tests passing.
     </details>
 
     <details><summary>Hint — Task 5 (squash messy commits into one)</summary>
 
-    Step 8's interactive rebase is exactly this. Or — if your two
-    commits are both small and you don't mind losing the individual
-    messages — Step 9's `git merge --squash` does the same job at
-    merge time. **Either is acceptable**; the test only cares that
-    `main` ends with exactly one new commit containing your fix.
+    Step 8's interactive rebase, or Step 9's `git merge --squash`.
+    Either works — the test only cares that `main` ends with exactly
+    one new commit.
     </details>
 
     <details><summary>Hint — Task 6 (merge to main)</summary>
 
-    Step 9 or the basic tutorial's Step 9. Whichever merge strategy
-    you pick, main should end up with your one clean fix commit on
-    top.
+    Step 9. One clean fix commit ends up on top of `main`.
     </details>
 
     <details><summary>Hint — Task 7 (restore the shelved note)</summary>
 
-    Step 3. Inverse of Task 1. The note must reappear in
-    `calculator.py` exactly as it was, still uncommitted.
+    Step 3. Inverse of Task 1. Note reappears, still uncommitted.
     </details>
 
     <details><summary>Hint — Task 8 (prove reflog still has your back)</summary>
 
-    Step 1. `git reflog` should still show the messy pre-squash
-    commits. This is a *read-only* verification — don't branch or
-    reset anything, just confirm the history of HEAD's movements is
-    intact and would let you recover your intermediate work if you
-    needed to. If you see at least two reflog entries from your fix
-    branch, you're safe.
+    Step 1. `git reflog` should still list the pre-squash commits.
+    Read-only — don't branch or reset. Two+ entries from your fix
+    branch = safe.
     </details>
 
     ### Success criteria
 
-    When you think you're done, check each of these yourself — the
-    automated tests check the same things:
-
     - `python3 test_calculator.py` prints `all tests pass`.
-    - `main`'s log ends with exactly **one** new fix commit on top
-      of the pre-session state — not two or three WIP commits.
-    - `calculator.py` still contains your uncommitted
+    - `main` ends with exactly **one** new fix commit, not multiple
+      WIP commits.
+    - `calculator.py` still has the uncommitted
       `# TODO: add clamp helper` note.
-    - `git reflog` shows your intermediate messy commits — proof
-      you could still recover them if asked.
+    - `git reflog` shows your intermediate messy commits.
 
     ### You can now
 
-    - **Compose** 5+ advanced Git tools into one realistic
-      end-to-end workflow, without instruction.
-    - **Choose** between squash/rebase/merge based on what the
-      resulting history should look like, not memorized rules.
-    - **Trust** the reflog safety net after combining multiple
-      destructive operations.
-    - **Read state first, act second** — the habit that
-      distinguishes professional Git usage from the "blind-testing"
-      antipattern Step 1 named.
+    - Compose 5+ advanced Git tools into one end-to-end workflow.
+    - Pick between squash/rebase/merge based on the target history.
+    - Trust the reflog after stacking destructive operations.
+    - Read state first, act second.
 
-    > **If you completed this unguided**, you have crossed the
-    > line from "knows Git commands" to "reaches for the right Git
-    > tool under pressure." That's the real outcome of the advanced
-    > tutorial. Nothing below this step is new content — only a
-    > cumulative quiz that interleaves everything you've built.
+    Nothing below this step is new material — only a cumulative quiz.
   watch_files:
   - myproject/calculator.py
   - myproject/test_calculator.py
@@ -3922,44 +3121,44 @@ steps:
     - git reflog -n 20
     - python3 test_calculator.py
     explanation: |
-      - **Tool choices (many right answers).** The solution shown uses stash → automated bisect → branch + two WIP commits → interactive-rebase fixup → regular merge → stash pop → reflog check. An equally valid path: stash → manual bisect → fix with one commit directly → squash-merge to main → stash pop → reflog check. The tests only verify the end state, not the path.
-      - **Why stash first, always.** Bisect moves HEAD across historical commits; a dirty working tree would either block bisect or carry uncommitted edits across arbitrary commits. Same principle as Step 3's "clean tree for context switch."
-      - **Why bisect.** Manually reading 5 diffs would work here but would not work at 500. The point is the habit: for regressions, bisect is the default reach, even for small histories.
-      - **Why read the culprit's intent.** Step 5's warning: the author wasn't malicious. Their commit message and diff may reveal which part of the change was intended and which was the accidental regression — informing whether you fix the bug or revert the whole commit.
-      - **Why clean the fix branch before merging.** Main's history is read during future bisects (this one's regression will be someone else's bisect in six months). Each commit on main should be one reason, not "WIP, WIP, WIP, real fix."
-      - **Why reflog at the end.** Proof that the desirable-difficulty exercise did not actually destroy anything. This is the Step 1 safety-net claim, cashed in on a composite workflow.
+      - **Many right paths.** Shown: stash → automated bisect → branch with WIP commits → interactive-rebase fixup → merge → stash pop → reflog. Equally valid: stash → manual bisect → one-shot fix → squash-merge → stash pop → reflog. Tests check the end state, not the path.
+      - **Stash first.** Bisect moves HEAD across arbitrary historical commits; a dirty tree either blocks it or contaminates those commits.
+      - **Bisect, not eyeballing.** Reading 5 diffs works; reading 500 doesn't. Build the habit at small scale.
+      - **Read the culprit first.** The commit message may reveal what was intentional — informing whether you patch the bug or revert the whole commit.
+      - **Clean before merging.** Today's WIP commits are tomorrow's bisect noise. One commit per reason on `main`.
+      - **Reflog at the end.** Proof that the destructive operations didn't actually destroy anything. Step 1's safety-net claim, cashed in.
   tests:
   - description: 'On main branch (cleanup verified)'
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
     hints:
-    - text: Capstone should end on `main`. If you're still on your fix branch or in detached HEAD, `git switch main`. Running `git status` first is the professional habit — "read state, then act."
+    - text: 'End on `main`. `git switch main` if you''re on a fix branch or detached.'
   - description: 'No bisect or rebase still in progress'
     command: cd /tutorial/myproject && [ ! -f .git/BISECT_LOG ] && [ ! -d .git/rebase-merge ] && [ ! -d .git/rebase-apply ]
     hints:
-    - text: '`git status` will name the in-flight operation. The cleanup command depends on what it is — `git bisect reset` for bisect (Step 6), `git rebase --continue` or `--abort` for rebase (Step 7/8), `git merge --abort` for a paused merge. Always close out every mid-flight state before moving on.'
+    - text: '`git status` names the paused operation. Reset it: `git bisect reset`, `git rebase --abort`, or `git merge --abort` as appropriate.'
   - description: 'absolute() works correctly for negatives, zero, and positives'
     command: cd /tutorial/myproject && python3 -c "import sys; sys.path.insert(0,'.'); from calculator import absolute; assert absolute(-4) == 4 and absolute(3) == 3 and absolute(0) == 0"
     hints:
-    - text: '`absolute()` is still broken on `main`. Task 2''s bisect should have pointed at the commit titled `Capstone: simplify absolute return path`. Read that commit with `git show <sha>` to see the broken body, then restore an implementation that returns `x` for non-negatives and `-x` for negatives.'
+    - text: 'Bisect should have pointed at `Capstone: simplify absolute return path`. Check the commit with `git show`, then fix `absolute` to return `x` when `x >= 0`, else `-x`.'
   - description: 'Regression test passes end-to-end'
     command: cd /tutorial/myproject && python3 test_calculator.py | grep -q 'all tests pass'
     hints:
-    - text: '`python3 test_calculator.py` from `/tutorial/myproject` should print `all tests pass`. If it raises, read the assertion line — it tells you which case of `absolute()` is still wrong, so you can fix it precisely.'
+    - text: '`python3 test_calculator.py` should print `all tests pass`. If it raises, the assertion line tells you which case of `absolute` is still broken.'
   - description: 'Exactly one fix commit landed on main (not 2+ WIP commits visible on main)'
     command: cd /tutorial/myproject && [ $(git log main --oneline | grep -ciE '^[a-f0-9]+ (WIP|wip)') -eq 0 ]
     hints:
-    - text: '`main` has leftover "WIP" commits. Task 5 of the capstone wants your messy intermediate commits collapsed into **one** clean commit before landing. Two valid routes: (a) `git rebase -i HEAD~N` on the fix branch and `squash`/`fixup` the WIPs (Step 8), or (b) `git merge --squash <fix-branch>` followed by one `git commit` (Step 9). Either lands exactly one new commit on main.'
+    - text: "Messy WIP commits landed on `main`. Collapse them into one: either `rebase -i` + `squash` (Step 8) or `git merge --squash` + commit (Step 9). Either way, one clean commit."
   - description: 'The in-progress clamp note survived the session (still in working tree, uncommitted)'
     command: "cd /tutorial/myproject && grep -q 'TODO: add clamp helper' calculator.py && ! git log main --oneline | grep -qi 'clamp'"
     hints:
-    - text: 'The `# TODO: add clamp helper` note is missing from `calculator.py`. Task 1 had you shelve it with `git stash` so bisect had a clean tree — Task 7 is where you restore it. Check `git stash list`; if the entry is still there, `git stash pop` brings the note back into the working tree.'
-      condition: 'code_missing: TODO: add clamp helper'
-    - text: The note survived but it has been committed to main (it shouldn't be). The capstone wants the note to remain **uncommitted** in the working tree, exactly as you found it. Unstage/uncommit it with `git reset HEAD~1` (if it's the tip commit) and leave the edit dirty in the working tree.
-      condition: 'code_contains: TODO: add clamp helper'
+    - text: "The TODO note is missing from `calculator.py`. You stashed it for the bisect — `git stash pop` restores it. Leave it uncommitted."
+      condition: 'source_missing: TODO: add clamp'
+    - text: "The note got committed to `main`. The capstone wants it to stay uncommitted. `git reset HEAD~1` if it's the tip, and leave the edit dirty."
+      condition: 'source_contains: TODO: add clamp'
   - description: 'Reflog has at least a few entries from this session (safety net intact)'
     command: cd /tutorial/myproject && [ $(git reflog -n 20 | wc -l) -ge 5 ]
     hints:
-    - text: '`git reflog` should show HEAD movements from your stash, bisect, branch-switches, and commits. If it is empty or near-empty, something has been cleared — but normally this test passes automatically once you''ve done any work.'
+    - text: '`git reflog` should have plenty of entries by now. If it''s empty, something cleared it — but this test usually passes on its own.'
   quiz:
     title: Cumulative Final Quiz — Choose the Right Tool
     min_score: 0.8
@@ -3972,7 +3171,7 @@ steps:
       - '(a) All four → `git merge`'
       - '(a) Backport → `git rebase`; (b) Feature integration → `git cherry-pick`; (c) WIP cleanup → `git merge`; (d) One-commit landing → `git rebase`'
       correct_index: 1
-      explanation: Cherry-pick is surgical (one commit), merge is bulk (many commits), interactive rebase is for history cleanup, squash-merge collapses a branch into one commit. Steps 4, 7, 8, 9 each framed this table; this question just asks you to recognize when to use which. The others mis-apply cherry-pick (wrong for 50 commits) or merge (doesn't clean WIP).
+      explanation: 'Cherry-pick = one commit surgically. Merge = many commits in bulk. Interactive rebase = history cleanup. Squash-merge = branch → one commit. The distractors misuse cherry-pick for 50 commits (tedious + conflicts) and merge for WIP cleanup (merge doesn''t rewrite).'
     - question: '**[Interleaves Steps 2, 4, 7, 8, 9]** Which of these operations create commits with **new SHAs** even when the patch is identical to an earlier commit? Select all that apply.'
       type: multiple
       options:
@@ -3987,7 +3186,7 @@ steps:
       - 1
       - 2
       - 3
-      explanation: 'A commit''s SHA hashes its tree + parent(s) + author + committer + message. **Change any of those and the SHA changes.** Cherry-pick, rebase, interactive-rebase, and squash-merge all create new commit objects with different parents or combined trees. Fast-forward merge and `git branch` do NOT create commits — they only move pointers (Step 1''s whole point). This is the deep schema: commits are immutable; "moving" a commit is always "copy + move pointer to copy."'
+      explanation: 'A commit''s SHA hashes tree + parents + author + committer + message. Change any field, new SHA. Cherry-pick, rebase, interactive rebase, and squash-merge all create new commit objects (new parents or combined trees). Fast-forward merge and `git branch` only move pointers. Commits are immutable — "moving" one is always copy + move-pointer-to-copy.'
     - question: '**[Interleaves Steps 1, 7, 8]** You performed three destructive-feeling operations in sequence: `git reset --hard HEAD~3`, then `git rebase -i` dropping a commit, then entering detached HEAD and making a throwaway commit. Which **single** tool can recover commits lost in all three cases?'
       options:
       - '`git revert` — it reverses any recent operation'
@@ -3995,7 +3194,7 @@ steps:
       - '`git stash pop` — stash tracks destructive operations automatically'
       - 'Nothing — destructive operations are final'
       correct_index: 1
-      explanation: Reflog is the universal safety net because it records HEAD's position history, not the cause. Whether HEAD moved via reset, rebase drop, or leaving detached HEAD, the SHA it was at is recorded. Branch that SHA back into reachability and the "lost" work is found. This is the Step 1 lesson cashed in on a composite workflow — and the reason the tutorial framed destructive commands as "less scary than they sound."
+      explanation: 'Reflog records every HEAD position, not the cause. Reset, rebase-drop, detached-HEAD orphan — all recoverable the same way: find the SHA in the reflog, branch it back into reachability. Step 1''s safety net, used in composite.'
     - question: '**[Interleaves basic tutorial Step 11 + advanced Step 7]** You hit a conflict during `git rebase main`. You edit the file, remove all `<<<<<<<` / `=======` / `>>>>>>>` markers, and run `git add`. Which command finishes **this one commit''s** resolution?'
       options:
       - '`git commit` — identical to finishing a merge'
@@ -4003,7 +3202,7 @@ steps:
       - '`git merge --continue`'
       - '`git push --force`'
       correct_index: 1
-      explanation: A rebase conflict is identical in mechanics to a merge conflict — same markers, same `git add` to mark resolved — but the final verb differs because rebase is *replaying*, not *merging*. Reflex-typing `git commit` here is the single most common mistake; it leaves the rebase half-done. `git rebase --abort` at any point restores the pre-rebase state.
+      explanation: 'Same markers and `git add` as a merge conflict, but the final verb differs because rebase is *replaying*, not merging. Reflex-typing `git commit` is the classic mistake — it leaves the rebase half-done. `--abort` bails at any point.'
     - question: '**[Interleaves Steps 5, 6]** A bug appeared because someone **removed** a line of validation that used to prevent it. Which investigation tool finds the commit that introduced the bug?'
       options:
       - '`git blame` — it shows the author of every existing line'
@@ -4011,7 +3210,7 @@ steps:
       - '`git log --grep="delete"` — it finds commits with "delete" in the message'
       - '`git show HEAD` — it shows the most recent commit'
       correct_index: 1
-      explanation: Blame attributes *existing* lines only — a missing line is invisible to it. Bisect operates on behavioral outcomes (did the test pass or fail?) regardless of whether the change was an addition, modification, or deletion. This is why the capstone you just finished started with bisect, not blame — the bug could just as easily have been a deletion, and starting with bisect generalizes.
+      explanation: 'Blame only sees lines that still exist — deletions are invisible to it. Bisect operates on behavior (test pass/fail), so it finds deletions, additions, and modifications alike. That''s why the capstone reached for bisect first.'
     - question: '**[Interleaves Steps 2, 10, 12]** A submodule is stored in the outer repo as a gitlink entry (mode `160000`) containing a 40-character SHA. That SHA references which kind of Git object?'
       options:
       - A blob object containing the submodule's files
@@ -4019,7 +3218,7 @@ steps:
       - A commit object in the submodule's own object database
       - A tag object
       correct_index: 2
-      explanation: 'The gitlink pins a *commit* SHA (in the submodule''s repo). That commit deterministically resolves to a tree, which resolves to blobs — so one SHA is equivalent to a full content snapshot. Same object-model reasoning as Step 2 — snapshot-identity is carried by the commit SHA, which is why "one 40-char pin" is enough information to reconstruct the entire submodule''s state.'
+      explanation: 'The gitlink pins a commit SHA in the submodule''s repo. That commit → tree → blobs, so one 40-char pin reconstructs the full snapshot. Same object-model insight as Step 2.'
     - question: '**[Interleaves Steps 7, 8, 9]** Which of these operations are **forbidden** on a branch that has been pushed and is shared with teammates? Select all that apply.'
       type: multiple
       options:
@@ -4034,7 +3233,7 @@ steps:
       - 1
       - 2
       - 3
-      explanation: 'The cardinal rule — anything that **rewrites** published commits is forbidden on shared branches, because teammates holding the old SHAs will diverge. That rules out rebase (any flavor), amend, and force-push. Revert and merge are *additive* (they only append new commits without changing existing history), so they are safe. Same rule, different commands. Memorize the property (rewrite = dangerous), not the per-command list.'
+      explanation: 'Cardinal rule: anything that **rewrites** published commits is forbidden on shared branches — teammates with the old SHAs diverge. Rebase (any flavor), amend, and force-push all rewrite. Revert and merge only *append* — safe. Memorize the property (rewrite = dangerous), not a list of commands.'
     - question: '**[Interleaves Steps 1, 7]** You rebased `feature` locally, then `git push` was rejected because teammate Alice had pushed to `feature` in the meantime. What is the safe recovery sequence?'
       type: parsons
       display: block
@@ -4048,7 +3247,7 @@ steps:
       - 'git rebase --abort'
       - 'git revert HEAD'
       - 'rm -rf .git && git clone'
-      explanation: 'When rebasing a shared branch goes wrong, the fix is always — *undo your rewrite first*, then integrate normally. Reflog finds the pre-rebase SHA; `reset --hard` restores it; pull merges Alice''s work; push succeeds. The distractors represent the antipatterns Step 1 named — `push --force` overwrites Alice''s work; `rebase --abort` does not apply after the rebase is complete; `revert` is for undoing a single commit, not a rebase; `rm -rf .git && clone` is the "burning down the repo" antipattern.'
+      explanation: 'Undo your rewrite first, then integrate normally. Reflog finds the pre-rebase SHA; `reset --hard` restores it; `pull` merges Alice''s work; `push` succeeds. Distractors: `push --force` overwrites Alice; `rebase --abort` doesn''t apply after the rebase finished; `revert` undoes a single commit, not a rebase; `rm -rf .git && clone` is "burn the repo down."'
     - question: '**[Interleaves Steps 3, 6]** You are mid-edit on a feature when a teammate asks you to bisect a regression on `main`. Your working tree has uncommitted changes you want to keep. Two tools from this tutorial compose to solve this cleanly — which pair?'
       options:
       - '`git commit -m "WIP"` then `git bisect` — commit your WIP so bisect has a clean tree'
@@ -4056,7 +3255,7 @@ steps:
       - '`git restore .` then `git bisect` — discards your WIP so bisect has a clean tree'
       - '`git bisect` then `git stash` — stash shelves the bisect state'
       correct_index: 1
-      explanation: Bisect moves HEAD across arbitrary historical commits — a dirty working tree either blocks it or carries your edits into commits they don't belong in. Stash is designed exactly for this — private, local, temporary. Committing WIP pollutes history if pushed; `git restore .` destroys your work. Recognize the compose-two-tools pattern — most real Git tasks chain more than one command.
+      explanation: 'Bisect moves HEAD across arbitrary commits — a dirty tree either blocks it or bleeds edits into the wrong commit. Stash is built for this: private, local, temporary. Committing WIP pollutes history if pushed; `git restore .` destroys work.'
     - question: '**[Interleaves Steps 6, 9]** Three months ago your team squash-merged the `feature-stats` branch into `main`. A regression has surfaced that bisect on `main` narrows down to the squash commit. The squash commit changed 800 lines. What is your next move?'
       options:
       - Revert the whole squash commit from `main` and re-investigate later
@@ -4064,7 +3263,7 @@ steps:
       - '`git bisect` on the (still-existing) `feature-stats` branch — its internal commits were preserved, giving fine-grained resolution that the squash on main destroyed'
       - Give up — squash merge permanently discards internal commits
       correct_index: 2
-      explanation: Squash-merge collapses *main's* history, not the feature branch's. The feature branch's commits still exist (and its reflog too) if it wasn't deleted. Bisect there pinpoints the exact internal commit. This is the strongest pragmatic argument for keeping merged feature branches around for a while, not deleting them the day they merge. Step 9's quiz framed this; this question checks that you can *reach* for the recovery without being reminded.
+      explanation: 'Squash-merge collapses `main`''s history, not the feature branch''s. If the branch still exists, its internal commits do too — bisect there for fine-grained resolution. Strong argument for not deleting feature branches the day they merge.'
     - question: '**[The unifying insight]** After working through the whole advanced tutorial, which statement best captures what every command you learned actually does?'
       options:
       - Git commands either delete old state or create new state; they never do both
@@ -4072,7 +3271,7 @@ steps:
       - Git commands are magical; the best strategy is to memorize the most common ones
       - Commands behave unpredictably depending on remote configuration
       correct_index: 1
-      explanation: 'This is the one-sentence schema from Step 2 that every subsequent step cashed in. Branch creation is pointer-only. Commit creates an object + moves a pointer. Rebase creates new objects + moves a pointer. Cherry-pick creates one new object + moves a pointer. Merge creates at most one new object (the merge commit) + moves a pointer. Squash creates one new object + moves a pointer. Even the "destructive" commands (reset, rebase drop) only move pointers — the old objects remain in `.git/objects` and reflog keeps their addresses. If you internalize this, nothing in Git is mysterious.'
+      explanation: 'The Step 2 schema every later step cashed in. Branch = pointer only. Commit/rebase/cherry-pick/merge/squash = new immutable object + move pointer to it. Even "destructive" reset and rebase-drop only move pointers; the old objects stay in `.git/objects` with their addresses in reflog. Internalize this and Git stops being mysterious.'
     - question: '**[Evaluate — meta]** A junior teammate says: "Destructive Git commands like rebase and reset are too dangerous to use; I''ll stick with merge and revert only." Evaluate this position.'
       options:
       - Correct — rebase and reset should be avoided by anyone who isn't a Git expert
@@ -4080,4 +3279,4 @@ steps:
       - Incorrect — there is no difference between local and shared branches
       - Incorrect — reflog auto-recovers destructive operations immediately in all cases
       correct_index: 1
-      explanation: 'Conditional knowledge is the mark of an expert (Ambrose et al. 2010). The cardinal rule is not "rebase = bad" — it is "rebase rewrites history, which is dangerous on shared branches and safe on local ones." The junior''s heuristic is safer *and* less effective; teaching them *when* each tool is appropriate is the goal. The same tool, on the same commits, is either routine or catastrophic depending on one thing — has this history been pushed and pulled by others? This is the single most important distinction the advanced tutorial taught.'
+      explanation: 'The rule isn''t "rebase = bad" — it''s "rebase rewrites history, dangerous on shared branches, safe on local ones." Blanket avoidance is safer *and* less effective. Same tool, same commits, routine vs. catastrophic depending on one thing: has this history been pushed and pulled by others?'

--- a/_data/tutorials/git-advanced.yml
+++ b/_data/tutorials/git-advanced.yml
@@ -299,12 +299,20 @@ steps:
     command: '[ -d /tutorial/myproject/.git ]'
   - description: feature-divide branch exists
     command: cd /tutorial/myproject && git branch | grep -q 'feature-divide'
+    hints:
+    - text: The `feature-divide` branch was prepared for you by setup and shouldn't need creating — `git branch` lists every local branch. If you accidentally deleted it while exploring, remember that a branch is just a 41-byte pointer file; you can recreate it at any commit with `git branch feature-divide <sha>` (use `git reflog` or `git log --all` to locate the right commit).
   - description: Currently on main branch (not detached)
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: '`HEAD` is still detached or pointing somewhere other than `main`. Task 2 had you detach HEAD to *look around*, but like returning from a museum archive you must re-attach HEAD to a branch pointer before leaving. Which `git switch` invocation puts HEAD back on a named branch?'
+      condition: 'output_contains: detached'
+    - text: 'Inspect `.git/HEAD` — if it holds a raw SHA instead of `ref: refs/heads/main`, HEAD is detached. Re-attach by switching back to the main branch (one short command).'
   - description: rescued-work branch exists and points to an experimental commit
     command: cd /tutorial/myproject && git log rescued-work --oneline 2>/dev/null | grep -qi 'experimental'
     hints:
-    - text: You need to use `git reflog` to find the SHA of the experimental commit you made in detached HEAD, then create a branch at that SHA with `git branch rescued-work <sha>`.
+    - text: Before Task 3 you must first make an "orphan" experimental commit. Detach HEAD with `git switch --detach HEAD`, edit `calculator.py` (any change will do — the hint test checks for the word "experimental" in the commit message), then `git add` and `git commit` — but **stay in detached HEAD** so the commit becomes orphaned when you leave.
+      condition: 'output_missing: Experimental'
+    - text: The orphan commit exists (check `git reflog`), but no branch points at it yet. `git reflog` lists every position HEAD has visited — find the line for your experimental commit, copy its short SHA, and use `git branch rescued-work <sha>` to anchor the commit so it's no longer orphaned.
   quiz:
     title: Branch Internals & Detached HEAD — Knowledge Check
     min_score: 0.8
@@ -486,8 +494,12 @@ steps:
   tests:
   - description: On main branch with calculator.py
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main' && [ -f calculator.py ]
+    hints:
+    - text: You're no longer on `main`, or `calculator.py` isn't in the current directory. This step is exploration-only — no file changes required. If you wandered into detached HEAD or another branch while experimenting, `git switch main` brings you back and restores the tracked files.
   - description: You can resolve HEAD~1 (at least 2 commits on main)
     command: cd /tutorial/myproject && git rev-parse --quiet --verify HEAD~1 >/dev/null
+    hints:
+    - text: '`HEAD~1` means "one commit before HEAD", so `main` needs at least two commits. Run `git log --oneline` — if you see only one commit, history was truncated (perhaps a `git reset --hard` rewound too far). Use `git reflog` to find the earlier tip SHA and `git reset --hard <sha>` to restore it.'
   quiz:
     title: Relative Addresses & Object Database — Knowledge Check
     min_score: 0.8
@@ -746,12 +758,23 @@ steps:
   tests:
   - description: Stash is empty (work was popped and committed)
     command: cd /tutorial/myproject && [ $(git stash list | wc -l) -eq 0 ]
+    hints:
+    - text: Run `git stash list` — something is still on the stash stack. Two common reasons you might end here accidentally. (1) You used `git stash apply` (which restores but *keeps* the entry) when you meant `git stash pop` (which removes it). (2) You never popped at all and left your WIP stashed. Either way, `git stash pop` (or `git stash drop`) clears the list.
   - description: calculator.py contains the safe_divide hotfix
     command: cd /tutorial/myproject && grep -q 'def safe_divide' calculator.py
+    hints:
+    - text: The hotfix was committed to a temporary branch (`hotfix-divide-zero`). For `safe_divide` to appear on `main`, you must **merge** that branch back into `main` before deleting it. Re-read Task 3 — which command after `git switch main` integrates the hotfix?
+      condition: 'code_missing: def safe_divide'
+    - text: '`safe_divide` exists in `calculator.py` but the test still fails — check that you ran it *after* saving the file in the editor. A `grep` against an unsaved buffer will miss your changes.'
+      condition: 'code_contains: def safe_divide'
   - description: power function has been committed
     command: cd /tutorial/myproject && git log --oneline | grep -qi 'power'
+    hints:
+    - text: 'After `git stash pop` your in-progress `power` function is back in the working tree — but restoring it is not the same as committing it. The test looks for the word "power" in a commit message, so you still need a two-step save: `git add calculator.py` then `git commit -m "Add power function..."`. (Pick any message that includes "power".)'
   - description: Working tree is clean
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
+    hints:
+    - text: '`git status` will point at whatever is dirty. Most likely causes in this step: (a) `git stash pop` produced a conflict you didn''t finish resolving, (b) you edited but didn''t commit the finalized `power` function, or (c) a merge/commit was left half-done. Clean up the specific file Git is flagging, then commit or discard.'
   quiz:
     title: git stash — Knowledge Check
     min_score: 0.8
@@ -1099,14 +1122,29 @@ steps:
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: Cherry-picking leaves HEAD on whatever branch you ran the command from. Tasks 3 switches you to `experimental` to make a conflicting commit — return with `git switch main` before the conflict resolution, so the cherry-pick lands on the correct branch.
   - description: main contains the absolute value function (cherry-picked)
     command: cd /tutorial/myproject && grep -q 'def absolute' calculator.py && git log --oneline | grep -qi 'absolute value'
+    hints:
+    - text: 'The `absolute` function or its commit is missing from `main`''s history. Inspect the source first: `git log experimental --oneline` shows two commits — you want the one titled `Add absolute value function` (the **tip** of `experimental`), not the earlier experimental_multiply. Either cherry-pick it by its SHA, or use the relative reference: `git cherry-pick experimental`.'
+      condition: 'code_missing: def absolute'
+    - text: The `absolute` function is in the file, but the commit title doesn't match. Cherry-pick normally preserves the source commit's message — if you overrode it, make sure the new commit message still contains the phrase "absolute value".
+      condition: 'code_contains: def absolute'
   - description: main does NOT contain experimental_multiply
     command: cd /tutorial/myproject && ! grep -q 'def experimental_multiply' calculator.py
+    hints:
+    - text: '`experimental_multiply` leaked into `main`. That happens if you merged the whole `experimental` branch or cherry-picked the wrong commit. Cherry-pick is **surgical** — it copies *one* commit. Pick only the "Add absolute value function" commit (the tip of `experimental`), not the earlier one. If the mistake already landed, `git reset --hard HEAD~1` on a clean tree rewinds it.'
   - description: main includes a commit with 'Document' or 'comment' in the message
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'document|comment'
+    hints:
+    - text: 'Task 3 sets up a deliberate conflict by editing `def add` on `main`. In the editor, rewrite the one-line `def add(a, b): return a + b` into a multi-line version with a `"""Return the sum of two numbers."""` docstring, then `git add calculator.py && git commit -m "Document add function"` — the message must contain "Document" or "comment".'
   - description: No unresolved conflict markers remain
     command: cd /tutorial/myproject && ! grep -E '^(<{7}|={7}|>{7})' calculator.py
+    hints:
+    - text: Conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) are still present in `calculator.py`. A conflict is not a failure — Git is asking you to choose. Open the file, keep *both* the docstring **and** the inline comment (the instructions show the exact merged form), delete the three marker lines, save, then `git add calculator.py` and `git cherry-pick --continue`.
+      condition: 'code_contains: <<<<<<<'
+    - text: '`git status` should say `You are currently cherry-picking commit …`. After removing markers and saving, finish with `git add calculator.py && git cherry-pick --continue`. If you want to start over instead, `git cherry-pick --abort` restores a clean main.'
   quiz:
     title: Cherry-Pick — Knowledge Check
     min_score: 0.8
@@ -1296,12 +1334,20 @@ steps:
   tests:
   - description: calculator.py exists and has at least 2 commits in its history
     command: cd /tutorial/myproject && [ -f calculator.py ] && [ $(git log --oneline -- calculator.py | wc -l) -ge 2 ]
+    hints:
+    - text: This test just verifies the starting state — `calculator.py` should exist under `/tutorial/myproject` with a multi-commit history. If you're failing it, you're probably in the wrong directory or the file was deleted. `cd /tutorial/myproject` and `ls` to check.
   - description: Blame runs without error on calculator.py
     command: cd /tutorial/myproject && git blame calculator.py >/dev/null
+    hints:
+    - text: '`git blame calculator.py` should run cleanly from `/tutorial/myproject`. An error usually means you''re in the wrong directory or passed a non-existent filename. Run `pwd` and `ls calculator.py` to verify.'
   - description: Blame reports per-line SHA + author + timestamp (format check)
     command: cd /tutorial/myproject && git blame calculator.py | head -1 | grep -qE '^[\^a-f0-9]+ .* \([^)]+[0-9]+\)'
+    hints:
+    - text: Plain `git blame calculator.py` (no extra flags) prints lines in the default format — each starts with a SHA, then author, then a parenthesized timestamp. If output is empty, the file has no committed content yet; check `git log -- calculator.py`.
   - description: -L line-range flag works (returns output for specified range)
     command: cd /tutorial/myproject && [ -n "$(git blame -L 1,3 calculator.py 2>/dev/null)" ]
+    hints:
+    - text: 'The `-L` flag restricts blame to a line range. The syntax is `-L <start>,<end>` (comma-separated, no spaces). Example: `git blame -L 1,3 calculator.py` limits output to the first three lines — very useful on large files when you already know which lines matter.'
   quiz:
     title: git blame — Knowledge Check
     min_score: 0.8
@@ -1574,12 +1620,23 @@ steps:
   tests:
   - description: Bisect has been cleaned up (no active bisect)
     command: cd /tutorial/myproject && [ ! -f .git/BISECT_LOG ]
+    hints:
+    - text: '`.git/BISECT_LOG` still exists — bisect is paused mid-search. *Always* end bisect with `git bisect reset` (even after `git bisect run` finishes automatically), otherwise HEAD stays parked on a random historical commit. One command, always the same: `git bisect reset`.'
   - description: Test file was committed
     command: cd /tutorial/myproject && git log --oneline -- test_calculator.py | grep -q '.'
+    hints:
+    - text: '`test_calculator.py` isn''t in Git''s history. The setup script should have committed it — if the test is failing, the setup may not have run. Try `git add test_calculator.py && git commit -m "Add regression tests"` manually.'
   - description: At least 5 new commits exist on main
     command: cd /tutorial/myproject && [ $(git log --oneline main | wc -l) -ge 7 ]
+    hints:
+    - text: Fewer than 7 commits on `main` — the 5 pre-built commits (the regression + decoys) are missing. Likely cause is that you ran `git reset --hard` to an earlier SHA during bisect confusion. Use `git reflog` to find the pre-bisect tip and `git reset --hard <sha>` to restore it before rerunning the step.
   - description: The absolute function has been repaired (handles negatives, zero, and positives correctly)
     command: cd /tutorial/myproject && python3 -c "import sys; sys.path.insert(0,'.'); from calculator import absolute; assert absolute(-4) == 4 and absolute(3) == 3 and absolute(0) == 0 and absolute(-0.5) == 0.5"
+    hints:
+    - text: 'The `absolute()` function is still broken. Task 4: once bisect points at the culprit commit, open `calculator.py` and replace the buggy body (`return x` / `return x  # simplification`) with the correct implementation — it should return `x` for non-negatives and `-x` for negatives. Then commit the fix.'
+      condition: 'code_contains: def absolute'
+    - text: 'The `absolute` function was removed entirely. Add it back: one line of body that returns the magnitude, negating when `x < 0`. Then commit the fix.'
+      condition: 'code_missing: def absolute'
   quiz:
     title: git bisect — Knowledge Check
     min_score: 0.8
@@ -1939,14 +1996,27 @@ steps:
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: Finish this step on `main`. Tasks 3 and 5 have you switch to feature branches temporarily; after the last cleanup command (`git branch -D feature-trailer`) make sure HEAD is back on `main` with `git switch main`.
   - description: feature-sqrt branch was merged and deleted
     command: cd /tutorial/myproject && ! git branch | grep -q 'feature-sqrt'
+    hints:
+    - text: '`feature-sqrt` is still in `git branch`. After rebasing and fast-forward-merging it into `main`, the branch pointer is redundant — remove it with `git branch -d feature-sqrt` (lowercase `d` works because the commits are now reachable from main).'
   - description: square_root function is on main
     command: cd /tutorial/myproject && grep -q 'def square_root' calculator.py && git log --oneline main | grep -qi 'square_root'
+    hints:
+    - text: The `square_root` commit never made it onto `main`. The workflow is two moves, in order. (1) `git switch feature-sqrt && git rebase main` replays the feature commit on top of main. (2) `git switch main && git merge feature-sqrt` fast-forwards main up to the rebased tip. Skipping step 2 leaves `main` unchanged.
   - description: History is linear (no merge commit for feature-sqrt)
     command: cd /tutorial/myproject && [ $(git log --merges --oneline main | grep -ci 'Merge branch.*feature-sqrt') -eq 0 ]
+    hints:
+    - text: A merge commit for `feature-sqrt` exists on `main` — meaning you merged **before** rebasing (or forced a non-ff merge). Rebase linearizes *first*, so a subsequent merge is a fast-forward (no merge commit). If you have a merge commit now, `git reset --hard <pre-merge-sha>` (find it with `git reflog`), then rebase and merge in the correct order.
   - description: No rebase is in progress and no conflict markers remain (Task 5 resolved)
     command: cd /tutorial/myproject && [ ! -d .git/rebase-merge ] && [ ! -d .git/rebase-apply ] && ! grep -E '^(<{7}|={7}|>{7})' calculator.py
+    hints:
+    - text: Conflict markers remain in `calculator.py`. Task 5 deliberately creates a conflict. Open the file, keep *both* the `identity` helper **and** the trailer comment, delete the three marker lines (`<<<<<<<`, `=======`, `>>>>>>>`), then `git add calculator.py`.
+      condition: 'code_contains: <<<<<<<'
+    - text: A rebase is paused. After staging the resolved file, finish with `git rebase --continue` — **not** `git commit` (that is the most common mid-rebase reflex mistake). To bail out instead, `git rebase --abort` restores the pre-rebase state.
+      condition: 'output_contains: rebase'
   quiz:
     title: Rebase — Knowledge Check
     min_score: 0.8
@@ -2357,16 +2427,25 @@ steps:
   tests:
   - description: On refactor-power branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/refactor-power'
+    hints:
+    - text: 'Interactive rebase rewrites the *currently checked-out* branch. This step operates on `refactor-power`: `git switch refactor-power` before running any `rebase -i`.'
   - description: Secret was dropped from the active branch (SECRET_API_KEY not in calculator.py)
     command: cd /tutorial/myproject && ! grep -q 'SECRET_API_KEY' calculator.py
+    hints:
+    - text: '`SECRET_API_KEY` is still in `calculator.py`. Task 3 asks you to *drop* the commit that added it. Run `git rebase -i HEAD~2` and change the secret-commit''s action from `pick` to `drop` — in the VM you''d script that with `GIT_SEQUENCE_EDITOR="sed -i ''1s/^pick/drop/''" git rebase -i HEAD~2`.'
+      condition: 'code_contains: SECRET_API_KEY'
   - description: Secret-commit is gone from branch history
     command: cd /tutorial/myproject && ! git log --oneline | grep -qi 'Accidentally add secret'
+    hints:
+    - text: 'The "Accidentally add secret" commit is still in history. `git log --oneline -5` — if it''s there, your rebase didn''t mark that commit as `drop`. Re-run the rebase, double-check which line you''re changing (the sed index), and make sure the verb is `drop` (or `d`), not `fixup`/`squash`.'
   - description: secret-backup branch rescued the 'dropped' commit via reflog (proves reflog safety net)
     command: cd /tutorial/myproject && git log secret-backup --oneline 2>/dev/null | grep -qi 'Accidentally add secret'
     hints:
-    - text: Use `git reflog` to find the SHA of the dropped 'Accidentally add secret' commit, then `git branch secret-backup <sha>` to anchor it. This is the safety-net step from Task 3b.
+    - text: 'Dropped ≠ deleted. Run `git reflog -n 10` and look for the reflog line whose message is "Accidentally add secret" — the first column is the short SHA. Anchor it as a branch: `git branch secret-backup <sha>`. This is the Task 3b demonstration that the reflog can rescue anything rebase throws away.'
   - description: The 4 messy WIP/typo commits were squashed into fewer commits
     command: cd /tutorial/myproject && [ $(git log --oneline refactor-power | grep -ciE '(WIP|Fix typo|More typo)') -le 1 ]
+    hints:
+    - text: 'The four WIP/typo commits still appear in `git log` — the Task 2 squash didn''t happen. Run `git rebase -i HEAD~4`; in the todo list that opens, change lines 2–4 (everything *after* the oldest commit) from `pick` to `squash` (or `fixup`). The scripted form in the VM: `GIT_SEQUENCE_EDITOR="sed -i ''2,4s/^pick/squash/''" git rebase -i HEAD~4`.'
   quiz:
     title: Interactive Rebase — Knowledge Check
     min_score: 0.8
@@ -2616,12 +2695,20 @@ steps:
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: End this step on `main`. The squash merge is performed *from* `main` (that's why you `git switch main` before running it). If you're still on `feature-stats`, `git switch main` and redo the merge.
   - description: feature-stats branch has been deleted
     command: cd /tutorial/myproject && ! git branch | grep -q 'feature-stats'
+    hints:
+    - text: '`feature-stats` is still listed by `git branch`. Squash merge does **not** mark the feature branch as merged in Git''s eyes — its individual commits are not on main (only a new combined commit is). That means plain `git branch -d feature-stats` will refuse. Force it with capital-D: `git branch -D feature-stats`.'
   - description: mean, variance, and stddev are on main
     command: cd /tutorial/myproject && grep -q 'def mean' calculator.py && grep -q 'def variance' calculator.py && grep -q 'def stddev' calculator.py
+    hints:
+    - text: 'One or more of `mean`/`variance`/`stddev` is missing from `calculator.py` on `main`. Unlike regular `git merge`, `git merge --squash` only **stages** the combined diff — it does **not** create a commit for you. After the squash, run `git status` (you should see staged changes), then `git commit -m "..."` to record them.'
   - description: The three feature commits are NOT in main's history (only one combined commit)
     command: cd /tutorial/myproject && [ $(git log --oneline main | grep -ciE 'Add (mean|variance|stddev) function') -eq 0 ]
+    hints:
+    - text: '`main`''s log shows the feature''s individual commits — meaning you did a plain `git merge` (which preserves history) or a rebase, not a `--squash`. The goal of this step is *one* combined commit on main. Undo with `git reset --hard <pre-merge-sha>` (from reflog), then use `git merge --squash feature-stats` followed by `git commit`.'
   quiz:
     title: Squash Merge — Knowledge Check
     min_score: 0.8
@@ -2892,14 +2979,24 @@ steps:
   tests:
   - description: myproject has a math-utils submodule
     command: cd /tutorial/myproject && [ -f .gitmodules ] && grep -q 'math-utils' .gitmodules
+    hints:
+    - text: '`.gitmodules` is missing or doesn''t reference math-utils. Run `git submodule add /tutorial/math-utils.git vendor/math-utils` from inside `/tutorial/myproject` — that one command creates the `.gitmodules` entry and clones the submodule at `vendor/math-utils`.'
   - description: .gitmodules has been committed
     command: cd /tutorial/myproject && git log --oneline -- .gitmodules | grep -q '.'
+    hints:
+    - text: '`.gitmodules` exists in your working tree but isn''t in the repo''s history yet. `git submodule add` only **stages** the file; you still need `git commit -m "Add math-utils submodule"` to record it. Without that commit, a teammate cloning your repo won''t know the submodule exists.'
   - description: Submodule content is checked out
     command: '[ -f /tutorial/myproject/vendor/math-utils/utils.py ]'
+    hints:
+    - text: '`vendor/math-utils/utils.py` is missing. `git submodule add` normally clones the submodule content for you. If the directory is empty, run `git submodule update --init --recursive` to populate it from the pinned SHA.'
   - description: vendor/math-utils is tracked as a gitlink (mode 160000)
     command: cd /tutorial/myproject && git ls-files -s vendor/math-utils | grep -q '^160000'
+    hints:
+    - text: '`vendor/math-utils` is tracked as regular files instead of a gitlink. This happens if you manually `git add`-ed the submodule''s files instead of using `git submodule add`. Remove the path (`git rm -rf --cached vendor/math-utils`) and re-add it with `git submodule add /tutorial/math-utils.git vendor/math-utils`.'
   - description: colleague-clone was created successfully with its submodule populated
     command: '[ -f /tutorial/colleague-clone/vendor/math-utils/utils.py ]'
+    hints:
+    - text: '`colleague-clone/vendor/math-utils/` is empty (or the directory doesn''t exist). Plain `git clone` records the submodule entry but does **not** fetch its content. Use `git clone --recursive /tutorial/myproject colleague-clone`, or after a plain clone, `cd colleague-clone && git submodule update --init --recursive`.'
   quiz:
     title: Git Submodules — Knowledge Check
     min_score: 0.8
@@ -3128,12 +3225,20 @@ steps:
   tests:
   - description: Submodule working directory has the new quadruple function
     command: grep -q 'def quadruple' /tutorial/myproject/vendor/math-utils/utils.py
+    hints:
+    - text: 'The `quadruple` function isn''t in the submodule''s working directory. Inside the submodule, run `git fetch && git checkout origin/HEAD` — the submodule is a nested Git repo, and normal `git` commands run **inside** it to move its HEAD. The outer repo''s `git pull` does *not* update submodule working directories automatically.'
   - description: Outer repo has a commit bumping the submodule SHA
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'bump|v0.2|quadruple'
+    hints:
+    - text: Upgrading a submodule takes **two** actions — you only did half. After checking out the new commit inside `vendor/math-utils`, cd back to `/tutorial/myproject` and run `git add vendor/math-utils && git commit -m "Bump math-utils to v0.2"`. The outer commit records the new pinned SHA; without it, the upgrade never reaches teammates.
   - description: Outer repo is clean (no pending submodule modifications)
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
+    hints:
+    - text: '`git status` in `/tutorial/myproject` will tell you exactly what''s dirty. Two likely culprits: (a) you checked out a new SHA inside the submodule but never `git add`-ed it in the outer repo, or (b) you have staged but uncommitted changes. Commit the bump (or `git submodule update` to reset if you changed your mind).'
   - description: Remote (math-utils.git) has the new upstream commit
     command: git --git-dir=/tutorial/math-utils.git log --oneline --all | grep -qi 'quadruple'
+    hints:
+    - text: The upstream library hasn't published v0.2 yet. Task 1 asks you to run `/tutorial/publish-math-utils-v0.2.sh` — that helper simulates the upstream team committing `quadruple` and pushing it to the "remote" bare repo. Run it once before proceeding.
   quiz:
     title: Updating Submodules — Knowledge Check
     min_score: 0.8
@@ -3542,14 +3647,24 @@ steps:
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: Finish this step in the outer repo on `main`. If you cd'd into `vendor/math-utils` for Tasks 2–3 and never returned, `cd /tutorial/myproject` and `git switch main`.
   - description: Submodule contains a halve helper
     command: cd /tutorial/myproject && grep -q 'def halve' vendor/math-utils/utils.py
+    hints:
+    - text: '`def halve` isn''t in the submodule''s `utils.py`. Open `vendor/math-utils/utils.py` in the editor (the file tree lists it) and append the two-line `def halve(x): return x / 2` function — then save. Edits go in the submodule''s *file*, not in any other file.'
   - description: Submodule's inner commit for halve exists
     command: cd /tutorial/myproject/vendor/math-utils && git log --oneline | grep -qi 'halve'
+    hints:
+    - text: 'You edited the submodule file but never committed it *inside* the submodule. A submodule is a nested Git repo — it has its own staging area and history. `cd vendor/math-utils && git add utils.py && git commit -m "Add halve helper"`. Only then will the inner repo record the change.'
   - description: Outer repo has a commit that bumps the submodule SHA
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'bump|halve'
+    hints:
+    - text: 'The inner commit exists, but the outer repo still pins the **old** SHA. Go back to the outer repo (`cd /tutorial/myproject`) and run `git add vendor/math-utils && git commit -m "Bump math-utils: add halve helper"`. This outer commit is how teammates see the new version.'
   - description: Outer repo is clean (no pending submodule modifications)
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
+    hints:
+    - text: '`git status` in the outer repo will name the dirty path. The most common end-state here is "modified: vendor/math-utils (new commits)" — meaning the inner commit exists but the outer SHA bump commit is missing. Complete the two-step publish: inner commit first, then outer `git add` + commit.'
   quiz:
     title: Submodule Internals — Knowledge Check
     min_score: 0.8
@@ -3816,16 +3931,31 @@ steps:
   tests:
   - description: 'On main branch (cleanup verified)'
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: Capstone should end on `main`. If you're still on your fix branch or in detached HEAD, `git switch main`. Running `git status` first is the professional habit — "read state, then act."
   - description: 'No bisect or rebase still in progress'
     command: cd /tutorial/myproject && [ ! -f .git/BISECT_LOG ] && [ ! -d .git/rebase-merge ] && [ ! -d .git/rebase-apply ]
+    hints:
+    - text: '`git status` will name the in-flight operation. The cleanup command depends on what it is — `git bisect reset` for bisect (Step 6), `git rebase --continue` or `--abort` for rebase (Step 7/8), `git merge --abort` for a paused merge. Always close out every mid-flight state before moving on.'
   - description: 'absolute() works correctly for negatives, zero, and positives'
     command: cd /tutorial/myproject && python3 -c "import sys; sys.path.insert(0,'.'); from calculator import absolute; assert absolute(-4) == 4 and absolute(3) == 3 and absolute(0) == 0"
+    hints:
+    - text: '`absolute()` is still broken on `main`. Task 2''s bisect should have pointed at the commit titled `Capstone: simplify absolute return path`. Read that commit with `git show <sha>` to see the broken body, then restore an implementation that returns `x` for non-negatives and `-x` for negatives.'
   - description: 'Regression test passes end-to-end'
     command: cd /tutorial/myproject && python3 test_calculator.py | grep -q 'all tests pass'
+    hints:
+    - text: '`python3 test_calculator.py` from `/tutorial/myproject` should print `all tests pass`. If it raises, read the assertion line — it tells you which case of `absolute()` is still wrong, so you can fix it precisely.'
   - description: 'Exactly one fix commit landed on main (not 2+ WIP commits visible on main)'
     command: cd /tutorial/myproject && [ $(git log main --oneline | grep -ciE '^[a-f0-9]+ (WIP|wip)') -eq 0 ]
+    hints:
+    - text: '`main` has leftover "WIP" commits. Task 5 of the capstone wants your messy intermediate commits collapsed into **one** clean commit before landing. Two valid routes: (a) `git rebase -i HEAD~N` on the fix branch and `squash`/`fixup` the WIPs (Step 8), or (b) `git merge --squash <fix-branch>` followed by one `git commit` (Step 9). Either lands exactly one new commit on main.'
   - description: 'The in-progress clamp note survived the session (still in working tree, uncommitted)'
     command: "cd /tutorial/myproject && grep -q 'TODO: add clamp helper' calculator.py && ! git log main --oneline | grep -qi 'clamp'"
+    hints:
+    - text: 'The `# TODO: add clamp helper` note is missing from `calculator.py`. Task 1 had you shelve it with `git stash` so bisect had a clean tree — Task 7 is where you restore it. Check `git stash list`; if the entry is still there, `git stash pop` brings the note back into the working tree.'
+      condition: 'code_missing: TODO: add clamp helper'
+    - text: The note survived but it has been committed to main (it shouldn't be). The capstone wants the note to remain **uncommitted** in the working tree, exactly as you found it. Unstage/uncommit it with `git reset HEAD~1` (if it's the tip commit) and leave the edit dirty in the working tree.
+      condition: 'code_contains: TODO: add clamp helper'
   - description: 'Reflog has at least a few entries from this session (safety net intact)'
     command: cd /tutorial/myproject && [ $(git reflog -n 20 | wc -l) -ge 5 ]
     hints:

--- a/_data/tutorials/git-advanced.yml
+++ b/_data/tutorials/git-advanced.yml
@@ -167,10 +167,16 @@ steps:
   tests:
   - description: myproject is a Git repository
     command: '[ -d /tutorial/myproject/.git ]'
+    hints:
+    - text: '`/tutorial/myproject/.git` is missing — something went wrong with setup. Re-run the step to rebuild the starter repo.'
   - description: feature-divide branch exists
     command: cd /tutorial/myproject && git branch | grep -q 'feature-divide'
+    hints:
+    - text: 'No `feature-divide` branch. From main, run `git switch -c feature-divide` (or branch + switch separately). `git branch` lists what you have.'
   - description: Currently on main branch (not detached)
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: 'HEAD is detached or on another branch. `git switch main` re-attaches.'
   quiz:
     title: Branch Internals & Detached HEAD — Knowledge Check
     min_score: 0.8
@@ -323,10 +329,12 @@ steps:
   tests:
   - description: Currently on main branch (not detached)
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: 'Still detached after the rescue? `git switch main` re-attaches. The rescued-work branch you anchored stays put.'
   - description: rescued-work branch exists and points to an experimental commit (proves reflog rescue)
     command: cd /tutorial/myproject && git log rescued-work --oneline 2>/dev/null | grep -qi 'experimental'
     hints:
-    - text: You need to (1) create an orphan commit in detached HEAD and switch away, then (2) use `git reflog` to find its SHA, and (3) `git branch rescued-work <sha>` to anchor it.
+    - text: 'The recipe: (1) make an orphan commit in detached HEAD and switch away, (2) `git reflog` to find its SHA, (3) `git branch rescued-work <sha>` to anchor it. `HEAD@{1}` works as a shortcut for the SHA.'
   quiz:
     title: git reflog — Knowledge Check
     min_score: 0.8
@@ -511,8 +519,12 @@ steps:
   tests:
   - description: On main branch with calculator.py
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main' && [ -f calculator.py ]
+    hints:
+    - text: 'Not on main, or `calculator.py` went missing. `git switch main`; if the file is gone, restore it from the last commit: `git restore calculator.py`.'
   - description: You can resolve HEAD~1 (at least 2 commits on main)
     command: cd /tutorial/myproject && git rev-parse --quiet --verify HEAD~1 >/dev/null
+    hints:
+    - text: 'Only one commit on main, so `HEAD~1` resolves to nothing. Make a small second commit (touch any file, `git add && git commit`) and retry.'
   quiz:
     title: Relative Addresses & Object Database — Knowledge Check
     min_score: 0.8
@@ -742,12 +754,26 @@ steps:
   tests:
   - description: Stash is empty (work was popped and committed)
     command: cd /tutorial/myproject && [ $(git stash list | wc -l) -eq 0 ]
+    hints:
+    - text: '`git stash list` still shows entries. After popping your work and committing, there should be nothing left. `git stash drop` removes stale entries.'
   - description: calculator.py contains the safe_divide hotfix
     command: cd /tutorial/myproject && grep -q 'def safe_divide' calculator.py
+    hints:
+    - text: 'No `safe_divide` in `calculator.py`. The hotfix lives on `hotfix-divide-zero` — after `git switch main`, merge it in (`git merge hotfix-divide-zero`).'
+      condition: 'code_missing: def safe_divide'
+    - text: '`safe_divide` is in the file but the test still reports it missing. Did you save and switch back to `main`?'
+      condition: 'code_contains: def safe_divide'
   - description: power function has been committed
     command: cd /tutorial/myproject && git log --oneline | grep -qi 'power'
+    hints:
+    - text: 'No `power` in the file — pop your stash first: `git stash pop` brings it back.'
+      condition: 'code_missing: def power'
+    - text: '`power` is in the file but not committed. `git add calculator.py && git commit -m "Add power function"`.'
+      condition: 'code_contains: def power'
   - description: Working tree is clean
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
+    hints:
+    - text: 'Uncommitted changes remain. `git status` tells you what; commit or discard to finish the step.'
   quiz:
     title: git stash — Knowledge Check
     min_score: 0.8
@@ -1049,14 +1075,32 @@ steps:
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: 'Cherry-pick while on the target branch. `git switch main` first, then cherry-pick.'
   - description: main contains the absolute value function (cherry-picked)
     command: cd /tutorial/myproject && grep -q 'def absolute' calculator.py && git log --oneline | grep -qi 'absolute value'
+    hints:
+    - text: 'Cherry-pick the tip of `experimental` — a branch name resolves to its tip, so `git cherry-pick experimental` works.'
+      condition: 'code_missing: def absolute'
+    - text: 'The function is there but the commit message does not mention "absolute value". Did you edit the message during cherry-pick?'
+      condition: 'code_contains: def absolute'
   - description: main does NOT contain experimental_multiply
     command: cd /tutorial/myproject && ! grep -q 'def experimental_multiply' calculator.py
+    hints:
+    - text: 'You cherry-picked the wrong commit — `experimental_multiply` should have stayed on `experimental`. Undo with `git reset --hard HEAD~1` and pick the correct SHA.'
   - description: main includes a commit with 'Document' or 'comment' in the message
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'document|comment'
+    hints:
+    - text: 'Task 4 wants a docstring edit on `main` with "Document" in the commit message — that is what creates the conflict Task 4 asks you to resolve.'
+      condition: 'code_missing: Return the sum'
+    - text: 'Docstring is in the file but no commit mentions "Document" or "comment" yet. `git commit -am "Document add function"`.'
+      condition: 'code_contains: Return the sum'
   - description: No unresolved conflict markers remain
     command: cd /tutorial/myproject && ! grep -E '^(<{7}|={7}|>{7})' calculator.py
+    hints:
+    - text: 'Conflict markers still in `calculator.py`. Keep both the docstring and the inline comment, remove the `<<<` / `===` / `>>>` lines, then `git add calculator.py && git cherry-pick --continue`.'
+      condition: 'code_contains: <<<<<<<'
+    - text: '`git cherry-pick --abort` bails if you want to start over — it resets cleanly.'
   quiz:
     title: Cherry-Pick — Knowledge Check
     min_score: 0.8
@@ -1238,12 +1282,20 @@ steps:
   tests:
   - description: calculator.py exists and has at least 2 commits in its history
     command: cd /tutorial/myproject && [ -f calculator.py ] && [ $(git log --oneline -- calculator.py | wc -l) -ge 2 ]
+    hints:
+    - text: '`calculator.py` needs at least two commits in its history for blame to show interesting output. Make a small edit and commit it if the file has only one.'
   - description: Blame runs without error on calculator.py
     command: cd /tutorial/myproject && git blame calculator.py >/dev/null
+    hints:
+    - text: 'Run `git blame calculator.py` in the terminal. If it errors, check the working directory — you must be inside `/tutorial/myproject`.'
   - description: Blame reports per-line SHA + author + timestamp (format check)
     command: cd /tutorial/myproject && git blame calculator.py | head -1 | grep -qE '^[\^a-f0-9]+ .* \([^)]+[0-9]+\)'
+    hints:
+    - text: 'Each blame line should look like `<sha> (<author> <date> <lineno>) <code>`. If yours does not, your Git version may need an upgrade — but normally this just means blame was never run.'
   - description: -L line-range flag works (returns output for specified range)
     command: cd /tutorial/myproject && [ -n "$(git blame -L 1,3 calculator.py 2>/dev/null)" ]
+    hints:
+    - text: 'Try `git blame -L 1,3 calculator.py` — restricts blame to lines 1–3. Syntax is `-L <start>,<end>`.'
   quiz:
     title: git blame — Knowledge Check
     min_score: 0.8
@@ -1491,12 +1543,23 @@ steps:
   tests:
   - description: Bisect has been cleaned up (no active bisect)
     command: cd /tutorial/myproject && [ ! -f .git/BISECT_LOG ]
+    hints:
+    - text: '`git bisect reset` ends the bisect session and returns HEAD to where you started.'
   - description: Test file was committed
     command: cd /tutorial/myproject && git log --oneline -- test_calculator.py | grep -q '.'
+    hints:
+    - text: '`test_calculator.py` exists but was never committed. `git add test_calculator.py && git commit -m "Add regression test"` — bisect needs the test to be in history so it survives the checkouts.'
   - description: At least 5 new commits exist on main
     command: cd /tutorial/myproject && [ $(git log --oneline main | wc -l) -ge 7 ]
+    hints:
+    - text: 'Setup issue — normally the step seeds 5+ commits automatically. Re-run the step if history is sparse.'
   - description: The absolute function has been repaired (handles negatives, zero, and positives correctly)
     command: cd /tutorial/myproject && python3 -c "import sys; sys.path.insert(0,'.'); from calculator import absolute; assert absolute(-4) == 4 and absolute(3) == 3 and absolute(0) == 0 and absolute(-0.5) == 0.5"
+    hints:
+    - text: 'Fix `absolute(x)` to return `x` when `x >= 0`, else `-x`. After bisect pointed at the culprit, commit the repair on top of main.'
+      condition: 'code_contains: def absolute'
+    - text: '`def absolute` is gone entirely. Add it back with a one-line body using the sign of `x`, then commit.'
+      condition: 'code_missing: def absolute'
   quiz:
     title: git bisect — Knowledge Check
     min_score: 0.8
@@ -1799,14 +1862,25 @@ steps:
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: 'After rebase + merge, end on `main`. `git switch main` if you drifted.'
   - description: feature-sqrt branch was merged and deleted
     command: cd /tutorial/myproject && ! git branch | grep -q 'feature-sqrt'
+    hints:
+    - text: 'After the fast-forward merge, delete the branch: `git branch -d feature-sqrt`. Safe because its commits are now reachable from `main`.'
   - description: square_root function is on main
     command: cd /tutorial/myproject && grep -q 'def square_root' calculator.py && git log --oneline main | grep -qi 'square_root'
+    hints:
+    - text: 'Rebase `feature-sqrt` onto `main`, then fast-forward merge. Check `git log --oneline main` — the `square_root` commit should appear on top.'
   - description: History is linear (no merge commit for feature-sqrt)
     command: cd /tutorial/myproject && [ $(git log --merges --oneline main | grep -ci 'Merge branch.*feature-sqrt') -eq 0 ]
+    hints:
+    - text: 'A merge commit snuck in — you ran `git merge` without rebasing first, or with `--no-ff`. The point of rebase is linear history; redo with `git rebase main` on the feature branch, then `git merge` (fast-forwards).'
   - description: No rebase is in progress and no conflict markers remain (Task 5 resolved)
     command: cd /tutorial/myproject && [ ! -d .git/rebase-merge ] && [ ! -d .git/rebase-apply ] && ! grep -E '^(<{7}|={7}|>{7})' calculator.py
+    hints:
+    - text: 'Rebase is paused on a conflict. Edit the file, remove `<<<` / `===` / `>>>`, `git add`, then `git rebase --continue` — not `git commit`. `git rebase --abort` bails.'
+      condition: 'output_contains: rebase in progress'
   quiz:
     title: Rebase — Knowledge Check
     min_score: 0.8
@@ -2302,16 +2376,25 @@ steps:
   tests:
   - description: On refactor-power branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/refactor-power'
+    hints:
+    - text: '`git switch refactor-power` before rebasing. Interactive rebase rewrites the *current* branch.'
   - description: Secret was dropped from the active branch (SECRET_API_KEY not in calculator.py)
     command: cd /tutorial/myproject && ! grep -q 'SECRET_API_KEY' calculator.py
+    hints:
+    - text: 'The secret is still here. During `rebase -i HEAD~2`, change the `pick` of the secret commit to `drop`. Scripted: `GIT_SEQUENCE_EDITOR="sed -i ''1s/^pick/drop/''" git rebase -i HEAD~2`.'
+      condition: 'code_contains: SECRET_API_KEY'
   - description: Secret-commit is gone from branch history
     command: cd /tutorial/myproject && ! git log --oneline | grep -qi 'Accidentally add secret'
+    hints:
+    - text: 'The commit is still in `git log`. Interactive rebase with `drop` (not `pick`) on that line, save and exit the editor to finish the rebase.'
   - description: secret-backup branch rescued the 'dropped' commit via reflog (proves reflog safety net)
     command: cd /tutorial/myproject && git log secret-backup --oneline 2>/dev/null | grep -qi 'Accidentally add secret'
     hints:
-    - text: Use `git reflog` to find the SHA of the dropped 'Accidentally add secret' commit, then `git branch secret-backup <sha>` to anchor it. This is the safety-net step from Task 3b.
+    - text: '`git reflog` → find the SHA of the dropped "Accidentally add secret" commit → `git branch secret-backup <sha>`. The dropped commit is still in `.git/objects`; you''re just anchoring it.'
   - description: The 4 messy WIP/typo commits were squashed into fewer commits
     command: cd /tutorial/myproject && [ $(git log --oneline refactor-power | grep -ciE '(WIP|Fix typo|More typo)') -le 1 ]
+    hints:
+    - text: 'Rebase with `squash` (or `fixup`) on lines 2–4 to fold them into the pick on line 1. After the rebase, the WIP/typo commits should be folded together.'
   quiz:
     title: Interactive Rebase — Knowledge Check
     min_score: 0.8
@@ -2544,12 +2627,20 @@ steps:
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: 'Squash-merge lands on `main`. `git switch main` first, then `git merge --squash feature-stats`.'
   - description: feature-stats branch has been deleted
     command: cd /tutorial/myproject && ! git branch | grep -q 'feature-stats'
+    hints:
+    - text: 'After the squash commit on `main`, `git branch -D feature-stats` removes the branch. Use `-D` (not `-d`) — squash-merge leaves the branch looking "unmerged" to Git.'
   - description: mean, variance, and stddev are on main
     command: cd /tutorial/myproject && grep -q 'def mean' calculator.py && grep -q 'def variance' calculator.py && grep -q 'def stddev' calculator.py
+    hints:
+    - text: 'All three functions should land in one commit. `git merge --squash feature-stats` stages the combined changes — remember to `git commit -m "Add stats module"` afterward.'
   - description: The three feature commits are NOT in main's history (only one combined commit)
     command: cd /tutorial/myproject && [ $(git log --oneline main | grep -ciE 'Add (mean|variance|stddev) function') -eq 0 ]
+    hints:
+    - text: 'Individual feature commits are on `main` — looks like a regular merge, not `--squash`. Reset with `git reset --hard ORIG_HEAD` and redo with `git merge --squash`.'
   quiz:
     title: Squash Merge — Knowledge Check
     min_score: 0.8
@@ -2833,14 +2924,24 @@ steps:
   tests:
   - description: myproject has a math-utils submodule
     command: cd /tutorial/myproject && [ -f .gitmodules ] && grep -q 'math-utils' .gitmodules
+    hints:
+    - text: '`git submodule add /tutorial/math-utils.git vendor/math-utils` creates both `.gitmodules` and the submodule directory.'
   - description: .gitmodules has been committed
     command: cd /tutorial/myproject && git log --oneline -- .gitmodules | grep -q '.'
+    hints:
+    - text: '`git submodule add` stages `.gitmodules` and the gitlink but does not commit. `git commit -m "Add math-utils submodule"` finishes it.'
   - description: Submodule content is checked out
     command: '[ -f /tutorial/myproject/vendor/math-utils/utils.py ]'
+    hints:
+    - text: 'Submodule folder is empty. `git submodule update --init --recursive` populates it from the pinned SHA.'
   - description: vendor/math-utils is tracked as a gitlink (mode 160000)
     command: cd /tutorial/myproject && git ls-files -s vendor/math-utils | grep -q '^160000'
+    hints:
+    - text: 'Something committed `vendor/math-utils` as a regular directory rather than a gitlink. Remove it from the index (`git rm -r --cached vendor/math-utils`) and re-run `git submodule add`.'
   - description: colleague-clone was created successfully with its submodule populated
     command: '[ -f /tutorial/colleague-clone/vendor/math-utils/utils.py ]'
+    hints:
+    - text: '`git clone --recurse-submodules <url> /tutorial/colleague-clone` clones and populates in one shot. Without `--recurse-submodules`, the submodule directory is empty.'
   quiz:
     title: Git Submodules — Knowledge Check
     min_score: 0.8
@@ -3081,12 +3182,20 @@ steps:
   tests:
   - description: Submodule working directory has the new quadruple function
     command: grep -q 'def quadruple' /tutorial/myproject/vendor/math-utils/utils.py
+    hints:
+    - text: 'Edit inside the submodule: `cd vendor/math-utils` → add `def quadruple(x): return x * 4` to `utils.py`.'
   - description: Outer repo has a commit bumping the submodule SHA
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'bump|v0.2|quadruple'
+    hints:
+    - text: 'Inner work done but outer repo still pins the old SHA. `cd /tutorial/myproject && git add vendor/math-utils && git commit -m "Bump math-utils to add quadruple"`.'
   - description: Outer repo is clean (no pending submodule modifications)
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
+    hints:
+    - text: 'Usually `modified: vendor/math-utils (new commits)` — inner commit landed but outer bump is missing. Finish the outer commit.'
   - description: Remote (math-utils.git) has the new upstream commit
     command: git --git-dir=/tutorial/math-utils.git log --oneline --all | grep -qi 'quadruple'
+    hints:
+    - text: 'Inner commit never pushed. From inside the submodule: `git switch -c main` (if detached), then `git push origin main`.'
   quiz:
     title: Updating Submodules — Knowledge Check
     min_score: 0.8
@@ -3459,14 +3568,26 @@ steps:
   tests:
   - description: On main branch
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: 'You''re probably still inside the submodule. `cd /tutorial/myproject && git switch main`.'
   - description: Submodule contains a halve helper
     command: cd /tutorial/myproject && grep -q 'def halve' vendor/math-utils/utils.py
+    hints:
+    - text: 'Append `def halve(x): return x / 2` to `vendor/math-utils/utils.py`. The edit goes in the submodule''s file.'
+      condition: 'code_missing: def halve'
   - description: Submodule's inner commit for halve exists
     command: cd /tutorial/myproject/vendor/math-utils && git log --oneline | grep -qi 'halve'
+    hints:
+    - text: 'You edited the file but never committed *inside* the submodule. `cd vendor/math-utils && git add utils.py && git commit -m "Add halve helper"`.'
+      condition: 'code_contains: def halve'
   - description: Outer repo has a commit that bumps the submodule SHA
     command: cd /tutorial/myproject && git log --oneline | grep -qiE 'bump|halve'
+    hints:
+    - text: 'Outer repo still pins the old SHA. `cd /tutorial/myproject && git add vendor/math-utils && git commit -m "Bump math-utils: add halve helper"`.'
   - description: Outer repo is clean (no pending submodule modifications)
     command: cd /tutorial/myproject && git diff --quiet && git diff --cached --quiet
+    hints:
+    - text: 'Usually `modified: vendor/math-utils (new commits)` — inner landed, outer bump is missing. Finish it.'
   quiz:
     title: Submodule Internals — Knowledge Check
     min_score: 0.8
@@ -3786,20 +3907,35 @@ steps:
   tests:
   - description: 'On main branch (cleanup verified)'
     command: cd /tutorial/myproject && git symbolic-ref -q HEAD | grep -q 'refs/heads/main'
+    hints:
+    - text: 'End on `main`. `git switch main` if you''re still on a fix branch or detached.'
   - description: 'No bisect or rebase still in progress'
     command: cd /tutorial/myproject && [ ! -f .git/BISECT_LOG ] && [ ! -d .git/rebase-merge ] && [ ! -d .git/rebase-apply ]
+    hints:
+    - text: '`git status` names the paused operation. `git bisect reset`, `git rebase --abort`, or `git merge --abort` as appropriate.'
   - description: 'absolute() works correctly for negatives, zero, and positives'
     command: cd /tutorial/myproject && python3 -c "import sys; sys.path.insert(0,'.'); from calculator import absolute; assert absolute(-4) == 4 and absolute(3) == 3 and absolute(0) == 0"
+    hints:
+    - text: 'Bisect should have pointed at `Capstone: simplify absolute return path`. `git show <sha>` to see the damage, then fix `absolute` to return `x` when `x >= 0`, else `-x`.'
   - description: 'Regression test passes end-to-end'
     command: cd /tutorial/myproject && python3 test_calculator.py | grep -q 'all tests pass'
+    hints:
+    - text: '`python3 test_calculator.py` should print `all tests pass`. If it raises, the failing assertion tells you which case of `absolute` is still broken.'
   - description: 'Exactly one fix commit landed on main (not 2+ WIP commits visible on main)'
     command: cd /tutorial/myproject && [ $(git log main --oneline | grep -ciE '^[a-f0-9]+ (WIP|wip)') -eq 0 ]
+    hints:
+    - text: 'WIP commits landed on `main`. Collapse into one: `rebase -i` + `squash`, or `git merge --squash` + commit. Either way, one clean fix commit.'
   - description: 'The in-progress clamp note survived the session (still in working tree, uncommitted)'
     command: "cd /tutorial/myproject && grep -q 'TODO: add clamp helper' calculator.py && ! git log main --oneline | grep -qi 'clamp'"
+    hints:
+    - text: 'The TODO note is missing from `calculator.py`. You stashed it for the bisect — `git stash pop` restores it. Leave it uncommitted.'
+      condition: 'source_missing: TODO: add clamp'
+    - text: 'The note got committed to `main`. The capstone wants it uncommitted. `git reset HEAD~1` if it''s the tip, then leave the edit dirty.'
+      condition: 'source_contains: TODO: add clamp'
   - description: 'Reflog has at least a few entries from this session (safety net intact)'
     command: cd /tutorial/myproject && [ $(git reflog -n 20 | wc -l) -ge 5 ]
     hints:
-    - text: '`git reflog` should show HEAD movements from your stash, bisect, branch-switches, and commits. If it is empty or near-empty, something has been cleared — but normally this test passes automatically once you''ve done any work.'
+    - text: '`git reflog` should show your stash, bisect, branch-switches, and commits. Empty reflog usually means something was cleared — this test typically passes on its own.'
   quiz:
     title: Cumulative Final Quiz — Choose the Right Tool
     min_score: 0.8


### PR DESCRIPTION
Add progressive, question-driven hints to every step of the advanced git
tutorial (branch internals, detached HEAD, stash, cherry-pick, blame,
bisect, rebase, interactive rebase, squash merge, and submodules). Hints
use the existing condition DSL (code_contains / code_missing /
output_contains / output_missing) to surface the right guidance based on
the student's current code and terminal state, guiding them toward the
answer without giving it away.