### PR TITLE
Fix inline code color inside headings to match heading color

### DIFF
--- a/css/portfolio.css
+++ b/css/portfolio.css
@@ -617,6 +617,11 @@ html.dark-mode h2 {
 	-webkit-text-stroke: 1px #000;
 }
 
+/* Inline code inside headings inherits the heading color in all modes */
+h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
+	color: inherit !important;
+}
+
 html.dark-mode .text-danger {
 	color: white !important;
 }


### PR DESCRIPTION
Add h1-h6 code { color: inherit !important } so inline code inside
headings inherits the heading color instead of the default code color,
working automatically in both light and dark modes.

https://claude.ai/code/session_016GzLrLSMvksk8apK7UM1QN