### PR TITLE
Add good-diagrams skill and place teaching diagrams in SE book

### DIFF
--- a/.claude/skills/good-diagrams/SKILL.md
+++ b/.claude/skills/good-diagrams/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: good-diagrams
+description: Editorial guidelines for deciding WHEN a diagram earns its place in SEBook, and HOW to design it so it actually teaches. Invoke this skill every time you are about to add, edit, or review a diagram, or when you are deciding whether prose alone is sufficient. Pairs with the `diagrams` skill (which covers syntax / renderer choice) — this skill covers pedagogy and editorial judgment. Grounded in Mayer's multimedia-learning principles, Tufte's data-ink, Sweller's cognitive-load theory, Ambler's UML style, and Brown's C4 model.
+---
+
+# Good diagrams in SEBook
+
+Syntax is covered by the `diagrams` skill. This skill answers two harder questions: **should a diagram exist here at all**, and **will it actually help a student learn**.
+
+## The prime directive
+
+**A diagram earns its place only when it carries structural or temporal information that prose cannot compress.** Decorative figures and "chapter needs a picture" additions hurt learning — Mayer's Coherence Principle shows adding relevant-but-non-essential material *reduces* retention (effect size 0.86 across 23 of 23 experiments).
+
+Before adding a diagram, write its caption first:
+
+> "After reading this diagram, the student should understand that ___."
+
+If you cannot finish that sentence with a concrete takeaway that the surrounding prose doesn't already convey, **don't add the diagram**.
+
+## Decide: is a diagram warranted?
+
+### Add a diagram when
+
+- You are describing relationships among **3+ entities** (who calls whom, what contains what, what happens before what).
+- You find yourself writing phrases like *"A sits between B and C"*, *"the request flows through X then Y then Z"*, *"these four states transition as follows"*, *"the tree looks like..."*.
+- You're explaining a **topology, hierarchy, process, or lifecycle** — architecture, folder tree, git history, state machine, message sequence, class inheritance.
+- The reader must hold **spatial or temporal structure** in working memory to follow the next paragraph.
+- You're showing a **before/after** or contrasting two designs — small multiples (Tufte) excel here, especially for refactoring and design-pattern applications.
+- A concept has **multiple simultaneous attributes** (role + lifecycle + communication channel) that prose can only serialize awkwardly.
+
+### Do NOT add a diagram when
+
+- The content is **linear** — a numbered list or bulleted list already captures it.
+- You'd draw only **one or two boxes**. A sentence is faster and clearer.
+- The figure would **merely restate prose** with no new structural insight (Redundancy Principle violation).
+- You cannot write a one-sentence caption stating the takeaway — it's decorative, not explanatory.
+- The material is **deeply abstract** (e.g., referential transparency, type erasure) with no natural spatial metaphor — forcing boxes invents false structure.
+- Accurate rendering would require **so much detail the diagram becomes a reference schematic** — split it, or drop to prose + code.
+- The page already has a diagram covering the same concept — don't duplicate.
+- The surrounding page is already dense with diagrams and readers would skim. Coherence matters: fewer, better figures beat many mediocre ones.
+
+### Hard "no" signals
+
+If the answer to any of these is yes, you're about to add a bad diagram — stop:
+
+- "I just want something visual on this page." (chartjunk)
+- "Let me illustrate every sentence in this section." (redundancy)
+- "This is hard to understand — maybe a picture will save it." (usually the prose needs fixing first; pictures don't rescue bad explanations)
+- "I'll show the whole system." (almost always wrong abstraction level — narrow the scope)
+
+## Design rules (apply to every diagram you add)
+
+These are the 10 rules a reviewer should check against. Each is tied to a specific empirical principle.
+
+**1. One diagram = one takeaway.** If it teaches two things, split it into two figures. (Coherence Principle.)
+
+**2. Pick one abstraction level and commit.** Don't mix a user-facing service box with a database's internal schema on the same figure. The C4 model's whole point is that Context, Container, Component, and Code are *separate* diagrams. Mixing levels makes peers unidentifiable.
+
+**3. Place the diagram adjacent to the prose that references it.** Same screen, same scroll. The Spatial Contiguity Principle shows co-location produces learning gains (effect size 1.10, 22/22 experiments). If the paragraph that introduces the diagram is two screens up, readers lose the thread.
+
+**4. Labels go on the thing, not in a distant legend.** Split-Attention Effect (Chandler & Sweller): forcing readers to fuse an image with a separate key inflates cognitive load. Put the role name inside the box, the verb on the arrow, the multiplicity at the endpoint — not in a side table.
+
+**5. Signal what matters most.** Use weight, color, numbered callouts, or arrow emphasis to mark the critical path. Supporting infrastructure should recede visually. Mayer's Signaling Principle: cued elements are processed more deeply.
+
+**6. Strip every mark that doesn't carry meaning.** No 3D effects, no gratuitous icons, no decorative gradients. Tufte: "Above all else show the data." In non-data diagrams: every shape, color, and line should encode a distinction. If color isn't a variable, don't use color.
+
+**7. Keep notation consistent with the rest of the book.** Same shape means the same thing everywhere. If a cylinder is a database in the architecture chapter, it cannot be a queue in the state-machine chapter. Check neighboring chapters before inventing notation.
+
+**8. Prefer the most specific diagram type available.** A state machine drawn in freeform is worse than one drawn with `language-uml-state` — the renderer gives you proper initial/final markers, guard syntax, and transition labels for free. Same for commit DAGs (use `diagram-gitgraph`), directory trees (use `diagram-folder-tree`), class hierarchies (use `language-uml-class`).
+
+**9. Cap complexity per figure.** Soft caps that have worked in SEBook:
+   - Class diagram: ≤ 7 classes visible at once; show only methods/fields relevant to the point (Fowler's "sketch mode").
+   - Sequence diagram: ≤ 5 lifelines; if you need more, split by phase.
+   - State diagram: ≤ 8 states; collapse related states into a composite state if needed.
+   - Freeform: ≤ 10 boxes; any more is usually a sign the abstraction is too low.
+
+**10. Prose and diagram do different work.** The diagram shows *structure and relationships*. The prose provides *causality, motivation, edge cases, and the "why"*. If your prose reads like a tour of the boxes ("the Controller connects to the Model, which connects to…"), delete one of them — you're just duplicating.
+
+## Placement and caption conventions
+
+- The diagram goes **immediately after** the paragraph that introduces it, not at the top of the section or the end of the page.
+- The paragraph immediately before the diagram should set up the question the diagram answers ("how does a request flow through the layers?" / "what state is the connection in when the timer fires?").
+- Prefer a short caption or a one-sentence lead-in that names the takeaway. SEBook doesn't enforce a caption style; a bold lead-in sentence immediately below the figure is acceptable ("**Figure:** the controller mediates between view and model; the model never calls the view directly.").
+- Don't re-introduce a diagram in a later section — reference it back if needed.
+
+## Small multiples for before/after
+
+When teaching a refactoring, a design pattern's application, or "the problem vs. the fix", use **two diagrams side-by-side with identical notation and scale**. Tufte's small-multiples principle: the eye detects the *difference* between comparable pictures far faster than it reconstructs a change from prose. In SEBook this typically means two `diagram-freeform` or two `language-uml-class` blocks in succession, with matching layouts so the reader's eye lands on the same spot in each.
+
+## Audit checklist (use when reviewing an existing page)
+
+Go through each diagram on the page and ask:
+
+1. **Caption test** — can you finish "the student should learn that ___"? If not, flag for removal.
+2. **Prose overlap** — does the surrounding paragraph narrate the diagram? If yes, cut the narration or cut the diagram.
+3. **Abstraction level** — are all elements peers at one level? Flag mixed levels.
+4. **Complexity** — over the soft caps in rule 9? Split.
+5. **Label placement** — any labels in a legend that could live on the element? Move them.
+6. **Notation consistency** — same shapes/arrows as neighboring chapters? If not, reconcile.
+7. **Signal** — is the critical path visually distinct from supporting elements? If everything is the same weight, add emphasis.
+8. **Redundancy** — every box, arrow, color carries information? Strip what doesn't.
+9. **Right type** — is this freeform when a specific type (`language-uml-state`, `diagram-gitgraph`, `diagram-folder-tree`, etc.) would fit? Switch.
+10. **Co-location** — is the diagram on the same screen as its introducing paragraph? Move it.
+
+## How this skill pairs with others
+
+- **`diagrams` skill** — tells you *which renderer class to use and where to find syntax*. This skill tells you *whether to draw at all, and how to design for learning*. Invoke both together: this skill first (should I? what should it show?), then the `diagrams` skill (how do I render it?).
+- **`uml-diagramming` skill (if available)** — deeper UML-specific style critique (arrow semantics, multiplicity, naming). Invoke after the other two when the diagram is UML.
+
+## Sources
+
+Empirical claims above come from:
+
+- Mayer, *Multimedia Learning* — Coherence, Signaling, Redundancy, Spatial Contiguity, Temporal Contiguity, Modality Principles. (Cambridge Handbook of Multimedia Learning.)
+- Chandler & Sweller (1992) — Split-Attention Effect. Cognitive Load Theory.
+- Paivio — Dual-Coding Theory.
+- Tufte, *The Visual Display of Quantitative Information* and *Envisioning Information* — data-ink ratio, chartjunk, small multiples.
+- Ambler, *The Elements of UML 2.0 Style* — general diagramming guidelines; consistency.
+- Fowler, *UML Distilled* — "sketch mode"; UML as communication.
+- Brown, C4 model — one abstraction level per diagram; legends and titles.
+- Novak et al. — concept maps and learning.

--- a/SEBook/architectural_styles/layers.md
+++ b/SEBook/architectural_styles/layers.md
@@ -24,6 +24,34 @@ To achieve the systemic properties of the style, architects must enforce strict 
 *   **Layer Bridging:** When a module in a higher layer accesses a nonadjacent lower layer, it is known as *layer bridging*. While occasional bridging is permitted for performance optimization, excessive layer bridging acts as an *architectural smell* that destroys the low coupling of the system, ultimately ruining the portability the style was meant to guarantee.
 *   **The Golden Rule:** Under no circumstances is a lower layer allowed to use an upper layer. Upward dependencies create cyclic references, which fundamentally invalidate the layering and turn the architecture into a "big ball of mud".
 
+The diagram below contrasts the four topologies. Solid arrows are *allowed* uses; dashed arrows annotated "✗" are the violations that turn a clean stack into a ball of mud.
+
+<div class="uml-class-diagram-container" data-uml-type="component" data-uml-spec='@startuml
+component "Presentation" as P
+component "Domain" as D
+component "Data Access" as DA
+component "Infrastructure" as I
+P --> D : strict (OK)
+D --> DA : strict (OK)
+DA --> I : strict (OK)
+P ..> DA : relaxed / bridging\n(skips one layer)
+D ..> P : golden-rule violation ✗\n(upward use)
+note right of P
+  Strict: use only
+  the layer directly below.
+end note
+note right of D
+  Relaxed: may skip layers
+  downward; acceptable.
+  Excessive bridging is a smell.
+end note
+note right of DA
+  Golden rule: NEVER
+  use a layer above.
+  Creates cycles; kills portability.
+end note
+@enduml'></div>
+
 #  Quality Attribute Trade-offs
 Every architectural style is a prefabricated set of constraints designed to elicit specific systemic qualities. The layered style presents a highly distinct profile of trade-offs:
 

--- a/SEBook/architectural_styles/pubsub.md
+++ b/SEBook/architectural_styles/pubsub.md
@@ -26,6 +26,27 @@ The primary components in this style are any independent entities equipped with 
 **The Event Bus Connector**
 The true "rock star" of this architecture is not the components, but the connector. The *event bus* (or event distributor) is an N-way connector responsible for accepting published events and dispatching them to all registered subscribers. All communications strictly route through this intermediary, preventing direct point-to-point coupling between the application components.
 
+The canonical topology looks like this — publishers on one side, the bus in the middle, subscribers on the other. Crucially, **no arrow ever crosses directly between a publisher and a subscriber**:
+
+<div class="uml-class-diagram-container" data-uml-type="component" data-uml-spec='@startuml
+component Publisher1
+component Publisher2
+component "Event Bus" as Bus
+component Subscriber1
+component Subscriber2
+component Subscriber3
+Publisher1 --> Bus : publish(event)
+Publisher2 --> Bus : publish(event)
+Bus --> Subscriber1 : notify
+Bus --> Subscriber2 : notify
+Bus --> Subscriber3 : notify
+note bottom of Bus
+  Publisher and Subscriber
+  never reference each other —
+  the bus is the only coupling point.
+end note
+@enduml'></div>
+
 **Behavioral Variation: Push vs. Pull Models**
 When an event occurs, how does the state information propagate to the subscribers? The literature details two distinct behavioral variations:
 *   **The Push Model:** The publisher sends all relevant changed data along with the event notification. This creates a rigid dynamic behavior but is highly efficient if subscribers almost always need the detailed information.

--- a/SEBook/designprinciples/solid.md
+++ b/SEBook/designprinciples/solid.md
@@ -103,7 +103,24 @@ DI is the most common way to *implement* DIP, but you can do DI without DIP (inj
 
 # How the Principles Reinforce Each Other
 
-SOLID is not five independent rules — the principles interact:
+SOLID is not five independent rules — the principles interact. The diagram below shows how mastering one unlocks others: arrows point from the enabler to the payoff.
+
+<div class="uml-class-diagram-container" data-uml-type="component" data-uml-spec='@startuml
+component "SRP\nSingle Responsibility" as SRP
+component "OCP\nOpen/Closed" as OCP
+component "LSP\nLiskov Substitution" as LSP
+component "ISP\nInterface Segregation" as ISP
+component "DIP\nDependency Inversion" as DIP
+LSP --> OCP : enables\n(safe polymorphism)
+DIP --> OCP : enables\n(pluggable impls)
+ISP --> LSP : shrinks\n(less to violate)
+SRP --> OCP : narrows change\nsurface
+note bottom of OCP
+  OCP is the common
+  payoff: extend without
+  modifying existing code.
+end note
+@enduml'></div>
 
 * **LSP enables OCP.** If every subtype honors the parent's contract, a router can iterate polymorphically without knowing which subclass it has — so new subclasses extend the system without modifying the router.
 * **DIP enables OCP.** If high-level modules depend on abstractions, new implementations can be plugged in as extensions — again, without modifying existing code.

--- a/SEBook/process.md
+++ b/SEBook/process.md
@@ -6,6 +6,25 @@ layout: sebook
 # Agile
 For decades, software development was dominated by the Waterfall model, a sequential process where each phase—requirements, design, implementation, verification, and maintenance—had to be completed entirely before the next began. This "Big Upfront Design" approach assumed that requirements were stable and that designers could predict every challenge before a single line of code was written. However, this led to significant industry frustrations: projects were frequently delayed, and because customer feedback arrived only at the very end of the multi-year cycle, teams often delivered products that no longer met the user's changing needs.
 
+In Waterfall, feedback from the customer only appears at the very end — after months or years of work:
+
+<div class="uml-class-diagram-container" data-uml-type="state" data-uml-spec='@startuml
+[*] --> Requirements
+Requirements --> Design : sign-off
+Design --> Implementation : sign-off
+Implementation --> Verification : code complete
+Verification --> Maintenance : release
+Maintenance --> [*]
+note right of Verification
+  Customer sees working
+  software for the FIRST time
+  here — often months or
+  years after Requirements.
+end note
+@enduml'></div>
+
+Agile inverts this: the team delivers a small working increment every one to four weeks and lets customer feedback reshape each subsequent iteration — the feedback loop closes in weeks, not years.
+
 ## Agile Manifesto
 In 2001, a group of software experts met in Utah to address these failures, resulting in the Agile Manifesto. Rather than a rigid rulebook, the manifesto proposed a shift in values: 
 * Individuals and interactions over processes and tools

--- a/SEBook/process/scrum.md
+++ b/SEBook/process/scrum.md
@@ -42,6 +42,25 @@ The framework follows a specific rhythm of time-boxed events:
 * **Sprint Review**: A working session at the end of the sprint where stakeholders provide feedback on the working increment. A good review includes live demos, not just slides.
 * **Sprint Retrospective**: The team reflects on their process and identifies ways to increase future quality and effectiveness.
 
+The sprint is a closed feedback loop: every event feeds the next, and the retrospective loops the team back into the next planning session.
+
+<div class="uml-class-diagram-container" data-uml-type="state" data-uml-spec='@startuml
+[*] --> SprintPlanning : sprint begins
+SprintPlanning : define goal,\nselect backlog items
+SprintPlanning --> Development : sprint backlog ready
+Development : build the increment
+Development --> DailyStandup : every 24 hours
+DailyStandup : 15-min sync,\nsurface blockers
+DailyStandup --> Development : continue work
+Development --> SprintReview : last day of sprint
+SprintReview : demo increment,\ncollect feedback
+SprintReview --> SprintRetrospective : product feedback captured
+SprintRetrospective : inspect process,\ncommit to one improvement
+SprintRetrospective --> SprintPlanning : next sprint
+@enduml'></div>
+
+The retrospective's arrow back to planning is the engine of empiricism: each cycle the team inspects both the *product* (in review) and the *process* (in retro), and adapts before the next sprint starts.
+
 # Scaling Scrum with SAFe
 When a product is too massive for a single team of 7–10 people, organizations often use the Scaled Agile Framework (SAFe). SAFe introduces the Agile Release Train (ART)—a "team of teams" that synchronizes their sprints. It operates on Program Increments (PI), typically lasting 8–12 weeks, which align multiple teams toward quarterly goals. While SAFe provides predictability for Fortune 500 companies, critics sometimes call it "Scrum-but-for-managers" because it can reduce individual team autonomy through heavy planning requirements.
 

--- a/SEBook/software_architecture.md
+++ b/SEBook/software_architecture.md
@@ -44,5 +44,24 @@ This discrepancy between the as-intended plan and the as-realized code is known 
 
 If a system's architecture is allowed to drift and erode without reconciliation, the descriptive and prescriptive architectures diverge completely. When this happens, the system loses its conceptual integrity, technical debt accumulates in the source code, and the system eventually becomes unmaintainable, necessitating a complete architectural recovery or overhaul {% cite Taylor2009 %}.
 
+The two architectures are two separate artifacts that *should* stay aligned — the diagram below names the two forces that pull them apart:
+
+<div class="uml-class-diagram-container" data-uml-type="component" data-uml-spec='@startuml
+component "Prescriptive Architecture\n(as-intended, the plan)" as P
+component "Descriptive Architecture\n(as-realized, the code)" as D
+P ..> D : drift\n(undocumented additions\nthat do not break rules)
+P ..> D : erosion\n(changes that violate\nthe stated rules)
+note bottom of P
+  Lives in diagrams, ADRs,
+  architect notes.
+end note
+note bottom of D
+  Lives in the source code.
+  This is the REAL architecture.
+end note
+@enduml'></div>
+
+The job of the architect is continuous *reconciliation*: either update the plan to reflect reality, or refactor the code to match the plan. Without that work, the gap grows monotonically.
+
 
 {% include quiz.html id="software_architecture" %}

--- a/SEBook/testing/tdd.md
+++ b/SEBook/testing/tdd.md
@@ -29,6 +29,20 @@ This structure manifests as the Red-Green-Refactor cycle:
 * Green: The mandate is to write the "simplest piece of code" to reach a passing state. Shortcuts and naive implementations are acceptable here; the priority is the verification of behavior.
 * Refactor: Once the bar is green, the developer performs "merciless refactoring" to remove duplication (code smells) and clarify intent. Following Kerievsky’s "Small Steps" methodology is vital. If a developer takes steps that are too large, they risk falling into a "World of Red"—a state where tests remain broken for long periods, the feedback loop is severed, and the productivity benefits of the cycle are lost.
 
+The three phases form a tight, repeating loop — the engine that drives every TDD session:
+
+<div class="uml-class-diagram-container" data-uml-type="state" data-uml-spec='@startuml
+[*] --> Red : start of cycle
+Red : write a tiny failing test
+Red --> Green : test fails\n(specification captured)
+Green : write simplest code to pass
+Green --> Refactor : test passes\n(behavior verified)
+Refactor : remove duplication,\nclarify intent
+Refactor --> Red : next behavior
+@enduml'></div>
+
+Each full turn of the cycle should take **minutes, not hours**. If you cannot return to green quickly, your step was too large — shrink the test and try again.
+
 # Strategic Impact: Quality, Documentation, and the "Information Hiding" Debate
 
 TDD’s impact transcends individual code blocks, serving as a "living" form of documentation. Because the tests are executed continuously, they provide an always-accurate specification of the system’s behavior. This dramatically increases the "bus factor"—the number of team members who can depart a project without the remaining team losing the ability to maintain the codebase. Furthermore, TDD ensures that bugs effectively "only exist for 10 seconds." Since failures are immediately linked to the most recent change, debugging becomes trivial, eliminating the wasteful scavenger hunts typical of sequential testing.

--- a/SEBook/testing/testdoubles.md
+++ b/SEBook/testing/testdoubles.md
@@ -3,6 +3,31 @@ title: Test Doubles
 layout: sebook
 ---
 
+A **test double** is any object that stands in for a real dependency during a test. The three kinds you will meet differ along two axes: *which direction of data flow they control* (indirect input vs. indirect output) and *when verification happens* (after the fact vs. during execution).
+
+<div class="uml-class-diagram-container" data-uml-type="class" data-uml-spec='@startuml
+class TestDouble <<abstract>> {
+  replaces a real dependency
+}
+class TestStub {
+  controls indirect inputs
+  (feeds values INTO the SUT)
+}
+class TestSpy {
+  records indirect outputs;
+  verify AFTER execution
+}
+class MockObject {
+  expects indirect outputs;
+  verify DURING execution
+}
+TestStub --|> TestDouble
+TestSpy --|> TestDouble
+MockObject --|> TestDouble
+@enduml'></div>
+
+Keep this map in mind as you read: each section below deepens one of the three branches.
+
 # Test Stub
 
 A Test Stub is an object that replaces a real component to allow a test to control the indirect inputs of the SUT. 


### PR DESCRIPTION
Introduces an editorial skill (.claude/skills/good-diagrams) that codifies
when a diagram earns its place and how to design it for learning, grounded
in Mayer's multimedia principles, Tufte's data-ink, and Ambler's UML style.

Applies that skill by adding eight diagrams to high-value spots in the book
where prose alone left structural or temporal relationships underspecified:

- testing/tdd.md           — Red-Green-Refactor as a state-machine cycle
- designprinciples/solid.md — SOLID reinforcement web (enabler -> payoff)
- process/scrum.md          — sprint lifecycle with retrospective loop
- testing/testdoubles.md    — taxonomy of Stub vs. Spy vs. Mock
- architectural_styles/pubsub.md — canonical publisher/bus/subscriber
- architectural_styles/layers.md — strict/relaxed/bridging/golden-rule
- process.md                — waterfall phases with late-feedback note
- software_architecture.md  — prescriptive vs. descriptive + drift/erosion

https://claude.ai/code/session_01PpDqytsekKzZAeBWBscA9n