### PR TITLE
Redesign TDD tutorial around dragon-dice scoring engine

### DIFF
--- a/_data/tutorials/tdd.yml
+++ b/_data/tutorials/tdd.yml
@@ -1,21 +1,23 @@
-title: "TDD with pytest"
-description: "Learn Test-Driven Development hands-on: write failing tests first, make them pass with minimal code, then refactor. Build the TDD mindset — testing as a design tool, not just verification."
+title: "TDD with pytest — Dragon Dice Battle"
+description: "Live the Red-Green-Refactor rhythm by growing a fantasy dice-scoring engine from scratch — twelve tiny tests, one design pressure at a time. Tests drive design, refactors stay safe, and the rules of the game emerge as code."
 
 backend: pyodide
 
-# Show code (left) and tests (right) side by side — students can toggle back
-# to tabbed view with the button above the editors. Files prefixed `test_`
-# route to the right pane automatically; everything else lands on the left.
+# Show code (left) and tests (right) side by side. Files prefixed `test_`
+# auto-route to the right pane; `scorer.py` lands on the left.
 editor_split: true
 
-# Keep the output panel compact — most TDD interaction happens in the editors,
-# and students only need a short strip to skim pytest's pass/fail summary.
+# Compact output panel — most action is in the editors. The strip below the
+# editors is just for skimming pytest's pass/fail summary.
 output_height: "25%"
 
 require_tests: true
 autosave_type: files
 
-# Global setup: install pytest, add /tutorial to sys.path, patch module cache
+# Global setup: install pytest, expose /tutorial on sys.path, and patch the
+# pytest module cache so each `pytest.main(...)` call sees the latest source
+# rather than a stale import. The module name list MUST include every project
+# module the student edits — for this tutorial that is just `scorer`.
 setup_commands:
   - "import pyodide_js; await pyodide_js.loadPackage('pytest')"
   - "import sys; sys.path.insert(0, '/tutorial')"
@@ -26,7 +28,7 @@ setup_commands:
         _sysmod = _sys
         def _patched(*a, **kw):
             for m in list(_sysmod.modules):
-                if m.startswith('test_') or m in ('password','fizzbuzz','word_counter','bank_account'):
+                if m.startswith('test_') or m == 'scorer':
                     del _sysmod.modules[m]
             return _orig(*a, **kw)
         return _patched
@@ -34,1551 +36,5009 @@ setup_commands:
 
 steps:
 
+  # ==========================================================================
+  # CYCLE 1 — Empty roll creates an empty battle report
+  #
+  # The first cycle is split into THREE separate tutorial steps so that
+  # students live each phase of Red-Green-Refactor as a distinct moment, not
+  # a slogan. No quiz appears until after the REFACTOR step — the goal here
+  # is to *feel* the rhythm before being asked to reason about it.
+  # ==========================================================================
+
   # --------------------------------------------------------------------------
-  # STEP 1 — The Red-Green-Refactor Rhythm
+  # STEP 1 — Cycle 1 RED: write the failing test
   # Pedagogy:
-  #   Worked Example     — full R-G-R cycle with sub-goal labels.
-  #   PRIMM              — predict before running.
-  #   Threshold concept  — TDD is design, not verification.
-  #   Fading begins      — first test given, second scaffolded, third TODO.
-  #   Bloom's level      — Understand / Apply / Analyze.
+  #   Worked example      — the test is given; student types it and runs.
+  #   PRIMM (Predict)     — student predicts what failure they will see.
+  #   Threshold concept   — TDD is design, not verification (set up here).
+  #   Cognitive load      — only ONE moving part: the test. No code yet.
+  #   Misconception fix   — "failing test = bad test" is named and refuted.
   # --------------------------------------------------------------------------
-  - title: "The Red-Green-Refactor Rhythm"
+  - title: "Cycle 1 — RED: Write the Failing Test"
     instructions: |
-      > **Prerequisite:** This tutorial assumes you have completed the [**Testing Foundations**](/SEBook/tools/testing-foundations-tutorial) tutorial — writing pytest tests, choosing inputs with partitions and boundaries, and testing behavior instead of implementation. If those ideas feel unfamiliar, do that tutorial first.
+      > **Prerequisite:** [Testing Foundations](/SEBook/tools/testing-foundations-tutorial) — pytest discovery, `assert`, partitions, behavior-not-implementation. If those feel new, do that one first.
 
-      > **Learning objective:** After this step you will be able to **execute** a complete Red-Green-Refactor TDD cycle and **explain** why TDD is a design technique, not just testing.
+      You'll grow a small dice-scoring engine over 15 steps using **only Test-Driven Development**.
 
-      ## The Core Insight
+      ## Test-Driven Development in one minute
 
-      Here is the single most important idea in this tutorial:
+      TDD is a **design** technique that uses tests as the medium of pressure. You write code in short cycles of three phases:
 
-      > **TDD is a design technique, not a testing technique.**
+      | Phase | What you do | Why this phase exists |
+      |---|---|---|
+      | 🔴 **RED** | Write **one** failing test that names a behavior you want | Forces the interface and expected behavior to be decided *before* any logic exists |
+      | 🟢 **GREEN** | Write the **smallest** code that makes the test pass | Resists speculative design; only build what a test demands |
+      | 🔵 **REFACTOR** | Improve the code while all tests stay green | The safety net lets you reshape structure without fear of regression |
 
-      When you write the test *first*, you are forced to decide:
-      - What is the **public interface**? (function name, parameters, return type)
-      - What is the **expected behavior**? (given this input, what should happen?)
-      - What are the **edge cases**? (empty input, negative numbers, etc.)
+      Each phase of cycle 1 is its own tutorial step so the rhythm becomes a *felt sequence*, not a slogan. From cycle 2 onward, each cycle is one step containing all three phases.
 
-      You answer all these design questions *before writing a single line of implementation*. The tests are a byproduct — the real value is the design thinking.
+      ## Why a *failing* test is the goal of RED
 
-      ### A Note Before We Begin
+      A failing test is **not a bug** — RED is the expected starting state of every cycle. But the failure has to come from the *behavior under test*, not from a typo:
 
-      TDD asks you to write a test *before* the code exists. This feels backward at first — and that is completely normal. Every developer who learns TDD goes through an uncomfortable adjustment period. If TDD feels strange or slow, you are doing it right. Stick with the process; it gets natural with practice.
+      - **Right reason** — `ImportError`, `AttributeError`, a value-mismatch on the assertion you wrote. The test correctly says *"this behavior does not exist yet."*
+      - **Wrong reason** — `SyntaxError`, missing colon, misspelled `test_` prefix. The test never ran. You've learned nothing about the unit, only about your typing.
 
-      ## The Three Phases
+      Students commonly delete a failing test to make the bar green. We're leaning into that discomfort instead. **Learning to read the failure** is what TDD trains.
 
-      TDD follows a strict three-phase cycle, repeated in short iterations:
+      ## The shape of every pytest test
 
-      | Phase | Color | What You Do | Key Rule |
-      |-------|-------|-------------|----------|
-      | **1. RED** | :red_circle: | Write ONE failing test | The test describes desired behavior that does not exist yet |
-      | **2. GREEN** | :green_circle: | Write the MINIMUM code to pass | Do not optimize. Do not add features. Just make the test pass |
-      | **3. REFACTOR** | :large_blue_circle: | Clean up the code | Remove duplication, improve names — but don't change behavior. All tests must still pass |
+      Every pytest test you write has the same four-part structure:
 
-      **Critical misconception:** You do NOT write all your tests first. You write **one test**, make it pass, refactor, then write the **next** test. One cycle at a time.
+      | Part | What it does |
+      |---|---|
+      | **Import** the unit under test | Tells Python what code you'll call |
+      | **Define** a function whose name starts with `test_` | pytest only discovers functions matching this pattern |
+      | **Arrange + act** | Set up any input and call the unit |
+      | **Assert** an observable property of the result | Pin down one thing the spec promises |
 
-      ## Worked Example: WordCounter
+      The pattern generalises; the *specifics* (what to import, call, and assert) come from the spec — and only from the spec.
 
-      Let's build a `WordCounter` class using TDD. We will walk through one full cycle together, then you will continue.
+      ## The dragon dice rules (reference for all 12 cycles)
 
-      ### Cycle 1: Count words in a simple sentence (WORKED EXAMPLE)
+      | Roll | Event | Damage |
+      |------|-------|--------|
+      | Single 1 | Dragon Flame | 100 |
+      | Single 5 | Lightning Spark | 50 |
+      | Triple 1 | Dragon Blast | 1000 |
+      | Triple 2 | Goblin Swarm | 200 |
+      | Triple 3 | Orc Charge | 300 |
+      | Triple 4 | Troll Smash | 400 |
+      | Triple 5 | Lightning Storm | 500 |
+      | Triple 6 | Demon Strike | 600 |
 
-      **RED** — Write a test that describes the behavior we want:
-      ```python
-      # Sub-goal: Define WHAT we want (the interface + expected behavior)
-      def test_count_words_simple():
-          counter = WordCounter()
-          result = counter.count("hello world")
-          assert result == {"hello": 1, "world": 1}
-      ```
-      Run this test — it fails because `WordCounter` does not exist yet. This is the **RED** phase. The failure is expected and correct.
+      Triples consume three dice; leftover 1s and 5s still score as singles. Dice are integers 1–6. **Today you implement only the empty-roll case.** Eleven more cycles add the rest.
 
-      **GREEN** — Write the *minimum* code to make it pass:
-      ```python
-      # Sub-goal: Write just enough code to pass the test
-      class WordCounter:
-          def count(self, text):
-              words = text.split()
-              result = {}
-              for word in words:
-                  result[word] = result.get(word, 0) + 1
-              return result
-      ```
-      Run the test again — it passes. This is the **GREEN** phase.
+      ## Cycle 1's spec
 
-      **REFACTOR** — The code is clean enough for now, so no refactoring needed. All tests still pass.
+      > **An empty roll produces a battle report with zero damage and no events.**
 
-      ### Task
+      That sentence names everything you need: a function `score`, a return value with `total_damage` and `events` attributes. Translate it into a pytest test using the four-part shape.
 
-      Open `test_word_counter.py`. Cycle 1's test is already provided.
+      ## Your task
 
-      1. **SEE RED FIRST:** Click **Run** on `test_word_counter.py` *before writing any code*. You should see the test FAIL with an `ImportError` — this IS the RED phase. The test describes behavior that does not exist yet. This failure is expected and correct.
-      2. **Go GREEN:** Now write the `WordCounter` class in `word_counter.py` to make the test pass. Run again — you should see GREEN.
-      3. **Cycle 2:** Complete `test_count_repeated_words` (partially scaffolded). Run the tests — the new test should FAIL (RED). Then update your implementation if needed to pass it (GREEN).
-      4. **REFACTOR:** After Cycle 2 passes, look at your `count()` method. If you used a manual dictionary loop, try refactoring to use Python's `collections.Counter` — which does the same thing in one line. Run the tests after refactoring to confirm they still pass. This is the REFACTOR phase: improve the code without changing behavior.
-      5. **Cycle 3:** Write `test_count_empty_string` entirely on your own. What should `count("")` return? Decide, write the test, see it fail, then make it pass.
+      1. In **`test_scorer.py`** (right pane), fill in the three sub-goal comments. Leave **`scorer.py`** empty — its code belongs to the GREEN step.
+      2. **Predict** the exact failure message you'll see, then click **Run**.
+      3. Expected output: `ImportError: cannot import name 'score'` (or `ModuleNotFoundError` if `scorer.py` is empty). **That IS the deliverable** — RED for the right reason.
 
-      **Important:** Always run the tests and see RED before writing implementation. If you skip this step, you cannot be sure your test is actually testing something.
+      ## Detail: why a tuple, not a list
 
-      ### Before You Move On (retrieval practice)
+      The empty events case is written as `()` (an empty tuple), not `[]` (an empty list). Tuples are immutable — they can't be mutated by accident, and they're safe dataclass defaults (cycle 2 uses that). Every test in this tutorial that pins down events uses a tuple.
 
-      Close this page. Without looking, answer in one sentence each:
+      ## References
 
-      - What does each of the three TDD phases do, and why is it important to *see RED first*?
-      - Why is TDD called a "design technique" rather than a "testing technique"?
+      - [pytest — Get started](https://docs.pytest.org/en/stable/getting-started.html)
+      - [Python — `assert` statement](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement)
+      - If you get stuck on the test, click **Show Solution** below the editor for one possible form.
+
+      ## Self-test before clicking Next
+
+      Close the page in your head and answer:
+
+      - What two pieces of information does pytest's failure message give you?
+      - Why is "RED for the right reason" worth distinguishing from "RED for any reason"?
+      - If you had to write a test for a `multiply(a, b)` function from scratch, what four parts would it contain?
 
     files:
-      - path: "word_counter.py"
+      - path: "scorer.py"
         content: |
-          # TODO: Implement the WordCounter class here.
-          # It should have a count(text) method that returns
-          # a dictionary of {word: count} for each word in the text.
-        language: "python"
-
-      - path: "test_word_counter.py"
-        content: |
-          """TDD for WordCounter — practice the Red-Green-Refactor rhythm."""
-          import pytest
-          from word_counter import WordCounter
-
-
-          # --- Cycle 1 (test provided — see RED first, then write implementation to go GREEN) ---
-          def test_count_words_simple():
-              """A simple sentence with no repeated words."""
-              counter = WordCounter()
-              result = counter.count("hello world")
-              assert result == {"hello": 1, "world": 1}
-
-
-          # --- Cycle 2 (partially scaffolded — complete the assertion) ---
-          def test_count_repeated_words():
-              """A sentence with repeated words should count each occurrence."""
-              counter = WordCounter()
-              result = counter.count("the cat sat on the mat")
-              # TODO: assert that 'the' appears 2 times and 'cat' appears 1 time
-              # Hint: assert result["the"] == ??? and result["cat"] == ???
-              pass
-
-
-          # --- Cycle 3 (write this test entirely on your own) ---
-          # TODO: Write test_count_empty_string
-          # What should counter.count("") return? Decide, then test it.
-
-
-          if __name__ == "__main__":
-              pytest.main(["-v"])
-        language: "python"
-
-    open_file: "test_word_counter.py"
-    run_file: "test_word_counter.py"
-
-    solution:
-      files:
-        - path: "word_counter.py"
-          content: |
-            class WordCounter:
-                def count(self, text):
-                    if not text.strip():
-                        return {}
-                    words = text.lower().split()
-                    result = {}
-                    for word in words:
-                        result[word] = result.get(word, 0) + 1
-                    return result
-          language: "python"
-        - path: "test_word_counter.py"
-          content: |
-            """TDD for WordCounter — practice the Red-Green-Refactor rhythm."""
-            import pytest
-            from word_counter import WordCounter
-
-
-            def test_count_words_simple():
-                """A simple sentence with no repeated words."""
-                counter = WordCounter()
-                result = counter.count("hello world")
-                assert result == {"hello": 1, "world": 1}
-
-
-            def test_count_repeated_words():
-                """A sentence with repeated words should count each occurrence."""
-                counter = WordCounter()
-                result = counter.count("the cat sat on the mat")
-                assert result["the"] == 2 and result["cat"] == 1
-
-
-            def test_count_empty_string():
-                """An empty string should return an empty dict."""
-                counter = WordCounter()
-                assert counter.count("") == {}
-
-
-            if __name__ == "__main__":
-                pytest.main(["-v"])
-          language: "python"
-      explanation: |
-        Implement WordCounter.count() using a dict to accumulate word frequencies.
-        Complete the assertion in test_count_repeated_words and add test_count_empty_string.
-
-    tests:
-      - description: "WordCounter class exists and is importable"
-        command: |
-          exec(open('/tutorial/word_counter.py').read())
-          assert 'WordCounter' in dir() or 'WordCounter' in open('/tutorial/word_counter.py').read(), \
-              "Define a class called WordCounter in word_counter.py"
-      - description: "test_count_words_simple passes"
-        command: |
-          import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_word_counter.py::test_count_words_simple', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"test_count_words_simple failed:\n{output}"
-      - description: "test_count_repeated_words has a real assertion (not just pass)"
-        command: |
-          source = open('/tutorial/test_word_counter.py').read()
-          func_body = source.split('test_count_repeated_words')[1].split('def ')[0]
-          assert 'assert' in func_body, \
-              "Replace 'pass' in test_count_repeated_words with an assert statement"
-      - description: "test_count_repeated_words passes"
-        command: |
-          import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_word_counter.py::test_count_repeated_words', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"test_count_repeated_words failed:\n{output}"
-      - description: "test_count_empty_string function exists"
-        command: |
-          source = open('/tutorial/test_word_counter.py').read()
-          assert 'def test_count_empty_string' in source, \
-              "Write a test function called test_count_empty_string"
-      - description: "All tests pass"
-        command: |
-          import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_word_counter.py', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"Some tests failed:\n{output}"
-
-    quiz:
-      title: "Red-Green-Refactor — Knowledge Check"
-      min_score: 0.8
-      shuffle: true
-      questions:
-
-        - question: |
-            A student writes five test functions, then starts implementing the code to make them all pass at once. What is wrong with this approach?
-          type: single
-          options:
-            - "Nothing is wrong — writing all tests first gives you a complete specification before you start coding, which mirrors how requirements docs work in waterfall"
-            - "TDD requires writing ONE test at a time. Writing all tests first loses the incremental feedback each cycle provides for guiding design"
-            - "Five tests is too many for one function — each function should have at most two or three well-chosen tests to keep the suite maintainable"
-            - "The tests should be in a separate file from the implementation, but the ordering of writing tests vs code does not affect the final result"
-          correct_index: 1
-          explanation: |
-            TDD's power comes from the rapid feedback loop. Each cycle (one test at a time)
-            tells you something about your design. If you write all tests upfront, you
-            lose this feedback and often end up with tests that don't match the final design.
-
-        - question: |
-            In the GREEN phase, a developer writes optimized, production-ready code. Is this correct?
-          type: single
-          options:
-            - "Yes — you should always write the best possible code since you are already in the flow"
-            - "No — GREEN means writing the MINIMUM code to pass. Optimization belongs in the REFACTOR phase"
-            - "No — the GREEN phase is only for writing comments and docstrings, not implementation"
-            - "Yes — as long as the test passes, writing extra code upfront saves time in later cycles"
-          correct_index: 1
-          explanation: |
-            The GREEN phase is about making the test pass as quickly and simply as possible.
-            Resist the urge to optimize or add features. The REFACTOR phase is where you
-            clean up, remove duplication, and improve the design — with all tests still passing.
-
-        - question: |
-            **Analyze:** A teammate says *"TDD is just a way to write more tests."* How would you correct this?
-          type: single
-          options:
-            - "They are right — TDD's primary goal is increasing test coverage to catch more bugs before release"
-            - "TDD is a design technique: writing the test first forces you to define the interface and behavior before implementation"
-            - "TDD actually reduces the number of tests by focusing on only the most critical paths through the code"
-            - "TDD is primarily a refactoring technique — the tests are just a safety net for the refactoring phase"
-          correct_index: 1
-          explanation: |
-            This is the threshold concept in TDD: it is a design technique, not a testing technique.
-            The test forces you to think about the public interface (how will I call this?)
-            and expected behavior (what should it return?) before you write any implementation.
-            This produces better-designed, more modular code as a natural consequence.
-
-        - question: |
-            What is the correct order of the TDD cycle?
-          type: single
-          options:
-            - "Green → Red → Refactor"
-            - "Refactor → Red → Green"
-            - "Red → Green → Refactor"
-            - "Red → Refactor → Green"
-          correct_index: 2
-          explanation: |
-            RED (write a failing test) → GREEN (write minimum code to pass) → REFACTOR (clean up).
-            The order matters: you must see the test fail first to confirm it is testing something real.
-            If a test passes immediately, it is not testing new behavior — this is the "Success Against
-            All Odds" anti-pattern.
-
-        - question: |
-            **(Spaced review — Foundations Step 4)** A refactor breaks two of your tests, but the function's inputs and outputs are unchanged. What is the most likely diagnosis?
-          type: single
-          options:
-            - "The refactor introduced a subtle output bug — revert it and investigate"
-            - "The broken tests are coupled to implementation details (e.g., private attributes). They should be rewritten to assert on observable behavior"
-            - "You should lower the assertion precision to accommodate the refactor"
-            - "Refactoring is incompatible with TDD — only add new code, never restructure existing code"
-          correct_index: 1
-          explanation: |
-            If behavior is unchanged but tests break, the tests were testing *how* the function
-            works (implementation details) rather than *what* it produces (behavior). This is
-            the *Refactoring Litmus Test* from Foundations: robust tests survive pure
-            refactorings; brittle tests don't.
-
-
-  # --------------------------------------------------------------------------
-  # STEP 2 — TDD Kata: FizzBuzz
-  # Pedagogy:
-  #   PPP Framework      — Presentation → Practice → Production via fading.
-  #   Fading             — 4 cycles with decreasing scaffolding.
-  #   Refactoring Litmus — refactor with alternative implementation; tests still pass.
-  #   Bloom's level      — Apply / Analyze.
-  # --------------------------------------------------------------------------
-  - title: "TDD Kata: FizzBuzz"
-    instructions: |
-      > **Learning objective:** After this step you will be able to **apply** the Red-Green-Refactor cycle independently across multiple iterations with fading scaffolding.
-
-      ## The FizzBuzz Kata
-
-      A "kata" is a small, focused exercise designed to practice the TDD rhythm. We will build the classic FizzBuzz function using **four TDD cycles**, with the scaffolding fading at each step:
-
-      **FizzBuzz rules:**
-      - If divisible by 3 → return `"Fizz"`
-      - If divisible by 5 → return `"Buzz"`
-      - If divisible by both 3 and 5 → return `"FizzBuzz"`
-      - Otherwise → return the number as a string (e.g., `"1"`, `"2"`)
-
-      ### Cycle 1: Regular numbers (FULL WORKED EXAMPLE)
-
-      The first test and implementation are **provided for you**. Study how the cycle works:
-
-      **RED:** `test_returns_number_as_string` checks that `fizzbuzz(1)` returns `"1"` and `fizzbuzz(2)` returns `"2"`.
-
-      **GREEN:** The simplest implementation is `return str(number)`.
-
-      **REFACTOR:** Nothing to refactor yet.
-
-      Run the tests to confirm Cycle 1 passes (GREEN).
-
-      **Self-check:** Why does the Cycle 1 implementation use `return str(number)` instead of a more complete solution? What TDD principle does this follow? (Answer: the GREEN phase requires writing the *minimum* code to pass the current test. We do not add logic for requirements that have no test yet.)
-
-      ### Cycle 2: Fizz (PARTIAL SCAFFOLD)
-
-      The test `test_fizz_for_multiples_of_3` is written for you. Your job:
-      1. Run the tests — you should see this new test **FAIL** (RED)
-      2. Modify `fizzbuzz()` in `fizzbuzz.py` to make it pass (GREEN)
-      3. Refactor if needed
-
-      ### Cycle 3: Buzz (HINT ONLY)
-
-      Write `test_buzz_for_multiples_of_5` yourself. The function signature is provided — fill in the assertions. **Run the tests and see RED first**, then write the implementation to go GREEN.
-
-      ### Cycle 4: FizzBuzz (INDEPENDENT)
-
-      Write `test_fizzbuzz_for_multiples_of_15` and the corresponding implementation entirely on your own. Full TDD cycle, no scaffolding. **Start with the test. See RED. Then go GREEN.**
-
-      ### Bonus Refactor: The Litmus Test
-
-      Once all four cycles pass, try a **different implementation** of the same function — for example, string concatenation instead of `if/elif`:
-
-      ```python
-      def fizzbuzz(number):
-          result = ""
-          if number % 3 == 0:
-              result += "Fizz"
-          if number % 5 == 0:
-              result += "Buzz"
-          return result or str(number)
-      ```
-
-      Replace your implementation with this one and re-run the tests. **All four tests should still pass.** This is the *Refactoring Litmus Test* from Foundations Step 4: robust tests verify behavior, so they survive a full rewrite of the internals. If your tests had asserted on anything specific to the `if/elif` implementation, they would have broken.
-
-      **Remember the rhythm:** RED (see it fail) → GREEN (make it pass) → REFACTOR (clean up).
-
-      ### Before You Move On (retrieval practice)
-
-      Without looking, explain in one sentence each:
-
-      - Why do we check divisibility by 15 *before* 3 or 5 in the `if/elif` version?
-      - What does it mean if a pure refactor (same behavior, different code) breaks a test?
-
-    files:
-      - path: "fizzbuzz.py"
-        content: |
-          def fizzbuzz(number):
-              """Return FizzBuzz result for the given number.
-
-              Rules:
-              - Divisible by 3 -> "Fizz"
-              - Divisible by 5 -> "Buzz"
-              - Divisible by both 3 and 5 -> "FizzBuzz"
-              - Otherwise -> the number as a string
-              """
-              # TODO: Add Fizz/Buzz/FizzBuzz logic ABOVE the return below.
-              # Each cycle should add a new condition.
-              return str(number)
-        language: "python"
-
-      - path: "test_fizzbuzz.py"
-        content: |
-          """TDD Kata: FizzBuzz — practice the rhythm with fading scaffolding."""
-          import pytest
-          from fizzbuzz import fizzbuzz
-
-
-          # --- Cycle 1 (FULL WORKED EXAMPLE — provided) ---
-          def test_returns_number_as_string():
-              assert fizzbuzz(1) == "1"
-              assert fizzbuzz(2) == "2"
-              assert fizzbuzz(4) == "4"
-
-
-          # --- Cycle 2 (PARTIAL SCAFFOLD — test provided, write the implementation) ---
-          def test_fizz_for_multiples_of_3():
-              assert fizzbuzz(3) == "Fizz"
-              assert fizzbuzz(6) == "Fizz"
-              assert fizzbuzz(9) == "Fizz"
-
-
-          # --- Cycle 3 (HINT ONLY — write the assertions and implementation) ---
-          def test_buzz_for_multiples_of_5():
-              # TODO: assert that fizzbuzz(5), fizzbuzz(10), fizzbuzz(20)
-              # all return "Buzz"
-              pass
-
-
-          # --- Cycle 4 (INDEPENDENT — write this test from scratch) ---
-          # TODO: Write test_fizzbuzz_for_multiples_of_15
-          # Test that fizzbuzz(15), fizzbuzz(30), fizzbuzz(45) return "FizzBuzz"
-          # Then update fizzbuzz.py to make it pass.
-          # Hint: If using if/elif, check divisibility by 15 BEFORE 3 or 5. Why?
-
-
-          if __name__ == "__main__":
-              pytest.main(["-v"])
-        language: "python"
-
-    open_file: "test_fizzbuzz.py"
-    run_file: "test_fizzbuzz.py"
-
-    solution:
-      files:
-        - path: "fizzbuzz.py"
-          content: |
-            def fizzbuzz(number):
-                """Return FizzBuzz result for the given number."""
-                if number % 15 == 0:
-                    return "FizzBuzz"
-                if number % 3 == 0:
-                    return "Fizz"
-                if number % 5 == 0:
-                    return "Buzz"
-                return str(number)
-          language: "python"
-        - path: "test_fizzbuzz.py"
-          content: |
-            """TDD Kata: FizzBuzz — practice the rhythm with fading scaffolding."""
-            import pytest
-            from fizzbuzz import fizzbuzz
-
-
-            def test_returns_number_as_string():
-                assert fizzbuzz(1) == "1"
-                assert fizzbuzz(2) == "2"
-                assert fizzbuzz(4) == "4"
-
-
-            def test_fizz_for_multiples_of_3():
-                assert fizzbuzz(3) == "Fizz"
-                assert fizzbuzz(6) == "Fizz"
-                assert fizzbuzz(9) == "Fizz"
-
-
-            def test_buzz_for_multiples_of_5():
-                assert fizzbuzz(5) == "Buzz"
-                assert fizzbuzz(10) == "Buzz"
-                assert fizzbuzz(20) == "Buzz"
-
-
-            def test_fizzbuzz_for_multiples_of_15():
-                assert fizzbuzz(15) == "FizzBuzz"
-                assert fizzbuzz(30) == "FizzBuzz"
-                assert fizzbuzz(45) == "FizzBuzz"
-
-
-            if __name__ == "__main__":
-                pytest.main(["-v"])
-          language: "python"
-      explanation: |
-        Check divisibility by 15 first, then 3, then 5. Complete cycles 3 and 4
-        by adding real assertions and the test_fizzbuzz_for_multiples_of_15 function.
-
-    tests:
-      - description: "Cycle 1 passes — regular numbers return as strings"
-        command: |
-          import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_fizzbuzz.py::test_returns_number_as_string', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"Cycle 1 failed:\n{output}"
-      - description: "Cycle 2 passes — multiples of 3 return 'Fizz'"
-        command: |
-          import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_fizzbuzz.py::test_fizz_for_multiples_of_3', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"Cycle 2 failed:\n{output}"
-      - description: "Cycle 3 — test_buzz_for_multiples_of_5 has real assertions"
-        command: |
-          source = open('/tutorial/test_fizzbuzz.py').read()
-          func_body = source.split('test_buzz_for_multiples_of_5')[1].split('def ')[0]
-          assert 'assert' in func_body, \
-              "Replace 'pass' in test_buzz_for_multiples_of_5 with assert statements"
-      - description: "Cycle 3 passes — multiples of 5 return 'Buzz'"
-        command: |
-          import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_fizzbuzz.py::test_buzz_for_multiples_of_5', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"Cycle 3 failed:\n{output}"
-      - description: "Cycle 4 — test_fizzbuzz_for_multiples_of_15 exists"
-        command: |
-          source = open('/tutorial/test_fizzbuzz.py').read()
-          assert 'def test_fizzbuzz_for_multiples_of_15' in source, \
-              "Write a test function called test_fizzbuzz_for_multiples_of_15"
-      - description: "Cycle 4 passes — multiples of 15 return 'FizzBuzz'"
-        command: |
-          import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_fizzbuzz.py::test_fizzbuzz_for_multiples_of_15', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"Cycle 4 failed:\n{output}"
-      - description: "All FizzBuzz tests pass together"
-        command: |
-          import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_fizzbuzz.py', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"Some tests failed:\n{output}"
-
-    quiz:
-      title: "TDD Kata — Knowledge Check"
-      min_score: 0.8
-      shuffle: true
-      questions:
-
-        - question: |
-            Why do we add one test at a time instead of writing all four FizzBuzz tests upfront?
-          type: single
-          options:
-            - "Writing fewer tests at a time reduces the total number of tests you need to maintain"
-            - "Each test drives a small, incremental design decision. Writing all tests first loses the feedback each cycle provides"
-            - "pytest can only discover and execute one test function per run, so you must add them sequentially"
-            - "It does not matter — both approaches produce the same code and the same test suite"
-          correct_index: 1
-          explanation: |
-            Incremental test-writing is the heart of TDD. Each test cycle gives you feedback:
-            "Does this design still work? Do I need to refactor?" Writing all tests first
-            is essentially waterfall planning disguised as TDD.
-
-        - question: |
-            You write a new test and run it. It **passes immediately** without you changing any code. What should you do?
-          type: single
-          options:
-            - "Celebrate — your existing code already handles this case, so you are ahead of schedule and can move to the next feature"
-            - "Be suspicious — a test that passes without new code may not be testing anything meaningful. Verify it checks real behavior"
-            - "Delete the test immediately since it is clearly redundant — keeping it would slow down future test runs without adding safety"
-            - "Move on to the next test — a passing test always indicates correct behavior, and questioning it wastes time"
-          correct_index: 1
-          explanation: |
-            If a test passes immediately, it means one of two things: (1) the behavior was
-            already implemented by a previous cycle (which is fine — but verify), or (2) the
-            test is not actually testing what you think. Always see RED first to confirm the
-            test is meaningful.
-
-        - question: |
-            If you use `if/elif` to implement FizzBuzz, why should you check divisibility by 15 **before** checking 3 or 5?
-          type: single
-          options:
-            - "15 is a larger number — Python convention is to order conditionals from largest to smallest"
-            - "15 is divisible by both 3 and 5, so checking 3 first returns 'Fizz' instead of 'FizzBuzz' — the first matching branch wins"
-            - "Python evaluates if/elif branches in parallel, so the most specific condition must come first for performance"
-            - "The order does not matter — Python's `elif` evaluates all branches and picks the most specific match"
-          correct_index: 1
-          explanation: |
-            With `if/elif`, the first matching branch executes and the rest are skipped. Since
-            15 is divisible by both 3 and 5, checking `if number % 3 == 0` first would return
-            "Fizz" and never reach the 15 check. The most specific condition must come first.
-
-        - question: |
-            **(Spaced review — Foundations Step 2)** A test function is named `def check_fizzbuzz():`. Will pytest discover and run it?
-          type: single
-          options:
-            - "Yes — pytest runs all functions in test files"
-            - "No — pytest only discovers functions whose names start with `test_`"
-            - "Yes — but only if you pass the function name explicitly"
-            - "No — pytest requires class-based tests"
-          correct_index: 1
-          explanation: |
-            pytest auto-discovers functions starting with `test_`. A function named
-            `check_fizzbuzz` would be silently ignored — a common mistake that leads
-            to tests never running without the developer realizing it.
-
-
-  # --------------------------------------------------------------------------
-  # STEP 3 — TDD Kata: Password Validator
-  # Pedagogy:
-  #   Production phase    — PPP framework, full scaffolding removal.
-  #   Generation Effect   — desirable difficulty, blank slate.
-  #   Invalid-input       — explicit requirement for non-string test (boundary hygiene).
-  #   parametrize         — refactor duplication as "listen to the test".
-  #   Bloom's level       — Apply / Create / Evaluate.
-  # --------------------------------------------------------------------------
-  - title: "TDD Kata: Password Validator"
-    instructions: |
-      > **Learning objective:** After this step you will be able to **independently apply** the full TDD cycle — writing tests first, then implementation — for a new problem, including boundary and invalid-input cases.
-
-      ## The Production Phase
-
-      This is the real test of your TDD skills. You will receive **requirements** and a minimal scaffold — a stub function and one example test. The rest is up to you.
-
-      ## Requirements: `validate_password(password)`
-
-      Build a function that validates passwords. It should return a tuple: `(is_valid, message)`.
-
-      | Rule | Valid Example | Invalid Example |
-      |------|--------------|-----------------|
-      | At least 8 characters | `"SecureP1"` | `"Short1"` |
-      | Contains at least one uppercase letter | `"Password1"` | `"password1"` |
-      | Contains at least one digit | `"Password1"` | `"Password"` |
-
-      **Return values:**
-      - Valid: `(True, "Valid")`
-      - Invalid: `(False, "<reason>")` — e.g., `(False, "Password must be at least 8 characters")`
-
-      ## Your TDD Workflow
-
-      The first test (`test_valid_password`) is provided as scaffolding. Your job:
-
-      1. **Write at least 4 more test functions** in `test_password.py`:
-         - One per validation rule (too-short, missing-uppercase, missing-digit) — **3 tests**
-         - At least **one test for an invalid input type** — e.g., `None`, an integer, or a non-string. This is the "invalid-input partition" from Foundations Step 3.
-      2. **Run tests** — they should all FAIL (RED) since `password.py` only has a stub
-      3. **Implement `validate_password()`** in `password.py` to make tests pass (GREEN). You will need to decide how `validate_password` should behave when given a non-string input — either return `(False, "Invalid input")` or raise a `TypeError`. Be consistent.
-      4. **Refactor** if needed
-
-      ### If You Feel Stuck
-
-      That is completely normal. Writing tests for something that does not exist yet feels backward at first. Every TDD practitioner felt this way initially. Focus on what the function *should return* for each input — that is all a test needs to express.
-
-      **Remember:** Write the tests *before* the implementation. This forces you to design the interface (function name, parameters, return type) before writing any logic.
-
-      ### Bonus Refactor: Listen to the Test
-
-      Once your 5+ tests pass, look at them. Do the *rule* tests (too-short, missing-uppercase, missing-digit, extra valid examples) all look nearly identical — same shape, only the input string and expected outcome differ? That **duplication in your test file is itself diagnostic feedback**: it is the *Copy-Paste Programming* anti-pattern, and pytest gives you a one-liner fix called `@pytest.mark.parametrize`:
-
-      ```python
-      @pytest.mark.parametrize("password, expected_valid", [
-          ("SecureP1",   True),   # happy path
-          ("Short1",     False),  # too short
-          ("password1",  False),  # missing uppercase
-          ("Password",   False),  # missing digit
-      ])
-      def test_validate_password(password, expected_valid):
-          is_valid, _ = validate_password(password)
-          assert is_valid is expected_valid
-      ```
-
-      One test function now covers four cases, each one reported separately by pytest. Adding a fifth rule means adding *one row*, not copy-pasting an entire function. **This is a refactor of the test code — the production code does not change, and your existing tests should still pass after the rewrite.**
-
-      Keep the invalid-input test as a separate function — it has a different shape (different assertion structure if it uses `pytest.raises`) and parametrizing it together with the rule tests would just muddle both.
-
-      ### Before You Move On (retrieval practice)
-
-      Without looking: why is the invalid-input partition important to test even when your user-facing form would never send that kind of data? What kind of bug are you hunting for?
-
-    files:
-      - path: "password.py"
-        content: |
-          def validate_password(password):
-              """Validate a password against security rules.
-
-              Returns:
-                  (True, "Valid") if all rules pass.
-                  (False, "reason") if a rule is violated.
-              """
-              # TODO: Replace this stub with real validation logic.
-              # Remember: decide what should happen for non-string inputs.
-              return (False, "Not implemented")
-        language: "python"
-
-      - path: "test_password.py"
-        content: |
-          """TDD Kata: Password Validator — write your tests FIRST."""
-          import pytest
-          from password import validate_password
-
-
-          # Here is the first test as an example (the "happy path"):
-          def test_valid_password():
-              is_valid, message = validate_password("SecureP1")
-              assert is_valid is True
-              assert message == "Valid"
-
-
-          # TODO: Write at least 4 more test functions below.
-          # Each test should check ONE rule or invalid case:
+          # Cycle 1 RED phase — DO NOT WRITE PRODUCTION CODE HERE YET.
           #
-          # def test_rejects_short_password():   ...
-          # def test_rejects_missing_uppercase(): ...
-          # def test_rejects_missing_digit():    ...
-          # def test_rejects_invalid_type():     # e.g., None, 42, ["Password1"]
-
-
-          if __name__ == "__main__":
-              pytest.main(["-v"])
+          # The next tutorial step (Cycle 1 GREEN) is where the BattleReport
+          # class and the score function are introduced. Right now we are
+          # only writing the failing test on the right.
         language: "python"
 
-    open_file: "test_password.py"
-    run_file: "test_password.py"
+      - path: "test_scorer.py"
+        content: |
+          """Cycle 1 RED — write the first failing test.
+
+          The sub-goals below describe the PURPOSE of each line you need to add,
+          not the syntax. Translate the spec ("an empty roll has no damage and no
+          events") into pytest assertions yourself. If you get stuck, consult the
+          rules table and the references in the instructions panel.
+          """
+          from scorer import score
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              # Sub-goal: call the unit under test on the simplest input the spec mentions
+              #           — and capture the result so the next two lines can inspect it.
+
+              # Sub-goal: pin down what the spec says about damage in this case.
+
+              # Sub-goal: pin down what the spec says about events in this case.
+              pass
+        language: "python"
+
+    open_file: "test_scorer.py"
+    run_file: "test_scorer.py"
 
     solution:
       files:
-        - path: "password.py"
+        - path: "scorer.py"
           content: |
-            def validate_password(password):
-                """Validate a password against security rules.
-
-                Returns:
-                    (True, "Valid") if all rules pass.
-                    (False, "reason") if a rule is violated or input is not a string.
-                """
-                if not isinstance(password, str):
-                    return (False, "Invalid input: password must be a string")
-                if len(password) < 8:
-                    return (False, "Too short")
-                if not any(c.isupper() for c in password):
-                    return (False, "Missing uppercase letter")
-                if not any(c.isdigit() for c in password):
-                    return (False, "Missing digit")
-                return (True, "Valid")
+            # Cycle 1 RED phase — DO NOT WRITE PRODUCTION CODE HERE YET.
           language: "python"
-        - path: "test_password.py"
+
+        - path: "test_scorer.py"
           content: |
-            """TDD Kata: Password Validator — tests written first."""
-            import pytest
-            from password import validate_password
+            """Cycle 1 RED — first failing test."""
+            from scorer import score
 
 
-            def test_valid_password():
-                is_valid, message = validate_password("SecureP1")
-                assert is_valid is True
-                assert message == "Valid"
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
 
-
-            def test_rejects_short_password():
-                is_valid, message = validate_password("Short1")
-                assert is_valid is False
-
-
-            def test_rejects_missing_uppercase():
-                is_valid, message = validate_password("password1")
-                assert is_valid is False
-
-
-            def test_rejects_missing_digit():
-                is_valid, message = validate_password("Password")
-                assert is_valid is False
-
-
-            def test_rejects_invalid_type():
-                is_valid, _ = validate_password(None)
-                assert is_valid is False
-
-
-            if __name__ == "__main__":
-                pytest.main(["-v"])
+                assert report.total_damage == 0
+                assert report.events == ()
           language: "python"
       explanation: |
-        Guard against non-string inputs first with `isinstance`, then check length, uppercase,
-        and digit rules in order. Write all 4 additional test functions (including the
-        invalid-type test) before implementing — that is the TDD discipline.
+        The RED step has exactly one job: write a test that describes a behavior that
+        does not yet exist. The implementation is intentionally empty so that pytest
+        fails with an ImportError. That import error is the deliverable.
 
     tests:
-      - description: "test_password.py contains at least 5 test functions (rules + invalid input)"
+      - description: "test_empty_roll_has_zero_damage_and_no_events function exists"
         command: |
-          source = open('/tutorial/test_password.py').read()
-          test_count = source.count('def test_')
-          assert test_count >= 5, \
-              f"Write at least 5 test functions (found {test_count}). You need: valid password, too-short, missing uppercase, missing digit, AND one invalid-input type test."
-      - description: "At least one test exercises a non-string (invalid-input partition)"
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_empty_roll_has_zero_damage_and_no_events' in source, \
+              "Define a test function called test_empty_roll_has_zero_damage_and_no_events in test_scorer.py"
+
+      - description: "Test asserts on report.total_damage == 0 (the observable oracle)"
         command: |
-          source = open('/tutorial/test_password.py').read()
           import re
-          # Strip comments so `validate_password(None)` in a `#` comment doesn't count.
-          code_only = re.sub(r'#.*', '', source)
-          non_string_args = ['(None', '(42', '(123', '([', '({', '(b"', "(b'"]
-          assert any(arg in code_only for arg in non_string_args), \
-              "Add a test that calls validate_password with a non-string argument (e.g., None, 42, or a list)"
-      - description: "validate_password function exists"
+          source = open('/tutorial/test_scorer.py').read()
+          # Strip Python line comments so the TODO hints in the scaffold don't satisfy the check.
+          code_only = re.sub(r'#.*', '', source).replace(' ', '')
+          assert 'total_damage==0' in code_only, \
+              "The test body must contain `assert report.total_damage == 0` — replace the TODO comment with the real assertion"
+
+      - description: "Test asserts on report.events == () (no events)"
         command: |
-          source = open('/tutorial/password.py').read()
-          assert 'def validate_password' in source, \
-              "Implement the validate_password function in password.py"
-      - description: "All student tests pass"
+          import re
+          source = open('/tutorial/test_scorer.py').read()
+          code_only = re.sub(r'#.*', '', source).replace(' ', '')
+          assert 'events==()' in code_only, \
+              "The test body must contain `assert report.events == ()` — an empty tuple, not a list and not None. Replace the TODO comment with the real assertion."
+
+      - description: "Implementation is still empty (RED phase requires no production code)"
+        command: |
+          impl = open('/tutorial/scorer.py').read()
+          assert 'class BattleReport' not in impl and 'def score' not in impl, \
+              "Cycle 1 RED requires that scorer.py has NO BattleReport class and NO score function yet — that comes in the next step (Cycle 1 GREEN). Move any implementation code there."
+
+      - description: "Running pytest shows RED for the right reason (ImportError or similar)"
         command: |
           import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_password.py', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"Your tests failed:\n{output}"
-      - description: "Valid passwords are accepted"
-        command: |
-          exec(open('/tutorial/password.py').read())
-          result = validate_password("SecureP1")
-          assert result[0] is True, f"Expected (True, ...) for 'SecureP1', got {result}"
-      - description: "Too-short passwords are rejected"
-        command: |
-          exec(open('/tutorial/password.py').read())
-          result = validate_password("Short1")
-          assert result[0] is False, f"Expected (False, ...) for 'Short1', got {result}"
-      - description: "Passwords without uppercase are rejected"
-        command: |
-          exec(open('/tutorial/password.py').read())
-          result = validate_password("password1")
-          assert result[0] is False, f"Expected (False, ...) for 'password1', got {result}"
-      - description: "Passwords without digits are rejected"
-        command: |
-          exec(open('/tutorial/password.py').read())
-          result = validate_password("Password")
-          assert result[0] is False, f"Expected (False, ...) for 'Password', got {result}"
-      - description: "Non-string input is handled (returns False or raises)"
-        command: |
-          exec(open('/tutorial/password.py').read())
-          try:
-              result = validate_password(None)
-              assert result[0] is False, \
-                  f"Expected (False, ...) or a raised exception for None, got {result}"
-          except (TypeError, ValueError, AttributeError):
-              pass  # raising is also an acceptable contract
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code != 0, \
+              f"In the RED phase, pytest should FAIL — but it passed. Did you accidentally implement something in scorer.py? Move that to the next step.\n{output}"
+          right_reason = any(token in output for token in [
+              'ImportError', 'ModuleNotFoundError', 'cannot import name',
+              'NameError', 'AttributeError', 'has no attribute',
+              'collection error',
+          ])
+          assert right_reason, \
+              f"The test failed, but not for the expected reason. RED-for-the-right-reason in this step means an ImportError (or similar) because the score function does not exist yet. Got:\n{output}"
 
-    quiz:
-      title: "Independent TDD — Knowledge Check"
-      min_score: 0.8
-      shuffle: true
-      questions:
-
-        - question: |
-            A student's test for the password validator looks like this:
-            ```python
-            def test_password():
-                assert validate_password("SecureP1") == (True, "Valid")
-                assert validate_password("short") == (False, "Password must be at least 8 characters")
-                assert validate_password("nouppercase1") == (False, "Password must contain an uppercase letter")
-                assert validate_password("NoDigits") == (False, "Password must contain a digit")
-            ```
-            What is the problem with this approach?
-          type: single
-          options:
-            - "Nothing — grouping related assertions keeps the suite compact, and pytest shows the line number of the failure so you can find it easily"
-            - "All four assertions are in one function. If the first fails, the rest never run — hiding failures. Each rule should be its own function"
-            - "The test is too long — each assertion should use a helper function to reduce duplication and improve the overall readability of the test suite"
-            - "The function name `test_password` is too generic — renaming it to something like `test_all_password_rules` would fix the issue"
-          correct_index: 1
-          explanation: |
-            Each `assert` should be in its own test function so you can see exactly which
-            rule failed. If `test_password()` fails on line 2, you don't know if lines 3 and 4
-            would also fail.
-
-        - question: |
-            You are writing a test for a new feature, but you find it very difficult to set up the test — you need to create five objects and configure them just to call one function. What does this difficulty tell you?
-          type: single
-          options:
-            - "Testing is inherently hard for complex features — invest the setup time because the safety net is worth the effort in the long run"
-            - "The difficulty is diagnostic: the function is too tightly coupled. 'Listen to the test' — simplify the design to make testing easier"
-            - "Skip the test for this function and document the expected behavior in detailed comments and docstrings instead"
-            - "Use mocking and dependency injection to isolate the function from its five dependencies, leaving the design unchanged"
-          correct_index: 1
-          explanation: |
-            This is the "listen to the test" principle. When a test is hard to write, the
-            function's design is often the problem. TDD uses this pain as architectural
-            feedback — simplify the design, and the test becomes easy.
-
-        - question: |
-            Why should an "invalid input type" test (e.g., `validate_password(None)`) be part of your suite, even if your form's UI would never pass a non-string?
-          type: single
-          options:
-            - "It should not be — testing inputs that the UI would never send is a waste of time and bloats the suite"
-            - "Because the function is a public API: callers other than the form (future endpoints, admin scripts, test helpers) may pass non-strings, and the function's contract must be defensive"
-            - "Because pytest requires every function to have an edge-case test for the linter to pass"
-            - "Because non-string inputs are the only way to hit the 100% coverage threshold Python enforces"
-          correct_index: 1
-          explanation: |
-            A validator is a reusable component. Its callers change over time — today it is
-            wired to one HTML form, tomorrow it is imported by a new REST endpoint or a CLI
-            tool. The test pins down the *contract* for invalid inputs so future callers
-            cannot assume string-ness is pre-validated. This is the "invalid-input partition"
-            from Foundations Step 3 applied to API design.
-
-        - question: |
-            **(Spaced review — Foundations Step 1)** A PM says: *"We have 95% test coverage, so we can skip manual QA for this release."* What is wrong with this reasoning?
-          type: single
-          options:
-            - "95% is too low — you need 100% line coverage to have confidence that every behavior is verified and QA can be skipped"
-            - "Coverage measures which lines were executed, not whether assertions are meaningful — tests can cover code without verifying behavior"
-            - "Manual QA is always required regardless of coverage, because automated tests and human testers catch fundamentally different issues"
-            - "Nothing is wrong — 95% coverage statistically guarantees that fewer than 5% of behaviors contain bugs"
-          correct_index: 1
-          explanation: |
-            High coverage does not mean high quality. A test that executes a function but
-            only asserts `True` covers the code but verifies nothing. Tests show the
-            presence of bugs, never their absence.
-
-        - question: |
-            A student has six tests for `validate_password` that look like this:
-            ```python
-            def test_short():        assert validate_password("Short1")[0]   is False
-            def test_no_upper():     assert validate_password("password1")[0] is False
-            def test_no_digit():     assert validate_password("Password")[0]  is False
-            def test_too_long():     assert validate_password("A1" * 50)[0]   is False
-            def test_only_symbols(): assert validate_password("!@#$%^&*")[0]  is False
-            def test_empty():        assert validate_password("")[0]          is False
-            ```
-            What is the **best** refactor?
-          type: single
-          options:
-            - "Combine all six tests into one function with six asserts — the file becomes shorter and pytest only has to call setup once"
-            - "Use `@pytest.mark.parametrize` to drive a single test function with six rows — keeps each case isolated in pytest reports while removing duplication"
-            - "Leave it as is — six separate tests is the cleanest possible expression of six independent behaviors and any change adds complexity"
-            - "Move the strings into a module-level list and write a `for` loop inside one test function that asserts each one in sequence"
-          correct_index: 1
-          explanation: |
-            `@pytest.mark.parametrize` is the idiomatic Python solution to *Copy-Paste*
-            test code. Each row still produces a separate pytest result, so a failure on row 3
-            tells you exactly which input broke — unlike a single test with a `for` loop, where
-            the first failure stops the rest.
+    # NO QUIZ — the user lives the rhythm first; the first knowledge check
+    # comes after the REFACTOR step (the next-next step).
 
 
   # --------------------------------------------------------------------------
-  # STEP 4 — TDD with AI Assistants
+  # STEP 2 — Cycle 1 GREEN: smallest code that passes
   # Pedagogy:
-  #   AI-Critical Pedagogy — students must AUDIT, not accept, AI-generated tests.
-  #   Generation Effect    — analyze flawed code before being told what is wrong.
-  #   Anti-pattern naming  — Liar test, Modify-the-Test, Mockery, tautology.
-  #   Prompt Problem       — write a clear test specification that constrains the AI.
-  #   Bloom's level        — Analyze / Evaluate / Create.
+  #   Worked example       — full GREEN code shown, with subgoal labels.
+  #   Transformation Priority Premise — start at "constant" before "variable".
+  #   Misconception fix    — GREEN means MINIMAL, not "production-ready".
+  #   Cognitive load       — frozen dataclass, @property, default tuple — each
+  #                          element labeled separately so they don't collide.
   # --------------------------------------------------------------------------
-  - title: "TDD with AI Assistants"
+  - title: "Cycle 1 — GREEN: Make It Pass"
     instructions: |
-      > **Learning objective:** After this step you will be able to **audit** AI-generated tests for common anti-patterns, **refactor** them into robust tests, and **explain** why test-first thinking is *more* important when working with an AI, not less.
+      > **The GREEN rule:** write the **smallest** code that makes the failing test pass. Anything more is *speculative design* — code with no test demanding it.
 
-      ## Why This Step Matters
+      ## The test is your contract
 
-      You will use AI coding assistants in your career. Empirical research on novice developers using GenAI for testing reports a worrying pattern: novices ran AI-generated tests on average **2 times** before moving on, while running their own manual tests **6 times** — a sign that they trusted the AI's output without verifying it. The same study found novices spent **21.5 minutes** refactoring AI-generated tests vs. **3.3 minutes** for experienced developers, because the underlying understanding gap remained.
+      Every line of the test is an obligation your code must satisfy:
 
-      The lesson: **AI accelerates typing, not thinking.** TDD is the discipline that keeps the thinking yours.
+      | Line of the test | What your code must provide |
+      |---|---|
+      | `from scorer import score` | A `score` name in `scorer.py` |
+      | `report = score([])` | `score` returns *something* |
+      | `assert report.total_damage == 0` | That something exposes `total_damage`, equal to `0` |
+      | `assert report.events == ()` | …and `events`, equal to `()` |
 
-      ## The Two AI-Specific Anti-Patterns
+      Four obligations. Anything you write that does not contribute to one of those four is speculative design — it has no test demanding it, so it has no test guarding it, so it has no business being there yet.
 
-      ### 1. The "Modify the Test" Anti-Pattern
+      ## Three Python tools the scaffold uses
 
-      When an AI agent runs a failing test and is told to make it pass, it has *two* ways to do that:
-      - Fix the production code (correct)
-      - **Change the test** so it asserts whatever the broken code happens to return (wrong)
+      Three building blocks you'll need. None are TDD-specific — they're standard Python tools you'll reach for many times.
 
-      A 2025 industrial case study explicitly warned: when an AI was given autonomy over both test and implementation, it sometimes *"optimized the test result by modifying the test instead of fixing the implementation code."* Novices trusted this and shipped broken behavior.
+      - **`@dataclass`** auto-writes `__init__`, `__repr__`, and `__eq__` from your field declarations. You write the field names and types; Python writes the bookkeeping. The auto-generated `__eq__` is what makes `assert report.events == (...)` work field-by-field. ([docs](https://docs.python.org/3/library/dataclasses.html))
+      - **`frozen=True`** added to `@dataclass(frozen=True)` makes instances immutable — fields can't be reassigned after construction. Frozen dataclasses are also hashable. We rely on this in cycle 2, where test assertions compare tuples of `ScoringEvent` instances. ([docs](https://docs.python.org/3/library/dataclasses.html#frozen-instances))
+      - **`@property`** turns a method into an attribute read. Calling sites use `report.total_damage` (no parens) but Python runs the function body each time. The test reads `total_damage` like a field; the `@property` decorator keeps that grammar consistent. ([docs](https://docs.python.org/3/library/functions.html#property))
 
-      **Your defense:** *You* write the test. The AI may write the implementation, but the test is the contract — you must own it.
+      ## The Transformation Priority Premise — why "smallest" beats "best"
 
-      ### 2. The Liar Test (Tautology)
+      Robert Martin's TPP lists code transformations from simplest to most complex: nothing → constant → variable → conditional → loop. The rule: always pick the *simpler* transformation that passes the current failing test, even when you "know" a more general one is coming.
 
-      An AI under pressure to "make it pass" will sometimes generate tests that are *vacuously true*:
-      ```python
-      def test_calculate_tax():
-          tax = calculate_tax(100, 0.10)
-          assert tax == tax            # tautology — always True
-          assert isinstance(tax, (int, float))  # type check, not behavior
-      ```
-      This passes. It tests nothing. The fix is the same as Foundations Step 2: assert on the **observable behavior** (`assert tax == 10.0`), not on shape or self-equality.
+      For cycle 1, the test only mentions the empty case. You do not need a loop yet — the empty-tuple default already produces 0 damage. The loop arrives when a test (cycle 4) actually demands it.
 
-      ## Your Task: Audit and Refactor
+      ## Your task
 
-      A junior developer used a generative AI to scaffold tests for a `BankAccount` class. The tests all *pass* — but several are dangerously broken. Open `test_bank_account.py`. For each test:
+      1. In **`scorer.py`** (left pane), replace each sub-goal comment with the matching line. Re-read the test for the contract.
+      2. **Predict** what pytest will show. Run.
+      3. Resist any "improvement" beyond what the test demands — the next step is REFACTOR, and it only earns work that has somewhere to go.
 
-      1. **Read** the test and the code it claims to verify
-      2. **Identify** the anti-pattern (the comment above each test names a category to consider)
-      3. **Refactor** the test to actually verify the intended behavior
+      ## Common mistakes to avoid
 
-      You must keep **at least four** test functions in the file, and your refactored suite must:
-      - Catch the bug planted in `bank_account.py`'s `withdraw()` method (when you fix the bug, your tests should go GREEN; before fixing, they should reveal the bug)
-      - Not contain any tautological assertions (`assert x == x`, `assert True`, `assert isinstance(...)` as the *only* assertion)
-      - Not access private attributes (no `account._balance`)
+      - **`events: list = []`** — Python rejects mutable defaults in dataclasses with `ValueError`. What immutable alternative matches the test's `events == ()` assertion?
+      - **Forgetting `@property`** — without it, `report.total_damage` is a *bound method object*, not a number; the assertion fails in a weird way.
+      - **`@dataclass` without `frozen=True`** — passes cycle 1, but cycle 2's tuple comparisons of value objects need the structural `__eq__` that frozen dataclasses provide.
+      - **`if not dice: ...`** — speculative branching. The empty-tuple default already handles the empty case.
 
-      **Workflow:** Refactor the tests first. Run them — they should now FAIL because of the planted bug. Then fix `bank_account.py`. Run again — GREEN.
+      If you get genuinely stuck, click **Show Solution** below the editor for one possible form.
 
-      ## The Prompt Problem (Optional Reflection)
+      ## Self-test before clicking Next
 
-      Researchers Denny et al. propose a new exercise type: writing a *prompt* so precisely that an AI generates the right test for you. After you finish the audit, write a one-paragraph "prompt" in a comment at the top of `test_bank_account.py` that — given to an AI — would have produced your refactored test suite directly. This is the new core skill: **specifying behavior is now more valuable than typing it.**
-
-      ### Before You Move On (retrieval practice)
-
-      Without looking: name the two AI-specific anti-patterns introduced in this step and describe one strategy for each that keeps you in control of the test's contract.
+      - What three things does `@dataclass` write for you that you'd otherwise type by hand?
+      - Why is `@property` a better fit than a plain method for `total_damage` *given how the test reads it*?
+      - What does `frozen=True` buy us, and which later cycle will first rely on it?
+      - What four obligations does the cycle-1 test impose — derived from reading the test alone?
 
     files:
-      - path: "bank_account.py"
+      - path: "scorer.py"
         content: |
-          class BankAccount:
-              """A simple bank account. Contains ONE planted bug — find it via tests."""
+          """Cycle 1 GREEN — smallest code that turns the failing test green.
 
-              def __init__(self, opening_balance=0):
-                  if opening_balance < 0:
-                      raise ValueError("Opening balance cannot be negative")
-                  self._balance = opening_balance
-
-              def deposit(self, amount):
-                  if amount <= 0:
-                      raise ValueError("Deposit amount must be positive")
-                  self._balance += amount
-
-              def withdraw(self, amount):
-                  if amount <= 0:
-                      raise ValueError("Withdrawal amount must be positive")
-                  # BUG: missing overdraft check — silently allows negative balance
-                  self._balance -= amount
-
-              def balance(self):
-                  return self._balance
-        language: "python"
-
-      - path: "test_bank_account.py"
-        content: |
-          """AUDIT: AI-generated tests for BankAccount. Several are broken.
-
-          Your job: refactor each test to actually verify behavior, then use the
-          refactored suite to find and fix the bug planted in bank_account.py.
+          The sub-goals below describe the PURPOSE of each line you need to add,
+          not the syntax. Re-read test_scorer.py to recover the contract: a name
+          to export, a return value, two attributes on the return value with
+          specific values. The Cart example in the instructions shows the toolkit
+          shape; you must translate it to the dragon-dice naming yourself.
           """
-          import pytest
-          from bank_account import BankAccount
+          from dataclasses import dataclass
 
 
-          # --- Test 1: AI tautology — passes for any int return value ---
-          # ANTI-PATTERN: The Liar (asserts shape, not behavior)
-          def test_deposit_increases_balance():
-              account = BankAccount(100)
-              account.deposit(50)
-              result = account.balance()
-              assert isinstance(result, int)   # vacuous — does not check value
+          @dataclass(frozen=True)
+          class BattleReport:
+              # Sub-goal: declare the storage that the test reads as `report.events`.
+              # Hint: the test compares this to `()`, which already tells you the
+              # type and the default value. (See the dataclasses docs link.)
+
+              @property
+              def total_damage(self):
+                  # Sub-goal: derive the total from whatever events the report holds.
+                  # Hint: with an empty-tuple default for events, an aggregate built-in
+                  # over an empty sequence already produces the value the test asserts.
+                  pass
 
 
-          # --- Test 2: AI accessed private state instead of the public API ---
-          # ANTI-PATTERN: Nitpicker (couples test to implementation)
-          def test_withdraw_reduces_balance():
-              account = BankAccount(100)
-              account.withdraw(30)
-              assert account._balance == 70    # touches private attribute
-
-
-          # --- Test 3: AI "fixed" the failing test by softening the assertion ---
-          # ANTI-PATTERN: Modify-the-Test (test rewritten to match buggy code)
-          def test_cannot_overdraft():
-              account = BankAccount(100)
-              account.withdraw(150)
-              # Original failing assertion was: account.balance() == 100 (rejected)
-              # AI weakened it to this — which always passes:
-              assert account.balance() != 999999
-
-
-          # --- Test 4: AI asserted on its own mock instead of real behavior ---
-          # ANTI-PATTERN: The Mockery (verifies the test setup, not the system)
-          def test_opening_balance():
-              expected = 250
-              account = BankAccount(expected)
-              assert expected == 250          # checks the local variable, not the account
-
-
-          if __name__ == "__main__":
-              pytest.main(["-v"])
+          def score(dice):
+              # Sub-goal: hand back the kind of object the test reads attributes on.
+              # Hint: ignore `dice` for now — no test makes a claim about non-empty
+              # rolls yet, so any branching on it would be speculative design.
+              pass
         language: "python"
 
-    open_file: "test_bank_account.py"
-    run_file: "test_bank_account.py"
+      - path: "test_scorer.py"
+        content: |
+          """Cycle 1 — first failing test (carried over from the RED step)."""
+          from scorer import score
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
 
     solution:
       files:
-        - path: "bank_account.py"
+        - path: "scorer.py"
           content: |
-            class BankAccount:
-                """A simple bank account — overdraft bug fixed."""
+            from dataclasses import dataclass
 
-                def __init__(self, opening_balance=0):
-                    if opening_balance < 0:
-                        raise ValueError("Opening balance cannot be negative")
-                    self._balance = opening_balance
 
-                def deposit(self, amount):
-                    if amount <= 0:
-                        raise ValueError("Deposit amount must be positive")
-                    self._balance += amount
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
 
-                def withdraw(self, amount):
-                    if amount <= 0:
-                        raise ValueError("Withdrawal amount must be positive")
-                    if amount > self._balance:
-                        raise ValueError("Insufficient funds")
-                    self._balance -= amount
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
 
-                def balance(self):
-                    return self._balance
+
+            def score(dice):
+                return BattleReport()
           language: "python"
 
-        - path: "test_bank_account.py"
+        - path: "test_scorer.py"
           content: |
-            """Refactored: each test now verifies real behavior via the public API."""
-            import pytest
-            from bank_account import BankAccount
+            """Cycle 1 — first failing test."""
+            from scorer import score
 
 
-            def test_deposit_increases_balance():
-                # Arrange-Act-Assert: assert on observable balance, not type
-                account = BankAccount(100)
-                account.deposit(50)
-                assert account.balance() == 150
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
 
-
-            def test_withdraw_reduces_balance():
-                # Use balance() public method instead of _balance private attribute
-                account = BankAccount(100)
-                account.withdraw(30)
-                assert account.balance() == 70
-
-
-            def test_cannot_overdraft():
-                # Real assertion: overdraft must raise OR balance must be unchanged
-                account = BankAccount(100)
-                with pytest.raises(ValueError):
-                    account.withdraw(150)
-                assert account.balance() == 100
-
-
-            def test_opening_balance():
-                # Assert against the account, not the local input variable
-                account = BankAccount(250)
-                assert account.balance() == 250
-
-
-            if __name__ == "__main__":
-                pytest.main(["-v"])
+                assert report.total_damage == 0
+                assert report.events == ()
           language: "python"
-
       explanation: |
-        Each refactored test now (a) uses only the public API, (b) asserts on observable
-        balance instead of types or local variables, and (c) actually exercises the bug.
-        Adding the overdraft guard in withdraw() is what makes test_cannot_overdraft pass.
+        Smallest possible GREEN code: a frozen dataclass with an empty-tuple default
+        for events and a property that sums damage across events. The score function
+        ignores its argument for now — the only behavior the current test pins down
+        is "an empty roll has no events and no damage."
 
     tests:
-      - description: "Refactored test file does not access private attributes"
+      - description: "BattleReport class is defined in scorer.py"
         command: |
-          source = open('/tutorial/test_bank_account.py').read()
-          assert '._balance' not in source, \
-              "Test 2 still accesses account._balance directly — refactor it to use account.balance() instead"
-      - description: "Refactored tests do not contain tautological assertions"
+          source = open('/tutorial/scorer.py').read()
+          assert 'class BattleReport' in source, \
+              "Define a class called BattleReport in scorer.py — see the worked example"
+
+      - description: "score function is defined in scorer.py"
         command: |
-          source = open('/tutorial/test_bank_account.py').read()
-          assert 'isinstance(result, int)' not in source, \
-              "Test 1 still uses isinstance() as the only assertion — assert on the actual balance value instead"
-          assert 'expected == 250' not in source, \
-              "Test 4 still asserts on the local variable 'expected' — assert on account.balance() instead"
-          assert '!= 999999' not in source, \
-              "Test 3's assertion is still a Liar (always true) — assert that the overdraft was either prevented OR raised an error"
-      - description: "Test file still contains at least 4 test functions"
+          source = open('/tutorial/scorer.py').read()
+          assert 'def score' in source, \
+              "Define a function called score(dice) in scorer.py"
+
+      - description: "BattleReport uses @dataclass(frozen=True) (immutable report)"
         command: |
-          source = open('/tutorial/test_bank_account.py').read()
-          test_count = source.count('def test_')
-          assert test_count >= 4, \
-              f"Keep at least 4 test functions (found {test_count}) — refactor each, do not delete them"
-      - description: "BankAccount.withdraw() rejects overdrafts (bug fixed)"
-        command: |
-          exec(open('/tutorial/bank_account.py').read())
-          account = BankAccount(100)
-          import pytest as _pt
-          try:
-              account.withdraw(150)
-              raised = False
-          except (ValueError, Exception):
-              raised = True
-          assert raised or account.balance() == 100, \
-              "withdraw(150) on a balance of 100 must either raise an error or leave the balance unchanged — the overdraft bug is still present"
-      - description: "All refactored tests pass after the bug fix"
+          source = open('/tutorial/scorer.py').read()
+          collapsed = source.replace(' ', '')
+          assert '@dataclass(frozen=True)' in collapsed, \
+              "Use @dataclass(frozen=True) on BattleReport — frozen reports cannot be mutated by accident, and we rely on that later"
+
+      - description: "GREEN: pytest passes (the bar is green)"
         command: |
           import pytest, io, sys
-          old = sys.stdout; sys.stdout = buf = io.StringIO()
-          code = pytest.main(['/tutorial/test_bank_account.py', '-v', '--tb=short', '--no-header'])
-          sys.stdout = old; output = buf.getvalue(); print(output)
-          assert code == 0, f"Some tests failed:\n{output}"
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"GREEN means pytest passes. Some tests are still failing:\n{output}"
+
+      - description: "Implementation is minimal — no speculative dice handling yet"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          # The current test does not need any of these. Adding them would be
+          # speculative design — code with no test demanding it.
+          for forbidden in ['ScoringEvent', 'Counter(', 'COMBO_RULES', 'SINGLE_RULES', 'validate_dice']:
+              assert forbidden not in source, \
+                  f"`{forbidden}` is not yet demanded by any test — remove it. The GREEN rule is *smallest* code that passes. Future cycles will add what they need."
+
+    # NO QUIZ — the first quiz follows the REFACTOR step.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 3 — Cycle 1 REFACTOR + FIRST QUIZ
+  # Pedagogy:
+  #   Misconception fix     — "REFACTOR is optional" / "REFACTOR is for later".
+  #   Threshold concept     — REFACTOR is a *phase you must enter*, even when
+  #                           there is nothing to clean up.
+  #   Cognitive apprentice. — instructor models what they look at on REFACTOR.
+  #   First quiz            — checks the rhythm before the rhythm scales up.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 1 — REFACTOR: The Pause That Counts"
+    instructions: |
+      > **The discipline:** REFACTOR is a phase you **enter every cycle** — even when the answer is *"nothing to clean this time."* Entering and looking is the discipline. Skipping the look is the failure mode that quietly degrades TDD into test-after.
+
+      ## The REFACTOR checklist (you'll re-use this every cycle)
+
+      | Category | Question to ask | Cycle 1 answer |
+      |---|---|---|
+      | **Duplication** | Two pieces of code expressing the same idea? | No — only one piece of code |
+      | **Names** | Do names describe what they *mean*, not how they work? | `BattleReport`, `total_damage`, `events`, `score` — all domain words |
+      | **Test names** | Does each test name read as a behavior sentence? | `test_empty_roll_has_zero_damage_and_no_events` — long but unambiguous |
+      | **Magic constants** | Unexplained numbers or strings? | None yet |
+      | **Imports** | Conventional order, no dead imports? | Just `from dataclasses import dataclass` — clean |
+
+      For cycle 1, every row is "fine." That's a real outcome of a REFACTOR phase — and *recognising it without skipping the look* is the win.
+
+      ## Your task
+
+      1. Re-read your code with the checklist. Spend 30 seconds — don't rush.
+      2. Make any tiny improvement you spot (e.g., a module docstring); keep the bar green.
+      3. Take the **first quiz** below, focused on the rhythm you just lived through.
+
+
+
+      ### Why REFACTOR is the most-skipped phase
+
+      Martin Fowler calls skipping refactor "the most common way to screw up TDD." Field studies of student and professional practice agree: developers treat the green bar as the finish line. Within a few cycles, duplication accumulates and the test suite ages — exactly because nobody paused at REFACTOR to look. By making "enter the phase even when there's nothing to do" a habit now, you defend against that drift for the rest of the tutorial.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          def score(dice):
+              return BattleReport()
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycle 1 — first failing test, now green."""
+          from scorer import score
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            def score(dice):
+                return BattleReport()
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycle 1 — first failing test, now green."""
+            from scorer import score
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+          language: "python"
+      explanation: |
+        Cycle 1's REFACTOR is intentionally a no-op. The point is to enter the phase
+        — to read the code with the refactor checklist in mind, decide there is
+        nothing to clean, and move on. Entering and finding nothing is the win;
+        forgetting to enter is the failure.
+
+    tests:
+      - description: "All tests still pass after the refactor look (the bar stayed green)"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"REFACTOR must keep the bar green. If a refactor breaks a test, undo it and try again — the test suite is the safety net.\n{output}"
+
+      - description: "Cycle 1's test is still present (the refactor did not delete behavior)"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_empty_roll_has_zero_damage_and_no_events' in source, \
+              "Cycle 1's test was deleted. REFACTOR changes structure, not behavior — and certainly not the tests that verify behavior."
 
     quiz:
-      title: "AI-Critical TDD — Knowledge Check"
+      title: "First Quiz — The Red-Green-Refactor Rhythm"
       min_score: 0.8
       shuffle: true
       questions:
 
         - question: |
-            An AI agent is told *"make this failing test pass"* and runs autonomously. What is the most dangerous failure mode the human reviewer must guard against?
+            What is the **correct** order of phases in a single TDD cycle?
           type: single
           options:
-            - "The AI generates code that is too long, exceeding the project's style guide for line length"
-            - "The AI rewrites the test so its assertion matches the buggy code's actual output, instead of fixing the production code"
-            - "The AI generates code in a different style than the rest of the codebase, requiring formatting cleanup"
-            - "The AI hallucinates an import that does not exist, causing the test to fail to load"
+            - "GREEN → RED → REFACTOR — write code, then prove it works with a test, then clean up"
+            - "RED → GREEN → REFACTOR — write a failing test, write the smallest code to pass it, then improve the design with the safety net in place"
+            - "RED → REFACTOR → GREEN — write a failing test, design the right structure first, then make the test pass"
+            - "REFACTOR → RED → GREEN — clean up old code first, then write a test for the new behavior, then implement it"
           correct_index: 1
           explanation: |
-            This is the *Modify-the-Test* anti-pattern documented in industrial case studies of
-            agentic AI. Both the implementation AND the test are now produced by the AI, so the
-            "passing" signal is meaningless — the AI has rewritten the contract instead of meeting
-            it. The human's job is to own the test specification.
+            RED → GREEN → REFACTOR. The order is load-bearing. RED proves the test reveals
+            missing behavior. GREEN proves the code now satisfies that behavior. REFACTOR
+            improves the code while the safety net (the green test) protects you.
 
         - question: |
-            Which of these AI-generated tests is **least useful** as a behavior check?
+            You write a new test and click Run. The bar is **immediately green** without you having to write any production code. What is the most defensible interpretation?
           type: single
           options:
-            - |
-              ```python
-              def test_add():
-                  result = add(2, 3)
-                  assert result == 5
-              ```
-            - |
-              ```python
-              def test_add():
-                  result = add(2, 3)
-                  assert isinstance(result, int)
-              ```
-            - |
-              ```python
-              def test_add():
-                  result = add(2, 3)
-                  assert result > 0 and result < 10
-              ```
-            - |
-              ```python
-              def test_add():
-                  with pytest.raises(TypeError):
-                      add("a", "b")
-              ```
+            - "Celebrate — the existing code already implements this behavior, so there is nothing to do this cycle"
+            - "Be suspicious — a test that passes without RED may be testing nothing meaningful, OR may genuinely be covered by an earlier refactor. Verify which by temporarily breaking the production code and confirming the test fails for the right reason"
+            - "Delete the test — a test that passes immediately is redundant and only adds runtime cost"
+            - "Rewrite the test until it fails, since the rule is `RED → GREEN → REFACTOR` and you cannot enter GREEN without first being RED"
           correct_index: 1
           explanation: |
-            Asserting only `isinstance(result, int)` is a *Liar test*: `add(2, 3)` returning
-            `0`, `99`, or even `5` would all pass. AI assistants sometimes default to type
-            checks because they always succeed.
+            Both halves matter. Sometimes a test passes immediately because a prior refactor
+            generalised behavior — that is a *positive* outcome, and the test still earns its
+            place by documenting that the behavior is intended. Other times the test is
+            vacuously true. The way to tell is to break the production code on purpose: a
+            real test will catch the break.
 
         - question: |
-            **Evaluate:** Why does the empirical evidence suggest TDD becomes *more* important when working with AI, not less?
+            In the GREEN phase, you have *two* implementations in mind: one is a hardcoded `if dice == []: return BattleReport()`, the other is a generic loop. The hardcoded version passes the current test. What does TDD discipline say to do?
           type: single
           options:
-            - "TDD slows down AI tools, which gives the developer time to type at a more comfortable pace and reduces fatigue over the workday"
-            - "Studies show novices accept AI output with minimal verification — TDD enforces a discipline where you must SEE the test fail and SEE it pass, restoring real verification"
-            - "AI tools cannot generate tests at all, so the developer must write every test by hand to compensate for that limitation in the toolchain"
-            - "TDD is a legacy practice from before AI tools existed, but it must be retained to satisfy compliance and audit requirements in regulated industries"
+            - "Write the generic loop — it will be needed eventually, and writing it now saves work in the next cycle"
+            - "Write the hardcoded version — TDD's GREEN rule is the smallest code that passes the *current* failing test, even if you know more cycles are coming"
+            - "Skip GREEN entirely and design the loop as part of REFACTOR — the cycle is flexible about which phase contains the new logic"
+            - "It does not matter — both choices satisfy the test, and the difference is purely stylistic"
           correct_index: 1
           explanation: |
-            Observational research on undergraduates using GenAI for testing found novices ran
-            AI-generated tests roughly *one third* as often as their own manual tests, with
-            documented concerns about an *illusion of competence*. TDD's strict Red-Green
-            discipline re-introduces the verification step the AI workflow tends to skip.
+            This is the Transformation Priority Premise in action: prefer simpler
+            transformations. The hardcoded version is fine as long as a future test will
+            challenge it. That challenge — and the design pressure it creates — is exactly
+            what cycle 4 of this tutorial will hand you.
 
         - question: |
-            **(Spaced review — Foundations Step 4)** You ask an AI to generate tests and it produces a test where Arrange takes 30 lines, Act takes 1 line, and Assert takes 1 line. What is the most likely diagnosis?
+            Why is REFACTOR worth entering even when there is nothing to clean up?
           type: single
           options:
-            - "The AI is correctly mocking every dependency to keep the test isolated — this is the recommended modern practice"
-            - "The AI has masked the *Excessive Setup* test smell — and likely the *Mockery* anti-pattern. The production code is too tightly coupled, and the test is verifying mock behavior instead of real behavior"
-            - "The AI has chosen a verbose style for readability — copy it as-is, since modern AI tools follow industry best practices by default"
-            - "Nothing is wrong — long Arrange sections are normal for any test that involves objects, regardless of how the production code is structured"
+            - "Because pytest requires every cycle to have all three phases or it will skip the test in the next run"
+            - "Because the discipline of *pausing to look* is the whole point — finding nothing actionable is fine, but skipping the look lets duplication and bad names accumulate silently across cycles"
+            - "Because REFACTOR is the only phase where you can add new tests without breaking the cycle's contract"
+            - "Because the GREEN code is always wrong on the first attempt and must be revised before moving on"
           correct_index: 1
           explanation: |
-            *Excessive Setup* and *Mockery* both signal architectural problems in the production
-            code, not the test. AI assistants will happily generate hundreds of lines of mock
-            scaffolding to make a test pass — but the test then verifies the mocks, not the
-            system. Listen to the test.
+            Field studies report that "skip refactor when it looks fine" is exactly how
+            test-driven discipline degrades into test-after over a few weeks. Every cycle is
+            a checkpoint where you ask "what do I see now?" Most cycles, the answer is
+            mostly fine. But you only know that because you looked.
 
+        - question: |
+            A teammate says: *"TDD is just unit testing — write your tests first instead of last."* What is the **most accurate** correction?
+          type: single
+          options:
+            - "They are right — TDD is a workflow ordering decision; the resulting tests and code are otherwise indistinguishable from test-after"
+            - "TDD is a *design* technique that uses tests as the medium. Writing the test first forces interface and behavior decisions before implementation, and the REFACTOR step is where the design pressure pays off — neither of which is part of plain unit testing"
+            - "TDD is primarily a refactoring technique, and the tests exist only as a regression safety net for the refactoring"
+            - "TDD requires writing all tests for a feature first, then all the code at once — which is the opposite of unit testing's incremental style"
+          correct_index: 1
+          explanation: |
+            This is the threshold concept: TDD is design first, testing second. The test
+            forces you to decide the public interface (function name, parameters, return
+            shape) before any logic exists. The REFACTOR phase is where the design that
+            emerged under pressure gets shaped intentionally. Calling it "unit testing in
+            reverse order" misses both halves.
+
+
+  # ==========================================================================
+  # CYCLES 2-12 — Each cycle is now ONE tutorial step with three tasks
+  # (RED, GREEN, REFACTOR). Quizzes appear on key cycles only — the design-
+  # pressure moments. Spacing avoids quiz fatigue while consolidating the
+  # most important learning beats.
+  # ==========================================================================
 
   # --------------------------------------------------------------------------
-  # STEP 5 — The Big Picture
+  # STEP 4 — Cycle 2: A single 1 creates a Dragon Flame event
   # Pedagogy:
-  #   Empirical grounding   — concrete citations, not vague "research shows".
-  #   Anti-pattern taxonomy — Level I-IV maturity model.
-  #   Test-levels quiz item — connects unit to integration/system pyramid.
-  #   Metaphor pair         — Ratchet + Boiled Frog for psychological scaffolding.
-  #   Spaced review         — questions from earlier TDD + Foundations content.
-  #   Bloom's level         — Evaluate / Create.
+  #   Worked-example fading — RED test now scaffolded, GREEN/REFACTOR tasks.
+  #   Allow-the-hardcode    — students must learn the first GREEN may be ugly.
+  #   Cognitive load        — introduces ScoringEvent (one new dataclass).
+  #   No quiz — let the rhythm settle into the second cycle without testing.
   # --------------------------------------------------------------------------
-  - title: "The Big Picture"
+  - title: "Cycle 2 — Single 1 → Dragon Flame"
     instructions: |
-      > **Learning objective:** After this step you will be able to **evaluate** when TDD is appropriate, **classify** common TDD anti-patterns by maturity level, and **articulate** the empirical evidence for the practice.
+      > **Spec:** a single die showing **1** creates a *Dragon Flame* event worth 100 damage.
 
-      ## When TDD Shines
+      From now on, each cycle is **one step with three tasks** (RED → GREEN → REFACTOR). Same discipline as cycle 1 — tighter packaging.
 
-      TDD is most valuable when:
-      - Building **new features** with clear behavioral requirements
-      - Working with **complex logic** (validation, calculation, state machines)
-      - Designing **APIs and interfaces** — the test forces you to think from the caller's perspective
-      - Working on a **team** — tests document expected behavior for other developers
+      ## Your task
 
-      ## When TDD is Overkill
+      1. **🔴 RED** — add `test_single_one_creates_dragon_flame_event` in `test_scorer.py`. The assertion should pin down `total_damage == 100` and one `ScoringEvent("Dragon Flame", (1,), 100)` in `events`. Update the import to bring in `ScoringEvent`. Run — predict the failure, check.
+      2. **🟢 GREEN** — introduce a `ScoringEvent` dataclass and the **smallest** change to `score`. The minimum here is a hardcoded `if dice == [1]:` branch — that's deliberate.
+      3. **🔵 REFACTOR** — walk the cycle-1 checklist. Resist generalising; cycle 4 will earn the loop.
 
-      TDD is less useful for:
-      - **One-off scripts** — quick data transformations you will use once
-      - **Exploratory prototyping** — when you are still figuring out the problem
-      - **UI layout code** — visual correctness is hard to assert programmatically
-      - **Non-binary outcomes** — ML models, image recognition, or anything where "correct" is a confidence interval, not a true/false
+      Expected RED: `ImportError: cannot import name 'ScoringEvent'` — the test forces you to *name* the event class before writing it. That's the design pressure of test-first thinking.
 
-      Even in these cases, *some* tests are almost always valuable. The question is whether to write them *first*.
+      ## Why "allow the hard-code" is a TDD discipline
 
-      ## Unit Is Not the Only Level
+      The instinct is to extract a rule, write a loop, build the abstraction now. TDD asks you to wait for the test that *demands* it. A speculative loop is a guess at the right shape; a loop refactor pulled by cycle 4's test is a *discovery*. **Refactor toward duplication, not before it.**
 
-      The tests you have written are **unit tests** — they exercise one function or class in isolation. That is one rung of the *testing pyramid*:
+      If you're genuinely stuck, click **Show Solution** below the editor.
 
-      | Level | What's under test | Runs in... | Typical cost |
+    files:
+      - path: "scorer.py"
+        content: |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          def score(dice):
+              return BattleReport()
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–2 — adding the Dragon Flame behavior."""
+          from scorer import score
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          # TODO (RED): import ScoringEvent from scorer
+          # TODO (RED): write test_single_one_creates_dragon_flame_event
+          #             score([1]) should return a report with total_damage == 100
+          #             and events == (ScoringEvent("Dragon Flame", (1,), 100),)
+        language: "python"
+
+    open_file: "test_scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            def score(dice):
+                if dice == [1]:
+                    return BattleReport((
+                        ScoringEvent("Dragon Flame", (1,), 100),
+                    ))
+                return BattleReport()
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–2 — empty roll and single Dragon Flame."""
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+          language: "python"
+      explanation: |
+        The hardcoded `if dice == [1]:` branch is the smallest GREEN that satisfies
+        the test. Cycle 4's test will make this branch insufficient — that is the
+        signal to refactor into a loop. Until then, the duplication is fine.
+
+    tests:
+      - description: "test_single_one_creates_dragon_flame_event function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_single_one_creates_dragon_flame_event' in source, \
+              "Add the test function `test_single_one_creates_dragon_flame_event` from the worked example"
+
+      - description: "ScoringEvent class is defined in scorer.py"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'class ScoringEvent' in source, \
+              "Define a ScoringEvent dataclass in scorer.py — the test imports it"
+
+      - description: "ScoringEvent is a frozen dataclass (immutability matters)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          collapsed = source.replace(' ', '')
+          # Find the ScoringEvent block and check the decorator just above it.
+          # We allow either the decorator immediately above class ScoringEvent or anywhere in the file.
+          assert '@dataclass(frozen=True)' in collapsed, \
+              "ScoringEvent should be a @dataclass(frozen=True) — frozen events can be safely compared by value in tests"
+
+      - description: "Both tests pass (cycle 2 GREEN)"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"Both cycle 1 and cycle 2 tests should now pass:\n{output}"
+
+      - description: "Implementation has not jumped ahead to a loop or rule objects"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          # If a student has already written the cycle-4 loop or cycle-8 rule
+          # objects, they have over-engineered. The next cycle's test is what
+          # earns those refactors.
+          for forbidden in ['ComboRule', 'SingleRule', 'COMBO_RULES', 'SINGLE_RULES']:
+              assert forbidden not in source, \
+                  f"`{forbidden}` belongs to a later cycle (cycle 8). Right now the smallest GREEN is `if dice == [1]:` — let the loop and the rule objects emerge under pressure from later tests."
+
+    # NO QUIZ — focus on the rhythm; the next quiz is two cycles away.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 5 — Cycle 3: A single 5 creates a Lightning Spark event
+  # Pedagogy:
+  #   Variation theory     — same shape of test, different value (contrast).
+  #   Make duplication     — two near-identical branches; visible, not yet fixed.
+  #   No quiz — duplication is itself the lesson; no need to test it yet.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 3 — Single 5 → Lightning Spark"
+    instructions: |
+      > **Spec:** a single die showing **5** creates a *Lightning Spark* event worth 50 damage.
+
+      Same shape as cycle 2, different values. The duplication this creates is *intentional* — cycle 4's test will earn the right to fix it.
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_single_five_creates_lightning_spark_event`, structured exactly like cycle 2's test but with the Lightning Spark values.
+      2. **🟢 GREEN** — add a second hardcoded `if dice == [5]:` branch. **Resist** the urge to write a loop or dict lookup.
+      3. **🔵 REFACTOR** — walk the checklist. The duplication is now visible; the right move is to **note it and write nothing**. No test demands the loop yet.
+
+      ## Why deliberately keeping ugly code is the disciplined move
+
+      You can clearly see duplication. Refactoring it now would be *guessing* at the right shape with one too few data points. Cycle 4's test will provide the second data point — and the loop refactor it earns is a discovery, not a guess. **Refactor toward duplication, not before it.**
+
+      Click **Show Solution** below the editor if you need one form of the test + GREEN code.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          def score(dice):
+              if dice == [1]:
+                  return BattleReport((
+                      ScoringEvent("Dragon Flame", (1,), 100),
+                  ))
+              return BattleReport()
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–3 — adding the Lightning Spark behavior."""
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          # TODO (RED): write test_single_five_creates_lightning_spark_event
+          #             score([5]) should return total_damage == 50 with
+          #             events == (ScoringEvent("Lightning Spark", (5,), 50),)
+        language: "python"
+
+    open_file: "test_scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            def score(dice):
+                if dice == [1]:
+                    return BattleReport((
+                        ScoringEvent("Dragon Flame", (1,), 100),
+                    ))
+                if dice == [5]:
+                    return BattleReport((
+                        ScoringEvent("Lightning Spark", (5,), 50),
+                    ))
+                return BattleReport()
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–3 — single Dragon Flame, single Lightning Spark."""
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+          language: "python"
+      explanation: |
+        Add a second hardcoded branch. The duplication between the two branches is
+        loud and intentional — cycle 4's test will provide the second data point
+        that earns the loop.
+
+    tests:
+      - description: "test_single_five_creates_lightning_spark_event function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_single_five_creates_lightning_spark_event' in source, \
+              "Add the test function `test_single_five_creates_lightning_spark_event`"
+
+      - description: "All three tests pass"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All three tests should pass:\n{output}"
+
+      - description: "Implementation still has the second hardcoded branch (no premature refactor to loop)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          # We expect TWO if-branches checking specific dice lists. A student
+          # who jumped to a `for die in dice:` loop has refactored without a
+          # justifying test — exactly the move cycle 4 will earn the right to.
+          has_branches = 'dice == [1]' in source and 'dice == [5]' in source
+          assert has_branches, \
+              "Cycle 3's smallest GREEN is to add a second `if dice == [5]:` branch. The loop refactor belongs in cycle 4 — once a test exists that *requires* it. Restore both hardcoded branches for now."
+
+    # NO QUIZ — duplication is the lesson; cycle 4 will pay for it.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 6 — Cycle 4: Repeated singles + FIRST REAL REFACTOR + QUIZ
+  # Pedagogy:
+  #   Design pressure       — `[1, 1]` cannot be satisfied by hardcoded branches.
+  #   Refactor under safety — three green tests guard the change to a loop.
+  #   Counter-misconception — "tests slow refactoring" is dismantled here.
+  #   Quiz                  — checks understanding of the safety-net concept.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 4 — Repeated Singles → First Real Refactor"
+    instructions: |
+      > **Spec:** `score([1, 1])` returns total damage 200 with **two** Dragon Flame events.
+
+      The first **design-breaking** test. Neither `dice == [1]` nor `dice == [5]` matches `[1, 1]` — the duplication you noted in cycle 3 just demanded payment.
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_two_ones_create_two_dragon_flames` asserting damage 200 and two Flame events. Run; predict the failure.
+      2. **🟢 GREEN** — you have two options. Pick the better one:
+         - *Option A*: a third hardcoded branch for `dice == [1, 1]`. Passes — and makes duplication worse, with a fourth branch coming next cycle.
+         - *Option B*: replace the hardcoded branches with a `for` loop over each die. Passes cycle 4 *and* retires the cycle-3 duplication in one move.
+      3. **🔵 REFACTOR** — re-run; the previous three tests are your safety net. Note what just happened: you rewrote the body of `score` and knew within a second that you didn't break anything.
+
+      ## The threshold-concept moment: *tests enable change*
+
+      You just **rewrote the body of `score`** — two hardcoded branches → generic per-die loop — and confirmed in one second that nothing broke. Without the test suite you'd have had to reason from scratch: *"Does this still handle empty? Single 1? Single 5?"*
+
+      That's what "tests enable change" means. Not "prevent change." Not "slow change." **Enable** — they replace fear-driven manual reasoning with a mechanical check. This is the cycle that earns the safety-net quiz below.
+
+      Click **Show Solution** if you need to see one form of option B.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          def score(dice):
+              if dice == [1]:
+                  return BattleReport((
+                      ScoringEvent("Dragon Flame", (1,), 100),
+                  ))
+              if dice == [5]:
+                  return BattleReport((
+                      ScoringEvent("Lightning Spark", (5,), 50),
+                  ))
+              return BattleReport()
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–4 — repeated singles force the first refactor."""
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          # TODO (RED): write test_two_ones_create_two_dragon_flames
+          #             score([1, 1]) should return total_damage == 200 and two
+          #             Dragon Flame events in events
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            def score(dice):
+                events = []
+
+                for die in dice:
+                    if die == 1:
+                        events.append(ScoringEvent("Dragon Flame", (1,), 100))
+                    if die == 5:
+                        events.append(ScoringEvent("Lightning Spark", (5,), 50))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–4 — empty, two singles, and repeated singles."""
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+          language: "python"
+      explanation: |
+        The right move is option 2 — replace the hardcoded branches with a per-die
+        loop. The previous three tests act as a safety net that lets you do the
+        rewrite confidently and confirm in one second that nothing broke.
+
+    tests:
+      - description: "test_two_ones_create_two_dragon_flames function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_two_ones_create_two_dragon_flames' in source, \
+              "Add the test function `test_two_ones_create_two_dragon_flames`"
+
+      - description: "All four tests pass"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All four tests should pass after cycle 4:\n{output}"
+
+      - description: "Implementation iterates over dice (loop refactor was applied)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          collapsed = source.replace(' ', '')
+          assert 'fordieindice' in collapsed or 'foreachdieindice' in collapsed or 'fordie' in collapsed, \
+              "Cycle 4's refactor replaces the hardcoded `if dice == [...]:` branches with a per-die `for` loop. Without that, adding a third hardcoded branch (`if dice == [1, 1]:`) just makes the duplication worse."
+
+      - description: "Hardcoded list-equality branches are gone (the duplication was paid down)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'dice == [1]' not in source and 'dice == [5]' not in source and 'dice == [1, 1]' not in source, \
+              "The whole point of cycle 4 was to retire the `if dice == [...]:` branches in favour of a generic per-die loop. Remove them."
+
+    quiz:
+      title: "Cycle 4 Quiz — Tests as Design Pressure"
+      min_score: 0.8
+      shuffle: true
+      questions:
+
+        - question: |
+            You noticed obvious duplication after cycle 3 but did not refactor it. Cycle 4's test then *forced* the refactor. Why is this sequence (notice → wait → refactor when test demands) better than (notice → refactor immediately)?
+          type: single
+          options:
+            - "It is not better — refactoring as soon as you see duplication is always the right move; this tutorial just artificially delayed it"
+            - "Waiting until a test demands the change ensures the refactor is justified by behavior, not by aesthetic preference. It also gives you more data points to design the right shape, instead of guessing"
+            - "Python performance is better when you delay extracting loops, because the interpreter optimises hardcoded branches differently from iterative ones"
+            - "It is purely a style choice — the resulting code in either order is identical, so the order of operations does not matter"
+          correct_index: 1
+          explanation: |
+            The test that demands the refactor is also the test that confirms the refactor
+            preserved behavior. Refactoring on aesthetic instinct alone is gambling — you
+            might pick a shape that the next test makes ugly anyway. The discipline is:
+            *let the tests speak first, then change the structure.*
+
+        - question: |
+            You replaced the hardcoded branches with a `for` loop and ran pytest. All four tests passed. What did the test suite just do for you that you would otherwise have had to do manually?
+          type: single
+          options:
+            - "Nothing — passing tests do not provide any information beyond what manual inspection of the new code would have"
+            - "It mechanically verified that the new structure preserves the behavior of the empty roll, single 1, single 5, and `[1, 1]` cases — replacing fear-driven manual reasoning with a one-second check"
+            - "It rewrote your code to be more efficient — the suite optimises the implementation as a side effect of being run"
+            - "It logged the change so a future code reviewer can audit it — the suite acts as a versioned history of refactor decisions"
+          correct_index: 1
+          explanation: |
+            *Tests enable change.* The four green checkmarks are not just "tests passed" —
+            they are "the empty case still works, single 1 still works, single 5 still
+            works, and `[1, 1]` works for the first time." Without the suite, you would
+            have to convince yourself of each line by reading.
+
+        - question: |
+            A teammate looks at your cycle-4 GREEN code and says: *"Why didn't you just add a third `if dice == [1, 1]:` branch? It would have passed the test."* What is the **most accurate** rebuttal?
+          type: single
+          options:
+            - "A third branch would have passed cycle 4, but the duplication would have got worse, cycle 5 would have demanded a fourth branch, and the eventual loop refactor would still have to happen — only with more code to delete"
+            - "A third branch is forbidden by pytest — only one `if` statement per function is allowed in TDD code"
+            - "The teammate is right and you should rewrite — TDD always prefers the smallest change, and one new `if` is smaller than rewriting the function"
+            - "It does not matter — both approaches produce the same byte code after Python compiles them"
+          correct_index: 0
+          explanation: |
+            The TDD GREEN rule is "smallest code that passes the failing test" *given the
+            current direction of the design*. A third hardcoded branch is locally minimal
+            but globally wasteful — you'll throw it away in cycle 5 or cycle 6 anyway. The
+            loop is the smallest *durable* change.
+
+        - question: |
+            **(Spaced review — Cycle 1)** Why is "RED for the right reason" still the right framing in cycle 4, even though we are now adding a test on top of an already-passing suite?
+          type: single
+          options:
+            - "It is not — `RED for the right reason` only applies to cycle 1, where there is no implementation at all"
+            - "Because the new test should fail with a *meaningful* mismatch (assertion failure on the expected events tuple) — not a typo or a missing import. That tells you the test is correctly pinning down a behavior that the current implementation cannot produce"
+            - "Because pytest will only run new tests after old ones have failed at least once"
+            - "Because every cycle must produce both a red bar and an import error or it will be rejected by the test runner"
+          correct_index: 1
+          explanation: |
+            "RED for the right reason" applies to every cycle. In cycle 1 the right reason is
+            usually `ImportError`. In later cycles it is typically an assertion failure
+            showing the *expected* tuple of events versus what the current code actually
+            produced. Either way, the failure has to come from the behavior under test, not
+            from a typo.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 7 — Cycle 5: Mixed dice (test passes immediately!)
+  # Pedagogy:
+  #   Misconception fix  — "passing first time = useless test" is dismantled.
+  #   Variation theory   — same loop, mixed dice, same shape.
+  #   No quiz — instructional emphasis is in the prose.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 5 — Mixed Dice (No Production Change)"
+    instructions: |
+      > **Spec:** `score([1, 5])` produces a mix of one Dragon Flame and one Lightning Spark.
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_one_and_five_create_two_different_events`. **Predict** what pytest will show this time, then run.
+      2. **🟢 GREEN** — most likely outcome: **all five tests pass without any production change**. Cycle 4's loop already handles mixed dice independently. The new test costs zero code — it just documents the intended behavior.
+      3. **🔵 REFACTOR** — verify the "free pass" with the ten-second **mutation move** (next collapsible).
+
+
+
+      ### The mutation move (verify the test isn't vacuous — do this!)
+
+      A test that passes immediately can mean two things:
+
+      | Why? | What it means |
+      |---|---|
+      | A previous refactor already generalised the behavior | ✅ Positive — design is healthy |
+      | The assertion is vacuously true / missing / wrong oracle | ❌ Defect — a *Liar* test |
+
+      Tell them apart in 10 seconds: **break the production code on purpose**. Open `scorer.py`, temporarily change `if die == 5:` to `if die == 999:`. Run pytest. The new test should now fail — proving it actually checks the behavior. Restore the line.
+
+      This single move is the strongest defence against AI-generated Liar tests. Make it a habit; we'll come back to it.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          def score(dice):
+              events = []
+
+              for die in dice:
+                  if die == 1:
+                      events.append(ScoringEvent("Dragon Flame", (1,), 100))
+                  if die == 5:
+                      events.append(ScoringEvent("Lightning Spark", (5,), 50))
+
+              return BattleReport(tuple(events))
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–5 — adding mixed dice."""
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          # TODO (RED): write test_one_and_five_create_two_different_events
+          #             score([1, 5]) should return total_damage == 150 with
+          #             one Dragon Flame followed by one Lightning Spark
+        language: "python"
+
+    open_file: "test_scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            def score(dice):
+                events = []
+
+                for die in dice:
+                    if die == 1:
+                        events.append(ScoringEvent("Dragon Flame", (1,), 100))
+                    if die == 5:
+                        events.append(ScoringEvent("Lightning Spark", (5,), 50))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–5 — five tests, all green."""
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_one_and_five_create_two_different_events():
+                report = score([1, 5])
+
+                assert report.total_damage == 150
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+          language: "python"
+      explanation: |
+        The cycle-4 loop already handles mixed dice. Cycle 5's test passes without
+        any production change — and this is a *positive* outcome that documents the
+        intended behavior. Verify with the ten-second mutation move described in the
+        instructions.
+
+    tests:
+      - description: "test_one_and_five_create_two_different_events function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_one_and_five_create_two_different_events' in source, \
+              "Add the test function `test_one_and_five_create_two_different_events`"
+
+      - description: "All five tests pass"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All five tests should pass without any production change — the cycle-4 loop already handles mixed dice:\n{output}"
+
+      - description: "No spurious change to scorer.py — cycle-5 GREEN required no production edit"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          # The mixed-dice case is handled by the existing per-die loop. If a student
+          # added a `if dice == [1, 5]:` special case, that's a regression toward the
+          # cycle-3 hardcoded style.
+          assert '[1, 5]' not in source and '[1,5]' not in source.replace(' ', ''), \
+              "Cycle 5's `score([1, 5])` is handled by the existing per-die loop. You should not have added a `[1, 5]` special case — that would undo cycle 4's refactor."
+
+    # NO QUIZ — instructional emphasis is in the prose.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 8 — Cycle 6: Three 1s = Dragon Blast + DESIGN-MOMENT QUIZ
+  # Pedagogy:
+  #   Design-breaking test  — per-die loop fundamentally cannot satisfy this.
+  #   Counter -> structure  — counting + leftover bookkeeping replaces iteration.
+  #   Threshold concept     — "tests force structural change, not just lines."
+  #   Quiz                  — checks the design-pressure interpretation.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 6 — Triple 1s → Dragon Blast (Design Moment)"
+    instructions: |
+      > **Spec:** three 1s in a roll combine into one *Dragon Blast* (1000 damage) instead of three Dragon Flames.
+
+      The pivot moment. Cycle 4's per-die loop walks each die independently — it has no way to know that *the other two 1s exist* when it processes the first. This test cannot be satisfied by tweaking a branch; the structure has to change. **A design-breaking test.**
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_three_ones_create_dragon_blast_instead_of_three_flames`. The current loop produces three Flames at 300 damage; the test demands one Blast at 1000. Run, see the value-mismatch.
+      2. **🟢 GREEN** — the structural shift: stop iterating dice in order, **count** how many of each face appeared (`collections.Counter`), then decide what to emit. Combos consume dice; leftovers still score as singles.
+      3. **🔵 REFACTOR** — re-run; the previous five tests survived a *full body rewrite* of `score`. That's the safety net working.
+
+      ### Why this was a design-breaking test (and why the previous tests still pass)
+
+      A *design-breaking* test cannot be satisfied by adding a branch — only by reshaping structure. The cycle-4 per-die loop was fundamentally per-die; combos are fundamentally per-face-count. You couldn't patch your way from one to the other.
+
+      Yet all five previous tests still pass after the rewrite. That's because they assert on **observable behavior** (`total_damage == 100`, `events == (event,)`), not on internals (which loop, which variable name). Behavior tests survive structural rewrites; implementation-tests don't. This is the *Refactoring Litmus Test*.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          def score(dice):
+              events = []
+
+              for die in dice:
+                  if die == 1:
+                      events.append(ScoringEvent("Dragon Flame", (1,), 100))
+                  if die == 5:
+                      events.append(ScoringEvent("Lightning Spark", (5,), 50))
+
+              return BattleReport(tuple(events))
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–6 — triple 1s break the per-die loop."""
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_one_and_five_create_two_different_events():
+              report = score([1, 5])
+
+              assert report.total_damage == 150
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          # TODO (RED): write test_three_ones_create_dragon_blast_instead_of_three_flames
+          #             score([1, 1, 1]) should return total_damage == 1000 with
+          #             a single Dragon Blast event whose dice_used is (1, 1, 1)
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from collections import Counter
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            def score(dice):
+                counts = Counter(dice)
+                events = []
+
+                if counts[1] >= 3:
+                    events.append(ScoringEvent("Dragon Blast", (1, 1, 1), 1000))
+                    counts[1] -= 3
+
+                for _ in range(counts[1]):
+                    events.append(ScoringEvent("Dragon Flame", (1,), 100))
+
+                for _ in range(counts[5]):
+                    events.append(ScoringEvent("Lightning Spark", (5,), 50))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–6 — combos enter the design."""
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_one_and_five_create_two_different_events():
+                report = score([1, 5])
+
+                assert report.total_damage == 150
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_ones_create_dragon_blast_instead_of_three_flames():
+                report = score([1, 1, 1])
+
+                assert report.total_damage == 1000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+          language: "python"
+      explanation: |
+        The structural shift: count occurrences with `Counter`, run the combo check
+        first, subtract the consumed dice, then emit singles for what's left. The
+        five previous tests act as the safety net for the rewrite — and all five
+        still pass because counting-and-emitting is observationally equivalent to
+        the per-die loop for non-combo cases.
+
+    tests:
+      - description: "test_three_ones_create_dragon_blast_instead_of_three_flames function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_three_ones_create_dragon_blast_instead_of_three_flames' in source, \
+              "Add the test function `test_three_ones_create_dragon_blast_instead_of_three_flames`"
+
+      - description: "Implementation uses Counter (the count-then-emit shape)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'Counter' in source, \
+              "Cycle 6's structural shift is from `for die in dice:` to counting occurrences with `collections.Counter`. Without that, the combo case `[1, 1, 1]` cannot be detected without re-walking the list."
+
+      - description: "Combo logic precedes leftover singles (Dragon Blast comes before Dragon Flame in the events tuple)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'Dragon Blast' in source, \
+              "The new event name `Dragon Blast` must be emitted by score() when the roll contains three 1s"
+
+      - description: "All six tests pass"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All six tests should pass after the count-then-emit refactor:\n{output}"
+
+    quiz:
+      title: "Cycle 6 Quiz — Design-Breaking Tests"
+      min_score: 0.8
+      shuffle: true
+      questions:
+
+        - question: |
+            What makes cycle 6's test a *design-breaking* test, as opposed to a normal "add a branch" test?
+          type: single
+          options:
+            - "Cycle 6's assertion is longer than previous assertions, so the implementation has to grow proportionally to satisfy it"
+            - "The per-die loop processes each die in isolation. There is no way for the loop to know, when it sees the first 1, that two more 1s exist later. Counting *requires* a structural shift — not a new branch"
+            - "It uses pytest.raises, which forces the implementation to add exception handling"
+            - "It tests three dice instead of one or two, and pytest internally requires a different runner for tests that exceed two arguments"
+          correct_index: 1
+          explanation: |
+            A *design-breaking* test is one no local edit can satisfy. The cycle-4 loop is
+            fundamentally per-die; combos are fundamentally per-face-count. You cannot
+            patch your way from one to the other — you have to re-shape the algorithm.
+            That re-shaping is what the test extracts as design pressure.
+
+        - question: |
+            After the count-then-emit refactor, all five previous tests still passed. What does that tell you about the previous tests?
+          type: single
+          options:
+            - "That they were unnecessary — passing on a totally different implementation means they were not pinning down anything specific"
+            - "That they were testing observable behavior (return values), not implementation details (which loop was used). Behavior-level tests survive a structural rewrite; implementation-level tests would have broken"
+            - "That pytest silently re-imports the previous implementation if the new one breaks them, so the green bar in this case is misleading"
+            - "That the previous tests were duplicates of each other and could be deleted to simplify the suite"
+          correct_index: 1
+          explanation: |
+            This is the *Refactoring Litmus Test* concept. Robust tests assert on what the
+            unit *does* (`report.total_damage == 100`, `report.events == (event,)`), not
+            on *how* it does it (`assert "for die in dice" in inspect.getsource(score)`).
+            The first survives a rewrite; the second breaks at the slightest refactor.
+
+        - question: |
+            Why does cycle 6's GREEN code subtract from `counts[1]` after emitting the Dragon Blast event?
+          type: single
+          options:
+            - "To avoid an off-by-one error in the next cycle's parametrized tests"
+            - "Because a combo *consumes* the dice it uses. If three 1s become a Dragon Blast, those three 1s are no longer available to score as Dragon Flames. The subtraction makes the bookkeeping explicit"
+            - "Because Python's Counter requires explicit decrement after every read; otherwise it caches stale values"
+            - "It is a stylistic choice — `counts[1] = 0` and `del counts[1]` would also work and produce the same behavior"
+          correct_index: 1
+          explanation: |
+            "Combos consume dice, leftovers still score as singles" is one of the rules. The
+            subtraction isn't a Python quirk — it is the domain rule made explicit in the
+            code. Cycle 7's test will verify exactly this leftover behavior.
+
+        - question: |
+            **(Spaced review — Cycle 4)** A teammate suggests "let's just add `if Counter(dice)[1] >= 3: ...` at the top of the existing per-die loop." Why is that *not* the same as the count-then-emit refactor we did?
+          type: single
+          options:
+            - "It would still re-walk dice in two different shapes (the loop + the Counter pass), which is a different smell — the code now has two competing models of what the input is, and future combos would multiply the inconsistency"
+            - "It would be slightly faster but would produce the same result, so functionally it is equivalent"
+            - "It would not work in Python — `Counter` cannot be called inside a `for` loop body"
+            - "Pytest would refuse to run it because the test runner forbids mixing iteration styles"
+          correct_index: 0
+          explanation: |
+            The refactor is not "add Counter on top of the existing loop." It is "*replace*
+            the per-die view with the per-face-count view." Mixing both is the worst of
+            both worlds: now the function maintains two parallel models of the input, and
+            every future change has to update both. The structural shift was the point.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 9 — Cycle 7: Combo + leftover singles (no production change!)
+  # Pedagogy:
+  #   Variation theory     — same shape, exercises the leftover bookkeeping.
+  #   Documentation tests  — tests that pin down behavior the design already has.
+  #   No quiz — light cycle to consolidate before the rule-object refactor.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 7 — Combo with Leftover Singles"
+    instructions: |
+      > **Spec:** `score([1, 1, 1, 1, 5])` produces one Dragon Blast plus *one* leftover Flame and a Lightning Spark.
+
+      Cycle 6's `counts[1] -= 3` already handles this — but until a test asserts it, the leftover behavior is only *implicitly* correct. A future refactor could break it silently. Cycle 7 turns implicit correctness into an explicit guardrail.
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_dragon_blast_plus_leftover_flame_and_spark`. **Predict** whether it passes immediately, then run.
+      2. **🟢 GREEN** — likely no production change. The cycle-6 design already produces this output.
+      3. **🔵 REFACTOR + mutation check** — apply the cycle-5 mutation move *required* this time: change `counts[1] -= 3` to `counts[1] -= 4`, run, confirm cycle 7 fails, restore. That proves the test is a real guardrail.
+
+      ### Why guardrail tests matter
+
+      The most common way a TDD suite degrades over time is *implicit correctness silently rotting into implicit incorrectness*. A behavior the code does today, but no test asserts, can disappear in a refactor — and nobody notices until a customer reports the bug. The discipline: when you spot behavior that "just works," ask if a future refactor could break it. If yes, write the test that protects it.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from collections import Counter
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          def score(dice):
+              counts = Counter(dice)
+              events = []
+
+              if counts[1] >= 3:
+                  events.append(ScoringEvent("Dragon Blast", (1, 1, 1), 1000))
+                  counts[1] -= 3
+
+              for _ in range(counts[1]):
+                  events.append(ScoringEvent("Dragon Flame", (1,), 100))
+
+              for _ in range(counts[5]):
+                  events.append(ScoringEvent("Lightning Spark", (5,), 50))
+
+              return BattleReport(tuple(events))
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–7 — adding the leftover-singles guardrail."""
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_one_and_five_create_two_different_events():
+              report = score([1, 5])
+
+              assert report.total_damage == 150
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_ones_create_dragon_blast_instead_of_three_flames():
+              report = score([1, 1, 1])
+
+              assert report.total_damage == 1000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          # TODO (RED): write test_dragon_blast_plus_leftover_flame_and_spark
+          #             score([1, 1, 1, 1, 5]) should return total_damage == 1150
+          #             with a Dragon Blast, then a Dragon Flame, then a Lightning Spark
+        language: "python"
+
+    open_file: "test_scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from collections import Counter
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            def score(dice):
+                counts = Counter(dice)
+                events = []
+
+                if counts[1] >= 3:
+                    events.append(ScoringEvent("Dragon Blast", (1, 1, 1), 1000))
+                    counts[1] -= 3
+
+                for _ in range(counts[1]):
+                    events.append(ScoringEvent("Dragon Flame", (1,), 100))
+
+                for _ in range(counts[5]):
+                    events.append(ScoringEvent("Lightning Spark", (5,), 50))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–7 — leftover bookkeeping protected by a guardrail test."""
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_one_and_five_create_two_different_events():
+                report = score([1, 5])
+
+                assert report.total_damage == 150
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_ones_create_dragon_blast_instead_of_three_flames():
+                report = score([1, 1, 1])
+
+                assert report.total_damage == 1000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+
+
+            def test_dragon_blast_plus_leftover_flame_and_spark():
+                report = score([1, 1, 1, 1, 5])
+
+                assert report.total_damage == 1150
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+          language: "python"
+      explanation: |
+        Cycle 6's `counts[1] -= 3` already produces the right output. Cycle 7's test
+        documents that intent — converting an implicit correctness into an explicit
+        guardrail. Mutate `-= 3` to `-= 4` on purpose to confirm the test catches it.
+
+    tests:
+      - description: "test_dragon_blast_plus_leftover_flame_and_spark function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_dragon_blast_plus_leftover_flame_and_spark' in source, \
+              "Add the test function `test_dragon_blast_plus_leftover_flame_and_spark`"
+
+      - description: "All seven tests pass without any production change"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All seven tests should pass — cycle 7's test passes for free thanks to cycle 6's `counts[1] -= 3`:\n{output}"
+
+      - description: "scorer.py still uses Counter (cycle 6's structure is intact)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'Counter' in source, \
+              "Do not regress to a per-die loop — the count-then-emit shape from cycle 6 is the design that lets cycle 7's test pass for free."
+
+    # NO QUIZ — light cycle, consolidating before cycle 8's big refactor.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 10 — Cycle 8: Three 2s + RULE OBJECTS REFACTOR + QUIZ
+  # Pedagogy:
+  #   Listening to the test  — adding a fourth combo branch is painful, on purpose.
+  #   Extract data from code — ComboRule + SingleRule with apply() method.
+  #   Open-Closed Principle  — new behavior = new data, not new branches.
+  #   Quiz                   — checks "listen to the test" interpretation.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 8 — Goblin Swarm → Rule Objects (Big Refactor)"
+    instructions: |
+      > **Spec:** three 2s combine into a *Goblin Swarm* (200 damage).
+
+      Before writing anything, imagine where `if counts[2] >= 3:` would go. Now imagine *six more triple combos* (cycles 9–14) each adding their own if-and-subtract block. Painful? **That pain is the design pressure.** Cycle 8 is when the structure has to change.
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_three_twos_create_goblin_swarm`, structured like cycle 6's test. Run; the existing code knows nothing about 2s.
+      2. **🟢 GREEN** — you have two choices:
+         - *Option A*: another `if counts[2] >= 3:` block. Local minimum, multiplies the pain five-fold across cycles 9–14.
+         - *Option B*: extract the rule shape into data. Pull combo-rule logic into a `ComboRule` class with an `apply(counts)` method; same for `SingleRule`. Then drive `score` from two registries.
+      3. **🔵 REFACTOR** — option B *is* the refactor. Re-run; the seven prior tests are your safety net.
+
+      ### Listening to the test & the Open-Closed Principle
+
+      The discipline of *listening to the test*: the difficulty of imagining six more if-blocks was a signal — the structure no longer fit. The cure is structural extraction.
+
+      You just applied the **Open-Closed Principle**: `score` is now *closed for modification* (you won't edit it again) but *open for extension* (cycle 9 will add four rules by appending data). Adding behavior = adding data, not editing code.
+
+      Refactor *toward* duplication, not before. Two data points (Dragon Blast + Goblin Swarm) are now enough to see the right shape; with one, you'd be guessing.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from collections import Counter
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          def score(dice):
+              counts = Counter(dice)
+              events = []
+
+              if counts[1] >= 3:
+                  events.append(ScoringEvent("Dragon Blast", (1, 1, 1), 1000))
+                  counts[1] -= 3
+
+              for _ in range(counts[1]):
+                  events.append(ScoringEvent("Dragon Flame", (1,), 100))
+
+              for _ in range(counts[5]):
+                  events.append(ScoringEvent("Lightning Spark", (5,), 50))
+
+              return BattleReport(tuple(events))
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–8 — Goblin Swarm forces the rule-object refactor."""
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_one_and_five_create_two_different_events():
+              report = score([1, 5])
+
+              assert report.total_damage == 150
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_ones_create_dragon_blast_instead_of_three_flames():
+              report = score([1, 1, 1])
+
+              assert report.total_damage == 1000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          def test_dragon_blast_plus_leftover_flame_and_spark():
+              report = score([1, 1, 1, 1, 5])
+
+              assert report.total_damage == 1150
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          # TODO (RED): write test_three_twos_create_goblin_swarm
+          #             score([2, 2, 2]) should return total_damage == 200 with
+          #             a Goblin Swarm event whose dice_used is (2, 2, 2)
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from collections import Counter
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            @dataclass(frozen=True)
+            class ComboRule:
+                die: int
+                count: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    if counts[self.die] >= self.count:
+                        dice_used = tuple([self.die] * self.count)
+                        events.append(ScoringEvent(self.name, dice_used, self.damage))
+                        counts[self.die] -= self.count
+
+                    return events
+
+
+            @dataclass(frozen=True)
+            class SingleRule:
+                die: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    for _ in range(counts[self.die]):
+                        events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                    return events
+
+
+            COMBO_RULES = (
+                ComboRule(1, 3, "Dragon Blast", 1000),
+                ComboRule(2, 3, "Goblin Swarm", 200),
+            )
+
+            SINGLE_RULES = (
+                SingleRule(1, "Dragon Flame", 100),
+                SingleRule(5, "Lightning Spark", 50),
+            )
+
+
+            def score(dice):
+                counts = Counter(dice)
+                events = []
+
+                for rule in COMBO_RULES:
+                    events.extend(rule.apply(counts))
+
+                for rule in SINGLE_RULES:
+                    events.extend(rule.apply(counts))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–8 — rule objects power the design."""
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_one_and_five_create_two_different_events():
+                report = score([1, 5])
+
+                assert report.total_damage == 150
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_ones_create_dragon_blast_instead_of_three_flames():
+                report = score([1, 1, 1])
+
+                assert report.total_damage == 1000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+
+
+            def test_dragon_blast_plus_leftover_flame_and_spark():
+                report = score([1, 1, 1, 1, 5])
+
+                assert report.total_damage == 1150
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_twos_create_goblin_swarm():
+                report = score([2, 2, 2])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+                )
+          language: "python"
+      explanation: |
+        Extract `ComboRule` and `SingleRule` dataclasses with an `apply` method, plus
+        two registry tuples (`COMBO_RULES`, `SINGLE_RULES`). The `score` function
+        becomes two trivial loops. New rules are now data — cycle 9 will append four
+        rows to `COMBO_RULES` without touching `score` at all.
+
+    tests:
+      - description: "test_three_twos_create_goblin_swarm function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_three_twos_create_goblin_swarm' in source, \
+              "Add the test function `test_three_twos_create_goblin_swarm`"
+
+      - description: "ComboRule class is defined"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'class ComboRule' in source, \
+              "Cycle 8's refactor introduces a `ComboRule` dataclass with an `apply(self, counts)` method. See the worked example."
+
+      - description: "SingleRule class is defined"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'class SingleRule' in source, \
+              "Cycle 8's refactor introduces a `SingleRule` dataclass — the per-occurrence sibling of `ComboRule`."
+
+      - description: "COMBO_RULES registry exists with at least Dragon Blast and Goblin Swarm"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'COMBO_RULES' in source, "Define a `COMBO_RULES` tuple of `ComboRule` instances at module level"
+          assert 'Dragon Blast' in source and 'Goblin Swarm' in source, \
+              "COMBO_RULES must include at least the Dragon Blast (triple 1) and Goblin Swarm (triple 2) rules"
+
+      - description: "SINGLE_RULES registry exists with Dragon Flame and Lightning Spark"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'SINGLE_RULES' in source, "Define a `SINGLE_RULES` tuple of `SingleRule` instances at module level"
+
+      - description: "score() body iterates over rules (no hardcoded counts[1] etc.)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          # If the student forgot to refactor score(), you'd still see the old
+          # `if counts[1] >= 3:` literal. Reject it.
+          assert 'counts[1] >= 3' not in source, \
+              "After the rule-object refactor, `score()` should not contain hardcoded combo checks like `if counts[1] >= 3:`. The combo logic now lives in `ComboRule.apply` and is driven by the COMBO_RULES registry."
+
+      - description: "All eight tests pass"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All eight tests should pass after the rule-object refactor:\n{output}"
+
+    quiz:
+      title: "Cycle 8 Quiz — Listening to the Test"
+      min_score: 0.8
+      shuffle: true
+      questions:
+
+        - question: |
+            What does "listening to the test" mean as a refactoring heuristic?
+          type: single
+          options:
+            - "Read every test out loud before running it, to catch typos in the test names that pytest cannot detect"
+            - "Treat the *difficulty* of writing or understanding a test (or the *pain* of adding new branches that match its shape) as a diagnostic signal that the production code's structure may be the real problem"
+            - "Use only test names that the codebase's audit log specifically asks for, ignoring the developer's own intuition about what to call them"
+            - "Run pytest with `--log-cli-level=DEBUG` and inspect the trace, since that output reveals the next refactor"
+          correct_index: 1
+          explanation: |
+            "Listen to the test" is a foundational TDD heuristic: when adding a test or a
+            branch hurts disproportionately, the structure is telling you something. In
+            cycle 8, the pain of imagining six more `if counts[X] >= 3:` branches was the
+            signal. The fix was a structural shift to data, not more code.
+
+        - question: |
+            Why is putting rules in a `COMBO_RULES` tuple of `ComboRule` instances **better** than keeping them as `if counts[X] >= 3:` branches inside `score()`?
+          type: single
+          options:
+            - "It is not better — it is just stylistically different. The byte code emitted is identical and the runtime cost is the same"
+            - "Adding a new rule now means appending one row of data, with no edit to `score()`. That is the Open-Closed Principle: the function is *closed* for modification but *open* for extension via the registry"
+            - "Tuples are faster than lists in Python, so the rule-object form is a performance optimisation"
+            - "Python's import system caches tuples but not function bodies, so subsequent test runs are quicker"
+          correct_index: 1
+          explanation: |
+            The Open-Closed Principle (OCP) says modules should be open for extension and
+            closed for modification. The rule-object refactor is the OCP in five lines:
+            `score()` no longer changes when you add a new triple combo — only the data
+            does. Cycle 9 will demonstrate the payoff by adding *four* combos at once.
+
+        - question: |
+            A teammate says: *"You should have done the rule-object refactor in cycle 6, when you first introduced combos. Why wait?"* What is the **most defensible** answer?
+          type: single
+          options:
+            - "Refactoring earlier would have been wrong — the rule-object shape only became visible after cycle 8's test added a *second* combo, and refactoring with one example is guessing at the right shape"
+            - "Cycle 6 was technically possible but pytest had not yet released support for dataclasses, so the refactor would have failed at import time"
+            - "It is a stylistic preference — both orderings produce identical code in the end and one is not measurably better than the other"
+            - "Earlier refactoring is always better; the tutorial's order is artificial and you should always do the biggest refactor as soon as you can"
+          correct_index: 0
+          explanation: |
+            Two data points are the minimum for seeing the right *shape* of an abstraction.
+            With only `Dragon Blast` (cycle 6), you'd be guessing whether the variation is
+            "the die that triggers" or "the count required" or "the name." Cycle 8's
+            `Goblin Swarm` provides the second data point, and only then is `ComboRule(die,
+            count, name, damage)` a *discovery* rather than a *guess*. Refactor *toward*
+            duplication, not *before* it.
+
+        - question: |
+            **(Spaced review — Cycle 6)** After the rule-object refactor, all seven previous tests still pass. Why is this expected, and what does it confirm about the previous tests?
+          type: single
+          options:
+            - "It is unexpected — refactoring should always break something. If nothing broke, the previous tests must have been weak"
+            - "It is expected because the previous tests assert on behavior (return values), not on internals (which class held the rule data). Behavior-level assertions survive structural rewrites — that is what makes them robust"
+            - "It is expected because pytest skips tests whose names contain numbers — and several of the previous tests do"
+            - "It is unexpected because Python's import order changed, so most tests should have failed to import"
+          correct_index: 1
+          explanation: |
+            The seven previous tests asserted on `report.total_damage`, `report.events`,
+            and `ScoringEvent` instances. None of them asserted on internal structure.
+            That is precisely why they survived a refactor that *replaced the entire
+            implementation strategy*. The Refactoring Litmus Test: behavior tests survive
+            structural change; implementation tests don't.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 11 — Cycle 9: Other triples (parametrize the test, append data)
+  # Pedagogy:
+  #   Open-Closed payoff   — new behaviors arrive as DATA, not as code edits.
+  #   pytest.parametrize   — same shape, varied inputs, distinct test results.
+  #   No quiz — the payoff is itself the demonstration.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 9 — Add the Rest of the Combo Rules"
+    instructions: |
+      > **Spec:** the four remaining triples — Triple 3 → Orc Charge (300), Triple 4 → Troll Smash (400), Triple 5 → Lightning Storm (500), Triple 6 → Demon Strike (600).
+
+      This cycle exists to **prove cycle 8's refactor paid off**. Four new behaviors → no edits to `score()`.
+
+      ## Your task
+
+      1. **🔴 RED** — write *one* parametrised test (`@pytest.mark.parametrize`) covering all four triples. Each row runs as a separate pytest result.
+      2. **🟢 GREEN** — append four rows to `COMBO_RULES`. **Do not touch `score()`.** That's the proof.
+      3. **🔵 REFACTOR** — re-run; check duplication (none — rules are data) and that all 12 results pass.
+
+      ### Why parametrize beats a for-loop inside one test
+
+      `@pytest.mark.parametrize` runs the function once per row, reporting each as a separate test result. A `for` loop inside a single test stops at the first failure, hiding everything after it. The parametrise idiom is the right Python answer to "N tests of the same shape" — DRY tests that still report separate failures.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from collections import Counter
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          @dataclass(frozen=True)
+          class ComboRule:
+              die: int
+              count: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  if counts[self.die] >= self.count:
+                      dice_used = tuple([self.die] * self.count)
+                      events.append(ScoringEvent(self.name, dice_used, self.damage))
+                      counts[self.die] -= self.count
+
+                  return events
+
+
+          @dataclass(frozen=True)
+          class SingleRule:
+              die: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  for _ in range(counts[self.die]):
+                      events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                  return events
+
+
+          COMBO_RULES = (
+              ComboRule(1, 3, "Dragon Blast", 1000),
+              ComboRule(2, 3, "Goblin Swarm", 200),
+          )
+
+          SINGLE_RULES = (
+              SingleRule(1, "Dragon Flame", 100),
+              SingleRule(5, "Lightning Spark", 50),
+          )
+
+
+          def score(dice):
+              counts = Counter(dice)
+              events = []
+
+              for rule in COMBO_RULES:
+                  events.extend(rule.apply(counts))
+
+              for rule in SINGLE_RULES:
+                  events.extend(rule.apply(counts))
+
+              return BattleReport(tuple(events))
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–9 — adding the four remaining triple combos."""
+          import pytest
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_one_and_five_create_two_different_events():
+              report = score([1, 5])
+
+              assert report.total_damage == 150
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_ones_create_dragon_blast_instead_of_three_flames():
+              report = score([1, 1, 1])
+
+              assert report.total_damage == 1000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          def test_dragon_blast_plus_leftover_flame_and_spark():
+              report = score([1, 1, 1, 1, 5])
+
+              assert report.total_damage == 1150
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_twos_create_goblin_swarm():
+              report = score([2, 2, 2])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+              )
+
+
+          # TODO (RED): write a parametrized test_other_triples_create_combo_events
+          #             that covers triples of 3, 4, 5, 6 with their respective events
+        language: "python"
+
+    open_file: "test_scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from collections import Counter
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            @dataclass(frozen=True)
+            class ComboRule:
+                die: int
+                count: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    if counts[self.die] >= self.count:
+                        dice_used = tuple([self.die] * self.count)
+                        events.append(ScoringEvent(self.name, dice_used, self.damage))
+                        counts[self.die] -= self.count
+
+                    return events
+
+
+            @dataclass(frozen=True)
+            class SingleRule:
+                die: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    for _ in range(counts[self.die]):
+                        events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                    return events
+
+
+            COMBO_RULES = (
+                ComboRule(1, 3, "Dragon Blast", 1000),
+                ComboRule(2, 3, "Goblin Swarm", 200),
+                ComboRule(3, 3, "Orc Charge", 300),
+                ComboRule(4, 3, "Troll Smash", 400),
+                ComboRule(5, 3, "Lightning Storm", 500),
+                ComboRule(6, 3, "Demon Strike", 600),
+            )
+
+            SINGLE_RULES = (
+                SingleRule(1, "Dragon Flame", 100),
+                SingleRule(5, "Lightning Spark", 50),
+            )
+
+
+            def score(dice):
+                counts = Counter(dice)
+                events = []
+
+                for rule in COMBO_RULES:
+                    events.extend(rule.apply(counts))
+
+                for rule in SINGLE_RULES:
+                    events.extend(rule.apply(counts))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–9 — all six triples expressible as data."""
+            import pytest
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_one_and_five_create_two_different_events():
+                report = score([1, 5])
+
+                assert report.total_damage == 150
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_ones_create_dragon_blast_instead_of_three_flames():
+                report = score([1, 1, 1])
+
+                assert report.total_damage == 1000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+
+
+            def test_dragon_blast_plus_leftover_flame_and_spark():
+                report = score([1, 1, 1, 1, 5])
+
+                assert report.total_damage == 1150
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_twos_create_goblin_swarm():
+                report = score([2, 2, 2])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+                )
+
+
+            @pytest.mark.parametrize(
+                "roll, expected_event",
+                [
+                    ([3, 3, 3], ScoringEvent("Orc Charge", (3, 3, 3), 300)),
+                    ([4, 4, 4], ScoringEvent("Troll Smash", (4, 4, 4), 400)),
+                    ([5, 5, 5], ScoringEvent("Lightning Storm", (5, 5, 5), 500)),
+                    ([6, 6, 6], ScoringEvent("Demon Strike", (6, 6, 6), 600)),
+                ],
+            )
+            def test_other_triples_create_combo_events(roll, expected_event):
+                report = score(roll)
+
+                assert report.total_damage == expected_event.damage
+                assert report.events == (expected_event,)
+          language: "python"
+      explanation: |
+        Append four rows to COMBO_RULES — one per remaining triple. The score()
+        function does not change. The parametrize decorator turns one test function
+        into four separately-reported test results, each pinning down one combo.
+
+    tests:
+      - description: "test_other_triples_create_combo_events function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_other_triples_create_combo_events' in source, \
+              "Add the parametrized test function `test_other_triples_create_combo_events`"
+
+      - description: "Test uses @pytest.mark.parametrize"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert '@pytest.mark.parametrize' in source, \
+              "Use @pytest.mark.parametrize for the four-combo test — not a `for` loop inside a single test function"
+
+      - description: "All six combo rules are now in COMBO_RULES"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          for combo_name in ['Dragon Blast', 'Goblin Swarm', 'Orc Charge', 'Troll Smash', 'Lightning Storm', 'Demon Strike']:
+              assert combo_name in source, \
+                  f"COMBO_RULES is missing `{combo_name}` — add a ComboRule row for it"
+
+      - description: "All tests pass (8 individual + 4 parametrized rows = 12 results)"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All twelve test results should pass after appending the four new ComboRule rows:\n{output}"
+
+      - description: "score() body was not edited (the rule-object refactor paid off)"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          # The score() body should still be the two-loop form from cycle 8.
+          # If a student went back and inlined any combo logic, that's a regression.
+          assert 'Orc Charge' not in source.split('def score(')[1] if 'def score(' in source else True, \
+              "score() should not directly mention any combo name — the rules live in COMBO_RULES. New behaviors are added as data, not by editing the function."
+
+    # NO QUIZ — the payoff itself is the lesson.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 12 — Cycle 10: Six 1s = TWO Dragon Blasts (HIDDEN EDGE CASE) + QUIZ
+  # Pedagogy:
+  #   Productive failure   — the "obvious" code has a bug; the test reveals it.
+  #   Boundary thinking    — three is enough; six is two combos worth.
+  #   Quiz                 — checks "TDD finds bugs you didn't know you had."
+  # --------------------------------------------------------------------------
+  - title: "Cycle 10 — Six 1s → Two Dragon Blasts (Hidden Bug)"
+    instructions: |
+      > **Spec:** `score([1, 1, 1, 1, 1, 1])` produces **two** Dragon Blasts (2000 damage).
+
+      **Predict first.** Before writing a test, look at your `ComboRule.apply` and trace through six 1s by hand. What does the current code actually produce?
+
+
+
+      ### Reveal the hidden bug (open after you've predicted)
+
+      The `if counts[1] >= 3:` runs once. It emits one Blast and `counts[1] -= 3` leaves `counts[1] == 3`. Those three 1s fall through to `SingleRule`, emitting three Flames. Total: 1000 + 300 = **1300 damage**.
+
+      But six 1s should be *two* Blasts → 2000 damage. **The code is wrong** — and no previous test caught it, because every prior combo test used exactly three of a face.
+
+      This is the kind of bug TDD literature reports: a defect the developer doesn't know exists in code they wrote themselves. The test surfaces it.
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_six_ones_create_two_dragon_blasts` asserting 2000 damage and two Blast events. Run; see the wrong events tuple.
+      2. **🟢 GREEN** — fix `ComboRule.apply` so it can emit *zero or more* combos per call, with the correct leftover bookkeeping. Hint: floor-division (`//`) and modulo (`%`) are the right operators.
+      3. **🔵 REFACTOR** — re-run. Especially gratifying: cycle 7's leftover guardrail still passes, because `4 % 3 == 1` matches `4 - 3 == 1` for that input. The fix only changed behavior on cases no prior test pinned down.
+
+      ### What this teaches about coverage vs. boundary thinking
+
+      Every previous combo test used *exactly* `count` dice (three 1s, three 2s, etc.). The bug only manifests at `2 × count` and beyond. *Line coverage* told you the `if` ran. It didn't tell you the line was right *for all relevant inputs*.
+
+      That's the gap between coverage and **boundary-value analysis**: every behavior has boundaries (`0`, `exactly N`, `2N`, `between N and 2N`) and a healthy suite probes each. Coverage is a *locator of under-tested code*; it isn't a measure of correctness.
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from collections import Counter
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          @dataclass(frozen=True)
+          class ComboRule:
+              die: int
+              count: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  if counts[self.die] >= self.count:
+                      dice_used = tuple([self.die] * self.count)
+                      events.append(ScoringEvent(self.name, dice_used, self.damage))
+                      counts[self.die] -= self.count
+
+                  return events
+
+
+          @dataclass(frozen=True)
+          class SingleRule:
+              die: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  for _ in range(counts[self.die]):
+                      events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                  return events
+
+
+          COMBO_RULES = (
+              ComboRule(1, 3, "Dragon Blast", 1000),
+              ComboRule(2, 3, "Goblin Swarm", 200),
+              ComboRule(3, 3, "Orc Charge", 300),
+              ComboRule(4, 3, "Troll Smash", 400),
+              ComboRule(5, 3, "Lightning Storm", 500),
+              ComboRule(6, 3, "Demon Strike", 600),
+          )
+
+          SINGLE_RULES = (
+              SingleRule(1, "Dragon Flame", 100),
+              SingleRule(5, "Lightning Spark", 50),
+          )
+
+
+          def score(dice):
+              counts = Counter(dice)
+              events = []
+
+              for rule in COMBO_RULES:
+                  events.extend(rule.apply(counts))
+
+              for rule in SINGLE_RULES:
+                  events.extend(rule.apply(counts))
+
+              return BattleReport(tuple(events))
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–10 — surfacing the multi-combo edge case."""
+          import pytest
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_one_and_five_create_two_different_events():
+              report = score([1, 5])
+
+              assert report.total_damage == 150
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_ones_create_dragon_blast_instead_of_three_flames():
+              report = score([1, 1, 1])
+
+              assert report.total_damage == 1000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          def test_dragon_blast_plus_leftover_flame_and_spark():
+              report = score([1, 1, 1, 1, 5])
+
+              assert report.total_damage == 1150
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_twos_create_goblin_swarm():
+              report = score([2, 2, 2])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+              )
+
+
+          @pytest.mark.parametrize(
+              "roll, expected_event",
+              [
+                  ([3, 3, 3], ScoringEvent("Orc Charge", (3, 3, 3), 300)),
+                  ([4, 4, 4], ScoringEvent("Troll Smash", (4, 4, 4), 400)),
+                  ([5, 5, 5], ScoringEvent("Lightning Storm", (5, 5, 5), 500)),
+                  ([6, 6, 6], ScoringEvent("Demon Strike", (6, 6, 6), 600)),
+              ],
+          )
+          def test_other_triples_create_combo_events(roll, expected_event):
+              report = score(roll)
+
+              assert report.total_damage == expected_event.damage
+              assert report.events == (expected_event,)
+
+
+          # TODO (RED): write test_six_ones_create_two_dragon_blasts
+          #             score([1, 1, 1, 1, 1, 1]) should return total_damage == 2000
+          #             and events containing TWO Dragon Blast ScoringEvents
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from collections import Counter
+            from dataclasses import dataclass
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            @dataclass(frozen=True)
+            class ComboRule:
+                die: int
+                count: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    number_of_combos = counts[self.die] // self.count
+
+                    for _ in range(number_of_combos):
+                        dice_used = tuple([self.die] * self.count)
+                        events.append(ScoringEvent(self.name, dice_used, self.damage))
+
+                    counts[self.die] %= self.count
+
+                    return events
+
+
+            @dataclass(frozen=True)
+            class SingleRule:
+                die: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    for _ in range(counts[self.die]):
+                        events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                    return events
+
+
+            COMBO_RULES = (
+                ComboRule(1, 3, "Dragon Blast", 1000),
+                ComboRule(2, 3, "Goblin Swarm", 200),
+                ComboRule(3, 3, "Orc Charge", 300),
+                ComboRule(4, 3, "Troll Smash", 400),
+                ComboRule(5, 3, "Lightning Storm", 500),
+                ComboRule(6, 3, "Demon Strike", 600),
+            )
+
+            SINGLE_RULES = (
+                SingleRule(1, "Dragon Flame", 100),
+                SingleRule(5, "Lightning Spark", 50),
+            )
+
+
+            def score(dice):
+                counts = Counter(dice)
+                events = []
+
+                for rule in COMBO_RULES:
+                    events.extend(rule.apply(counts))
+
+                for rule in SINGLE_RULES:
+                    events.extend(rule.apply(counts))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–10 — multi-combo edge case fixed."""
+            import pytest
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_one_and_five_create_two_different_events():
+                report = score([1, 5])
+
+                assert report.total_damage == 150
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_ones_create_dragon_blast_instead_of_three_flames():
+                report = score([1, 1, 1])
+
+                assert report.total_damage == 1000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+
+
+            def test_dragon_blast_plus_leftover_flame_and_spark():
+                report = score([1, 1, 1, 1, 5])
+
+                assert report.total_damage == 1150
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_twos_create_goblin_swarm():
+                report = score([2, 2, 2])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+                )
+
+
+            @pytest.mark.parametrize(
+                "roll, expected_event",
+                [
+                    ([3, 3, 3], ScoringEvent("Orc Charge", (3, 3, 3), 300)),
+                    ([4, 4, 4], ScoringEvent("Troll Smash", (4, 4, 4), 400)),
+                    ([5, 5, 5], ScoringEvent("Lightning Storm", (5, 5, 5), 500)),
+                    ([6, 6, 6], ScoringEvent("Demon Strike", (6, 6, 6), 600)),
+                ],
+            )
+            def test_other_triples_create_combo_events(roll, expected_event):
+                report = score(roll)
+
+                assert report.total_damage == expected_event.damage
+                assert report.events == (expected_event,)
+
+
+            def test_six_ones_create_two_dragon_blasts():
+                report = score([1, 1, 1, 1, 1, 1])
+
+                assert report.total_damage == 2000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+          language: "python"
+      explanation: |
+        The fix in ComboRule.apply: replace the one-shot `if` with a per-combo loop
+        driven by floor division (`counts[self.die] // self.count`), and replace
+        the subtraction with modulo (`counts[self.die] %= self.count`). Cycle 7's
+        guardrail still passes because `4 % 3 == 1` matches the previous `4 - 3 ==
+        1` for that specific input — the disagreement is only on multi-combo cases.
+
+    tests:
+      - description: "test_six_ones_create_two_dragon_blasts function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_six_ones_create_two_dragon_blasts' in source, \
+              "Add the test function `test_six_ones_create_two_dragon_blasts`"
+
+      - description: "ComboRule.apply uses floor-division (// self.count) for multi-combo"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert '// self.count' in source.replace(' ', ' ') or '//self.count' in source.replace(' ', ''), \
+              "ComboRule.apply must compute the number of combos as `counts[self.die] // self.count`. Without floor-division, six 1s only produces one Dragon Blast."
+
+      - description: "ComboRule.apply uses modulo (%= self.count) for the leftover"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert '%= self.count' in source.replace(' ', ' ') or '%=self.count' in source.replace(' ', ''), \
+              "ComboRule.apply must reduce counts[self.die] using `%= self.count` — modulo is the right operator when combos can repeat."
+
+      - description: "All tests pass (cycle 7's guardrail and the new multi-combo case)"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All tests should pass, including cycle 7's leftover-singles guardrail and the new multi-combo case:\n{output}"
+
+    quiz:
+      title: "Cycle 10 Quiz — TDD Finds Bugs You Didn't Know You Had"
+      min_score: 0.8
+      shuffle: true
+      questions:
+
+        - question: |
+            The "one Dragon Blast for any number of 1s ≥ 3" bug was sitting in your code from cycle 6 onward — *four cycles*. Why did no previous test catch it?
+          type: single
+          options:
+            - "pytest's collection algorithm has a known issue with bugs that span multiple cycles, so it deferred reporting"
+            - "Every previous test used at most three of a face (three 1s, three 2s, etc.). The bug only manifests when the count of a face is at least *six*. The suite had no such input, so the defect lived undisturbed"
+            - "The bug only manifests on Tuesdays, and the previous test runs happened on other days"
+            - "Cycle 6's `if counts[1] >= 3:` is correct — there was no bug; cycle 10 changed the requirement"
+          correct_index: 1
+          explanation: |
+            Boundary thinking. Every previous combo test gave the rule *exactly* `count`
+            dice. The bug was on the boundary where `counts[X] >= 2 * count`. Without a test
+            on that boundary, the code would have shipped wrong — and the developer would
+            have been completely confident in it. This is exactly the kind of failure mode
+            empirical TDD studies report.
+
+        - question: |
+            What is the **most defensible** general lesson from cycle 10 about test-suite design?
+          type: single
+          options:
+            - "Always test every input combinatorially — only complete coverage of the input space catches all bugs"
+            - "Coverage by line is what matters; cycle 10's bug was in code already covered, so coverage didn't help. The lesson is to *also* think about boundary cases (`exactly N`, `2N`, `between N and 2N`, `0`) per behavior"
+            - "Never use floor-division and modulo in production code — they are too easy to get wrong"
+            - "TDD is unreliable; this bug proves that even careful test-first development can miss things, so we should add manual QA after every cycle"
+          correct_index: 1
+          explanation: |
+            *Coverage* told us we executed the line. It did not tell us whether the line
+            was right *for all relevant inputs*. Boundary-value analysis (the partition
+            tradition you encountered in Foundations) complements coverage: every behavior
+            has a "just-at-the-boundary," "just-past-the-boundary," and "well-past-the-
+            boundary" input — and a healthy suite probes each.
+
+        - question: |
+            Cycle 7's guardrail (`[1, 1, 1, 1, 5]`) still passes after cycle 10's refactor. Why? Be precise.
+          type: single
+          options:
+            - "Because pytest skips guardrail tests after they pass once — they are stored as cached green results"
+            - "Because for `counts[1] = 4`, the old `counts[1] -= 3` and the new `counts[1] %= 3` both leave 1 in the counter — the two implementations agree on this specific input even though they disagree on `counts[1] >= 6`"
+            - "Because cycle 7's test is parameterized, and pytest reruns parameterized tests with looser tolerances"
+            - "Because cycle 7's test has been deleted by the cycle 10 refactor — the green count went down, not up"
+          correct_index: 1
+          explanation: |
+            This is a subtle but important point: a refactor does not have to *change every
+            output*. The two implementations of `apply` produce the same answer for any
+            input where the old answer was correct — and only the new answer is correct
+            where the old was wrong. That is what makes the cycle-10 fix a *generalisation*
+            rather than a *replacement*.
+
+        - question: |
+            **(Spaced review — Cycle 8)** A teammate looks at cycle 10's fix and says: *"This bug only existed because we extracted ComboRule. If we'd kept the inline `if counts[1] >= 3:` from cycle 6, we wouldn't have had this issue."* Are they right?
+          type: single
+          options:
+            - "Yes — the rule-object refactor introduced complexity that produced the bug. Inline code would have been simpler and safer"
+            - "No — the *exact same bug* was present in cycle 6's inline code (`if counts[1] >= 3: ... counts[1] -= 3` would also fail for six 1s). The rule-object refactor moved the bug from one place to another but did not introduce it. The defect was a missing test, not a missing pattern"
+            - "It depends on Python version — Python 3.10+ silently rewrites `if` to a multi-iteration form for combos, which is why old Python had the bug"
+            - "Yes — Python's `Counter` class re-orders subtraction operations under the hood when used with dataclasses"
+          correct_index: 1
+          explanation: |
+            The bug is the algorithm's bug, not the abstraction's. Whether the `if`/`-=`
+            sits in `score()` or in `ComboRule.apply` makes no difference to its behavior.
+            The lesson is honest: TDD does not prevent every bug; it surfaces them when
+            tests probe the right inputs. The rule-object refactor was about *future-
+            proofing the design*, not *correctness of cycle 6's logic*.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 13 — Cycle 11: Invalid dice raise an error
+  # Pedagogy:
+  #   Robustness testing  — one of the most-undertaught topics in the literature.
+  #   pytest.raises       — the right idiom for "this input should error."
+  #   No quiz — narrow, technique-focused cycle.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 11 — Invalid Dice Raise an Error"
+    instructions: |
+      > **Spec:** `score([1, 2, 9])` raises `ValueError("Die values must be between 1 and 6")`. Dice are integers 1–6.
+
+      So far every test was a happy-path test. **Happy-path-only suites are the single most common smell** in student-written test code (per testing-education research). TDD applies to *error* behavior just as much as to success — `pytest.raises` is the idiom.
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_invalid_die_value_raises_error` using `pytest.raises(ValueError, match=...)`. The current `score` silently ignores the 9, so the test fails because *no* exception is raised.
+      2. **🟢 GREEN** — add a `validate_dice(dice)` helper that raises `ValueError` for any die outside 1–6; call it at the top of `score`.
+      3. **🔵 REFACTOR** — checklist; constants like `VALID_DICE` keep the rule explicit.
+
+      ### Why <code>match=</code> matters & happy-path-only is dangerous
+
+      Without `match=`, the test would accept *any* `ValueError` — even one with no message, or the wrong message. With it, the test pins down the *contract*: the function raises and explains *why*. That's an oracle for the error case, not just for success.
+
+      The deeper lesson: line coverage doesn't catch missing error handling. A function that silently processes invalid input passes every happy-path assertion. Only an invalid-input test asks "does the boundary actually error?"
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from collections import Counter
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          @dataclass(frozen=True)
+          class ComboRule:
+              die: int
+              count: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  number_of_combos = counts[self.die] // self.count
+
+                  for _ in range(number_of_combos):
+                      dice_used = tuple([self.die] * self.count)
+                      events.append(ScoringEvent(self.name, dice_used, self.damage))
+
+                  counts[self.die] %= self.count
+
+                  return events
+
+
+          @dataclass(frozen=True)
+          class SingleRule:
+              die: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  for _ in range(counts[self.die]):
+                      events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                  return events
+
+
+          COMBO_RULES = (
+              ComboRule(1, 3, "Dragon Blast", 1000),
+              ComboRule(2, 3, "Goblin Swarm", 200),
+              ComboRule(3, 3, "Orc Charge", 300),
+              ComboRule(4, 3, "Troll Smash", 400),
+              ComboRule(5, 3, "Lightning Storm", 500),
+              ComboRule(6, 3, "Demon Strike", 600),
+          )
+
+          SINGLE_RULES = (
+              SingleRule(1, "Dragon Flame", 100),
+              SingleRule(5, "Lightning Spark", 50),
+          )
+
+
+          def score(dice):
+              counts = Counter(dice)
+              events = []
+
+              for rule in COMBO_RULES:
+                  events.extend(rule.apply(counts))
+
+              for rule in SINGLE_RULES:
+                  events.extend(rule.apply(counts))
+
+              return BattleReport(tuple(events))
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–11 — adding input validation."""
+          import pytest
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_one_and_five_create_two_different_events():
+              report = score([1, 5])
+
+              assert report.total_damage == 150
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_ones_create_dragon_blast_instead_of_three_flames():
+              report = score([1, 1, 1])
+
+              assert report.total_damage == 1000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          def test_dragon_blast_plus_leftover_flame_and_spark():
+              report = score([1, 1, 1, 1, 5])
+
+              assert report.total_damage == 1150
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_twos_create_goblin_swarm():
+              report = score([2, 2, 2])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+              )
+
+
+          @pytest.mark.parametrize(
+              "roll, expected_event",
+              [
+                  ([3, 3, 3], ScoringEvent("Orc Charge", (3, 3, 3), 300)),
+                  ([4, 4, 4], ScoringEvent("Troll Smash", (4, 4, 4), 400)),
+                  ([5, 5, 5], ScoringEvent("Lightning Storm", (5, 5, 5), 500)),
+                  ([6, 6, 6], ScoringEvent("Demon Strike", (6, 6, 6), 600)),
+              ],
+          )
+          def test_other_triples_create_combo_events(roll, expected_event):
+              report = score(roll)
+
+              assert report.total_damage == expected_event.damage
+              assert report.events == (expected_event,)
+
+
+          def test_six_ones_create_two_dragon_blasts():
+              report = score([1, 1, 1, 1, 1, 1])
+
+              assert report.total_damage == 2000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          # TODO (RED): write test_invalid_die_value_raises_error
+          #             score([1, 2, 9]) should raise ValueError("Die values must be between 1 and 6")
+          #             Use `with pytest.raises(ValueError, match="..."): score([1, 2, 9])`
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from collections import Counter
+            from dataclasses import dataclass
+
+
+            VALID_DICE = {1, 2, 3, 4, 5, 6}
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+
+            @dataclass(frozen=True)
+            class ComboRule:
+                die: int
+                count: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    number_of_combos = counts[self.die] // self.count
+
+                    for _ in range(number_of_combos):
+                        dice_used = tuple([self.die] * self.count)
+                        events.append(ScoringEvent(self.name, dice_used, self.damage))
+
+                    counts[self.die] %= self.count
+
+                    return events
+
+
+            @dataclass(frozen=True)
+            class SingleRule:
+                die: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    for _ in range(counts[self.die]):
+                        events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                    return events
+
+
+            COMBO_RULES = (
+                ComboRule(1, 3, "Dragon Blast", 1000),
+                ComboRule(2, 3, "Goblin Swarm", 200),
+                ComboRule(3, 3, "Orc Charge", 300),
+                ComboRule(4, 3, "Troll Smash", 400),
+                ComboRule(5, 3, "Lightning Storm", 500),
+                ComboRule(6, 3, "Demon Strike", 600),
+            )
+
+            SINGLE_RULES = (
+                SingleRule(1, "Dragon Flame", 100),
+                SingleRule(5, "Lightning Spark", 50),
+            )
+
+
+            def validate_dice(dice):
+                for die in dice:
+                    if die not in VALID_DICE:
+                        raise ValueError("Die values must be between 1 and 6")
+
+
+            def score(dice):
+                validate_dice(dice)
+
+                counts = Counter(dice)
+                events = []
+
+                for rule in COMBO_RULES:
+                    events.extend(rule.apply(counts))
+
+                for rule in SINGLE_RULES:
+                    events.extend(rule.apply(counts))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–11 — invalid dice now raise."""
+            import pytest
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_one_and_five_create_two_different_events():
+                report = score([1, 5])
+
+                assert report.total_damage == 150
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_ones_create_dragon_blast_instead_of_three_flames():
+                report = score([1, 1, 1])
+
+                assert report.total_damage == 1000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+
+
+            def test_dragon_blast_plus_leftover_flame_and_spark():
+                report = score([1, 1, 1, 1, 5])
+
+                assert report.total_damage == 1150
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_twos_create_goblin_swarm():
+                report = score([2, 2, 2])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+                )
+
+
+            @pytest.mark.parametrize(
+                "roll, expected_event",
+                [
+                    ([3, 3, 3], ScoringEvent("Orc Charge", (3, 3, 3), 300)),
+                    ([4, 4, 4], ScoringEvent("Troll Smash", (4, 4, 4), 400)),
+                    ([5, 5, 5], ScoringEvent("Lightning Storm", (5, 5, 5), 500)),
+                    ([6, 6, 6], ScoringEvent("Demon Strike", (6, 6, 6), 600)),
+                ],
+            )
+            def test_other_triples_create_combo_events(roll, expected_event):
+                report = score(roll)
+
+                assert report.total_damage == expected_event.damage
+                assert report.events == (expected_event,)
+
+
+            def test_six_ones_create_two_dragon_blasts():
+                report = score([1, 1, 1, 1, 1, 1])
+
+                assert report.total_damage == 2000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+
+
+            def test_invalid_die_value_raises_error():
+                with pytest.raises(ValueError, match="Die values must be between 1 and 6"):
+                    score([1, 2, 9])
+          language: "python"
+      explanation: |
+        Add a `validate_dice` helper called at the top of `score`. The helper raises
+        ValueError with a message that names the boundary, so the test can pin the
+        message down with `match=`.
+
+    tests:
+      - description: "test_invalid_die_value_raises_error function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_invalid_die_value_raises_error' in source, \
+              "Add the test function `test_invalid_die_value_raises_error`"
+
+      - description: "Test uses pytest.raises with a match= argument"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'pytest.raises' in source and 'match=' in source, \
+              "Use `with pytest.raises(ValueError, match=...): score([1, 2, 9])` — the `match=` argument pins down the error message"
+
+      - description: "validate_dice (or equivalent input check) is present in scorer.py"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'raise ValueError' in source, \
+              "Implement validation by raising ValueError when a die is not in 1–6"
+
+      - description: "All tests pass, including invalid-input"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All tests should pass — including the new invalid-input case:\n{output}"
+
+      - description: "Validation rejects an out-of-range die at runtime"
+        command: |
+          import importlib, sys
+          if 'scorer' in sys.modules:
+              del sys.modules['scorer']
+          import scorer as _s
+          raised = False
+          try:
+              _s.score([1, 2, 9])
+          except ValueError:
+              raised = True
+          assert raised, \
+              "score([1, 2, 9]) must raise ValueError. The validate_dice helper has not been wired in correctly."
+
+    # NO QUIZ — narrow, technique-focused cycle.
+
+
+  # --------------------------------------------------------------------------
+  # STEP 14 — Cycle 12: Battle report has a human-readable summary
+  # Pedagogy:
+  #   Behavior on an existing object — second responsibility for BattleReport.
+  #   String formatting under test  — the test pins down the exact format.
+  #   No quiz — last cycle; the next step is the comprehensive Big Picture quiz.
+  # --------------------------------------------------------------------------
+  - title: "Cycle 12 — Human-Readable Battle Summary"
+    instructions: |
+      > **Spec:** `report.summary()` returns a one-line string like `"Dragon Blast (1000) + Lightning Spark (50) = 1050"`. An empty report returns `"No damage."`.
+
+      Twelve cycles in. Cycle 12 is the only one that adds behavior to `BattleReport` itself rather than to `score`. *Where* a behavior lives is a design decision — putting `summary` on the report keeps formatting close to the data.
+
+      ## Your task
+
+      1. **🔴 RED** — add `test_battle_report_has_human_readable_summary`. Run; expect `AttributeError`.
+      2. **🟢 GREEN** — add a `summary` method to `BattleReport` that handles empty events as a special case and joins `name (damage)` segments with `" + "` for non-empty.
+      3. **🔵 REFACTOR** — final checklist. Re-run; all 16+ tests should be green. **You just completed twelve TDD cycles.**
+
+      ### A small design choice: method vs. property?
+
+      Properties signal *cheap, side-effect-free derived values*. `summary()` is cheap, but the empty-case branch and the f-string assembly do nontrivial work. Convention: methods for derived strings; properties for derived numbers and booleans. We chose a method. (Either would work — but be consistent within a project.)
+
+    files:
+      - path: "scorer.py"
+        content: |
+          from collections import Counter
+          from dataclasses import dataclass
+
+
+          VALID_DICE = {1, 2, 3, 4, 5, 6}
+
+
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
+
+
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+
+          @dataclass(frozen=True)
+          class ComboRule:
+              die: int
+              count: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  number_of_combos = counts[self.die] // self.count
+
+                  for _ in range(number_of_combos):
+                      dice_used = tuple([self.die] * self.count)
+                      events.append(ScoringEvent(self.name, dice_used, self.damage))
+
+                  counts[self.die] %= self.count
+
+                  return events
+
+
+          @dataclass(frozen=True)
+          class SingleRule:
+              die: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  for _ in range(counts[self.die]):
+                      events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                  return events
+
+
+          COMBO_RULES = (
+              ComboRule(1, 3, "Dragon Blast", 1000),
+              ComboRule(2, 3, "Goblin Swarm", 200),
+              ComboRule(3, 3, "Orc Charge", 300),
+              ComboRule(4, 3, "Troll Smash", 400),
+              ComboRule(5, 3, "Lightning Storm", 500),
+              ComboRule(6, 3, "Demon Strike", 600),
+          )
+
+          SINGLE_RULES = (
+              SingleRule(1, "Dragon Flame", 100),
+              SingleRule(5, "Lightning Spark", 50),
+          )
+
+
+          def validate_dice(dice):
+              for die in dice:
+                  if die not in VALID_DICE:
+                      raise ValueError("Die values must be between 1 and 6")
+
+
+          def score(dice):
+              validate_dice(dice)
+
+              counts = Counter(dice)
+              events = []
+
+              for rule in COMBO_RULES:
+                  events.extend(rule.apply(counts))
+
+              for rule in SINGLE_RULES:
+                  events.extend(rule.apply(counts))
+
+              return BattleReport(tuple(events))
+        language: "python"
+
+      - path: "test_scorer.py"
+        content: |
+          """Cycles 1–12 — adding the human-readable summary."""
+          import pytest
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_one_and_five_create_two_different_events():
+              report = score([1, 5])
+
+              assert report.total_damage == 150
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_ones_create_dragon_blast_instead_of_three_flames():
+              report = score([1, 1, 1])
+
+              assert report.total_damage == 1000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          def test_dragon_blast_plus_leftover_flame_and_spark():
+              report = score([1, 1, 1, 1, 5])
+
+              assert report.total_damage == 1150
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_twos_create_goblin_swarm():
+              report = score([2, 2, 2])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+              )
+
+
+          @pytest.mark.parametrize(
+              "roll, expected_event",
+              [
+                  ([3, 3, 3], ScoringEvent("Orc Charge", (3, 3, 3), 300)),
+                  ([4, 4, 4], ScoringEvent("Troll Smash", (4, 4, 4), 400)),
+                  ([5, 5, 5], ScoringEvent("Lightning Storm", (5, 5, 5), 500)),
+                  ([6, 6, 6], ScoringEvent("Demon Strike", (6, 6, 6), 600)),
+              ],
+          )
+          def test_other_triples_create_combo_events(roll, expected_event):
+              report = score(roll)
+
+              assert report.total_damage == expected_event.damage
+              assert report.events == (expected_event,)
+
+
+          def test_six_ones_create_two_dragon_blasts():
+              report = score([1, 1, 1, 1, 1, 1])
+
+              assert report.total_damage == 2000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          def test_invalid_die_value_raises_error():
+              with pytest.raises(ValueError, match="Die values must be between 1 and 6"):
+                  score([1, 2, 9])
+
+
+          # TODO (RED): write test_battle_report_has_human_readable_summary
+          #             score([1, 1, 1, 5]).summary() should equal
+          #             "Dragon Blast (1000) + Lightning Spark (50) = 1050"
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from collections import Counter
+            from dataclasses import dataclass
+
+
+            VALID_DICE = {1, 2, 3, 4, 5, 6}
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+                def summary(self):
+                    if not self.events:
+                        return "No damage."
+
+                    event_text = " + ".join(
+                        f"{event.name} ({event.damage})" for event in self.events
+                    )
+
+                    return f"{event_text} = {self.total_damage}"
+
+
+            @dataclass(frozen=True)
+            class ComboRule:
+                die: int
+                count: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    number_of_combos = counts[self.die] // self.count
+
+                    for _ in range(number_of_combos):
+                        dice_used = tuple([self.die] * self.count)
+                        events.append(ScoringEvent(self.name, dice_used, self.damage))
+
+                    counts[self.die] %= self.count
+
+                    return events
+
+
+            @dataclass(frozen=True)
+            class SingleRule:
+                die: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    for _ in range(counts[self.die]):
+                        events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                    return events
+
+
+            COMBO_RULES = (
+                ComboRule(1, 3, "Dragon Blast", 1000),
+                ComboRule(2, 3, "Goblin Swarm", 200),
+                ComboRule(3, 3, "Orc Charge", 300),
+                ComboRule(4, 3, "Troll Smash", 400),
+                ComboRule(5, 3, "Lightning Storm", 500),
+                ComboRule(6, 3, "Demon Strike", 600),
+            )
+
+            SINGLE_RULES = (
+                SingleRule(1, "Dragon Flame", 100),
+                SingleRule(5, "Lightning Spark", 50),
+            )
+
+
+            def validate_dice(dice):
+                for die in dice:
+                    if die not in VALID_DICE:
+                        raise ValueError("Die values must be between 1 and 6")
+
+
+            def score(dice):
+                validate_dice(dice)
+
+                counts = Counter(dice)
+                events = []
+
+                for rule in COMBO_RULES:
+                    events.extend(rule.apply(counts))
+
+                for rule in SINGLE_RULES:
+                    events.extend(rule.apply(counts))
+
+                return BattleReport(tuple(events))
+          language: "python"
+
+        - path: "test_scorer.py"
+          content: |
+            """Cycles 1–12 — twelve cycles, all green."""
+            import pytest
+            from scorer import score, ScoringEvent
+
+
+            def test_empty_roll_has_zero_damage_and_no_events():
+                report = score([])
+
+                assert report.total_damage == 0
+                assert report.events == ()
+
+
+            def test_single_one_creates_dragon_flame_event():
+                report = score([1])
+
+                assert report.total_damage == 100
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_single_five_creates_lightning_spark_event():
+                report = score([5])
+
+                assert report.total_damage == 50
+                assert report.events == (
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_two_ones_create_two_dragon_flames():
+                report = score([1, 1])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                )
+
+
+            def test_one_and_five_create_two_different_events():
+                report = score([1, 5])
+
+                assert report.total_damage == 150
+                assert report.events == (
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_ones_create_dragon_blast_instead_of_three_flames():
+                report = score([1, 1, 1])
+
+                assert report.total_damage == 1000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+
+
+            def test_dragon_blast_plus_leftover_flame_and_spark():
+                report = score([1, 1, 1, 1, 5])
+
+                assert report.total_damage == 1150
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Flame", (1,), 100),
+                    ScoringEvent("Lightning Spark", (5,), 50),
+                )
+
+
+            def test_three_twos_create_goblin_swarm():
+                report = score([2, 2, 2])
+
+                assert report.total_damage == 200
+                assert report.events == (
+                    ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+                )
+
+
+            @pytest.mark.parametrize(
+                "roll, expected_event",
+                [
+                    ([3, 3, 3], ScoringEvent("Orc Charge", (3, 3, 3), 300)),
+                    ([4, 4, 4], ScoringEvent("Troll Smash", (4, 4, 4), 400)),
+                    ([5, 5, 5], ScoringEvent("Lightning Storm", (5, 5, 5), 500)),
+                    ([6, 6, 6], ScoringEvent("Demon Strike", (6, 6, 6), 600)),
+                ],
+            )
+            def test_other_triples_create_combo_events(roll, expected_event):
+                report = score(roll)
+
+                assert report.total_damage == expected_event.damage
+                assert report.events == (expected_event,)
+
+
+            def test_six_ones_create_two_dragon_blasts():
+                report = score([1, 1, 1, 1, 1, 1])
+
+                assert report.total_damage == 2000
+                assert report.events == (
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                    ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                )
+
+
+            def test_invalid_die_value_raises_error():
+                with pytest.raises(ValueError, match="Die values must be between 1 and 6"):
+                    score([1, 2, 9])
+
+
+            def test_battle_report_has_human_readable_summary():
+                report = score([1, 1, 1, 5])
+
+                assert report.summary() == (
+                    "Dragon Blast (1000) + Lightning Spark (50) = 1050"
+                )
+          language: "python"
+      explanation: |
+        Add a `summary` method to BattleReport. Empty events return "No damage.";
+        otherwise join `name (damage)` segments with " + " and append `= total`.
+
+    tests:
+      - description: "test_battle_report_has_human_readable_summary function exists"
+        command: |
+          source = open('/tutorial/test_scorer.py').read()
+          assert 'def test_battle_report_has_human_readable_summary' in source, \
+              "Add the test function `test_battle_report_has_human_readable_summary`"
+
+      - description: "BattleReport.summary method is defined"
+        command: |
+          source = open('/tutorial/scorer.py').read()
+          assert 'def summary' in source, \
+              "Add a `summary` method to BattleReport"
+
+      - description: "Empty report returns 'No damage.'"
+        command: |
+          import importlib, sys
+          if 'scorer' in sys.modules:
+              del sys.modules['scorer']
+          import scorer as _s
+          empty = _s.score([])
+          assert empty.summary() == "No damage.", \
+              f"score([]).summary() should equal 'No damage.', got {empty.summary()!r}"
+
+      - description: "All twelve cycles' tests pass — the journey is green"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All tests across all twelve cycles should pass:\n{output}"
+
+    # NO QUIZ — the comprehensive Big Picture quiz is the next (final) step.
+
+
+  # ==========================================================================
+  # STEP 15 — THE BIG PICTURE
+  #
+  # Synthesizes the twelve-cycle journey: when TDD shines vs. when it doesn't,
+  # the anti-pattern taxonomy, the empirical case for TDD, and a final quiz
+  # that mixes spaced retrieval across earlier cycles with new application
+  # questions at Bloom's Analyze/Evaluate levels.
+  # ==========================================================================
+  - title: "The Big Picture — Lessons from Twelve Cycles"
+    instructions: |
+      Twelve cycles. Twelve tests. One small domain model with combos, leftovers, validation, and a summary method. Scroll through your final `scorer.py` — every line is justified by a test. No speculative code, no dead branch. **The tests are the byproduct; the design is the primary product.**
+
+      ## The takeaways that travel
+
+      1. **TDD is design, not testing.** The test is the contract; the implementation emerges under its pressure.
+      2. **Refactor *toward* duplication, not before it.** Two examples reveal the right shape; one is a guess.
+      3. **Tests enable change.** Behavior-level assertions survive structural rewrites; implementation-coupled tests don't.
+      4. **Coverage ≠ correctness.** Boundary thinking (cycle 10) catches what coverage misses.
+      5. **Listen to the test.** Pain in writing a test usually points at the production code.
+
+      Take the final knowledge check at the end of this step. The sections below review the whole journey, the anti-pattern taxonomy, the empirical case for TDD, and what to learn next.
+
+      ### The journey in one table
+
+      | Cycle | Behavior | Design move | Lesson |
       |---|---|---|---|
-      | **Unit** | One function or class, no I/O | Milliseconds | Cheap — run on every save |
-      | **Component / Integration** | A few modules wired together (still in-process) | Tens of ms | Moderate |
-      | **System / End-to-end** | The deployed application, real DB, real network | Seconds to minutes | Expensive — run in CI |
+      | 1 | Empty roll | First class + function | RED for the right reason |
+      | 2 | Single 1 | `ScoringEvent` introduced | Allow the ugly first GREEN |
+      | 3 | Single 5 | Second hardcoded branch | Refactor *toward* duplication |
+      | 4 | Repeated singles | Per-die loop | First real refactor; tests enable change |
+      | 5 | Mixed dice | (no production change) | Free pass — verify with the mutation move |
+      | 6 | Triple 1s | `Counter`, count-then-emit | Design-breaking test; structural shift |
+      | 7 | Combo + leftovers | (no production change) | Guardrail tests for implicit correctness |
+      | 8 | Triple 2s | Rule objects | Listening to the test; Open-Closed |
+      | 9 | Other triples | Append data | Refactor pays off; `parametrize` |
+      | 10 | Six 1s | `//` and `%=` | Hidden edge case; boundary > coverage |
+      | 11 | Invalid dice | `pytest.raises` | Robustness is first-class |
+      | 12 | Summary | Method on `BattleReport` | Behavior on the existing object |
 
-      TDD is almost always practiced at the unit level because the feedback loop has to fit inside a Red-Green-Refactor cycle of minutes. Higher levels catch integration bugs that unit tests cannot, but the feedback is too slow to drive minute-by-minute design. A robust project uses all three levels — many unit tests, fewer integration tests, a handful of end-to-end tests.
+      ### When TDD shines, when it's overkill
 
-      ## The Empirical Case for TDD
+      **TDD shines on**: new features with clear behavioral requirements; complex logic with branching cases; long-lived code modified by multiple people; API design (the test forces a caller's perspective); domains where regressions hurt (payments, scoring, calculations).
 
-      Industrial case studies provide concrete numbers:
+      **TDD is overkill on**: one-off throwaway scripts; exploratory prototyping where the problem isn't yet defined; UI layout (visual correctness); non-binary outcomes (ML accuracy, image recognition); Jupyter research explorations.
+
+      Even in the second list, *some* tests pay off — the question is whether to write them *first*. Kent Beck: *"the discipline of working strictly test-first is valuable but not necessarily something you want to do all the time."*
+
+      ### TDD anti-pattern taxonomy
+
+      | Level | Anti-pattern | What it looks like | Antidote |
+      |---|---|---|---|
+      | I | *The Liar* | Test passes but asserts vacuously (`isinstance(x, int)` only) | Cycle 5's mutation move |
+      | I | *The Nitpicker* | Asserts on private attributes / implementation details | Assert on observable behavior |
+      | II | *Success Against All Odds* | New test passes immediately, with no investigation | Verify with mutation |
+      | II | *Skip-the-Refactor* | Stop at green; never enter REFACTOR | Make the look mandatory |
+      | III | *The Giant* | One test asserts dozens of behaviors (mirrors a God Object) | One behavior per test |
+      | III | *Excessive Setup* | 30+ lines of fixture before one assertion | Decouple production code |
+      | IV | *The Mockery* | More mock setup than test logic | Listen — the design is wrong |
+      | IV | *Modify-the-Test* | AI rewrites the test to match buggy code | Own the spec yourself |
+
+      The pattern: higher the level, more it's an *architectural* smell. Listen to the test.
+
+      ### The empirical case for TDD
 
       | Study | Finding |
       |---|---|
-      | Microsoft & IBM (Williams et al.) | TDD teams achieved a **39%–91% decrease in pre-release defect density** vs. comparable non-TDD teams |
-      | Same studies | TDD took **15%–35% longer** in initial development time, offset by reduced debugging and maintenance |
-      | Erdogmus (2005) | Students using test-first wrote **more tests** AND were **more productive** per test |
-      | Williams et al. | Teams writing tests on a **minute-by-minute basis** had dramatically higher defect reductions than teams writing tests every few days |
-      | Janzen & Saiedian (ICSE 2007) | Mature programmers exposed to TDD were significantly more likely to *prefer* TDD for future projects — the **Residual Effect** |
+      | Microsoft & IBM (Williams et al., 2008) | **39–91% decrease in pre-release defect density** in TDD teams |
+      | Same studies | **15–35% longer** initial development; offset by reduced debugging |
+      | Erdogmus et al. (2005) | Test-first students wrote **more tests** AND were **more productive** per test |
+      | Janzen & Saiedian (ICSE 2007) | Mature programmers exposed to TDD significantly more likely to *prefer* TDD later — the **Residual Effect** |
+      | Fucci et al. (2017) | TDD's benefit comes from **granularity + uniformity**, not strict test-first ordering — your twelve tiny cycles embody both |
 
-      The Residual Effect is what makes TDD worth the initial discomfort: even when explicitly told to switch to test-last on a later project, students who learned TDD properly continue to write significantly more tests than peers who never learned it. The discipline rewires how you think about code quality.
+      Caveat: mixed for solo programmers on short tasks. Strongest in team settings, with CI, on long-lived systems.
 
-      ⚠️ The evidence is not unanimous — Müller and Hagner (2002) found "little or no advantage to test-first programming in either productivity or reliability" for solo programmers. The current consensus is that TDD's benefits are **context-dependent**: they show up most strongly in team settings, with continuous integration, on systems requiring long-term maintenance.
+      ### What to learn next (the same rhythm, scaled up)
 
-      ## Two Metaphors That Matter
+      - **Fixtures** (`@pytest.fixture`) for reusable setup of objects, DBs, mock APIs
+      - **Mocks, fakes, stubs** — with a strong default toward *fakes* over mocks
+      - **Property-based testing** with Hypothesis — `score(any list of 1–6)` should always satisfy invariants
+      - **Mutation testing** with `mutmut` or `cosmic-ray` — automate the cycle-5 mutation move across the whole suite
+      - **The Outside-In / Double-Loop pattern** (Percival, *Obey the Testing Goat*) — high-level acceptance tests drive unit tests
 
-      You met the **Ratchet** in Foundations Step 1: each passing test locks in progress; you can never accidentally slip backward. Its companion is the **Boiled Frog**:
-
-      > Software complexity sneaks up gradually. You add a small mock here, an `if` branch there, a global flag. No single change feels alarming — but six months later the codebase is unmaintainable. By writing tiny tests from the very first feature, TDD plants psychological *placeholders* that lower the barrier to adding more tests as the project grows. The frog notices the water heating because the thermometer is always running.
-
-      Together: the Ratchet preserves what works; the Boiled Frog metaphor warns about what slowly stops working.
-
-      ## TDD Anti-Pattern Taxonomy
-
-      Drawing on the maturity model from Aniche et al. (arXiv 2307.11534) and Codurance's TDD Anti-Patterns catalog, anti-patterns cluster by what they reveal about the developer's understanding:
-
-      | Level | Anti-Pattern | What it looks like | What it really means |
-      |---|---|---|---|
-      | **I — Basics** | *The Nitpicker* | Asserts on private fields or exact internal representation | The student has not separated interface from implementation |
-      | **II — TDD Cycle** | *Success Against All Odds* | A new test passes the first time it runs (no Red phase) | The cycle is being skipped; the test may not be testing anything |
-      | **II — TDD Cycle** | *Hidden Dependency* | Tests pass or fail based on test ordering, environment, or external state | Production code has hidden global coupling |
-      | **III — Design** | *The Giant* (God Object test) | One test function with hundreds of lines and dozens of assertions | The class under test violates the Single Responsibility Principle |
-      | **III — Design** | *Excessive Setup* | 30+ lines of Arrange before a single Act/Assert | Production code is too tightly coupled to its dependencies |
-      | **III — Design** | *The Liar* | Test passes but does not actually verify the intended behavior (tautology, type-only check) | Often introduced by AI assistants or copy-paste; see Step 4 |
-      | **IV — Advanced** | *The Mockery* | More mock setup than test logic; the test verifies the mocks, not the system | Business logic is tangled with infrastructure; redraw the abstraction boundaries |
-
-      Notice the pattern: the higher the level, the more the test smell is really an *architectural* smell. **Listen to the test** — when a test is hard to write, the production code is usually the problem.
-
-      ## Key Takeaways
-
-      1. **TDD is a design technique**, not a testing technique — tests are a valuable byproduct
-      2. **Red-Green-Refactor** — one test at a time, in short iterations
-      3. **Test behavior via the public API**, structured as Arrange-Act-Assert (from Foundations Step 4)
-      4. **Use parametrize** to kill copy-paste duplication (Step 3)
-      5. **Audit AI-generated tests** — the AI may modify the test instead of fixing the code (Step 4)
-      6. **Listen to the test** — difficulty writing a test is diagnostic feedback about your design
-      7. **The Ratchet preserves; the Boiled Frog warns**
-
-      ## What's Next
-
-      This tutorial covered the fundamentals. In more advanced TDD work, you will encounter:
-      - **Fixtures** — reusable test setup with `@pytest.fixture` (yields a context manager)
-      - **Mocking** — isolate code from external dependencies (databases, APIs) — but watch for *The Mockery*
-      - **The Double Loop** (Percival, *Obey the Testing Goat*) — an outer acceptance test (e.g., a Selenium browser test) drives the development of inner unit tests, ensuring every line of code traces back to a user-visible requirement
-
-      ### Final Exercise: Diagnose This Test Suite
-
-      Open `test_diagnose.py`. It contains a test suite written by a junior developer. Read each test and identify which **anti-pattern from the taxonomy table above** it exhibits (if any). Add a `# VERDICT:` comment to each test function explaining your analysis. This is not graded — it is a reflection exercise.
-
-      ### Before You Move On (retrieval practice)
-
-      Without looking, answer:
-
-      - Name one scenario where TDD pays off and one where it is overkill.
-      - Describe the Ratchet and the Boiled Frog metaphors, and what each warns about.
-      - Why is *The Mockery* classified at the highest maturity level of the taxonomy?
+      Each lives inside the same Red-Green-Refactor rhythm you just internalised. They scale the discipline; they don't replace it.
 
     files:
-      - path: "test_diagnose.py"
+      - path: "scorer.py"
         content: |
-          """Diagnose: Which principles does each test violate (if any)?"""
-          import pytest
+          # The full, twelve-cycle implementation lives here. Use this step's
+          # editor to scroll through what you built — every line is justified by
+          # a test in test_scorer.py. There is no speculative code.
+          from collections import Counter
+          from dataclasses import dataclass
 
 
-          # --- Test 1 ---
-          def test_login_system():
-              """Tests login, logout, session, and password reset all in one."""
-              user = {"username": "alice", "password": "Secret1"}
-              assert authenticate(user["username"], user["password"]) == True
-              assert create_session(user["username"]) is not None
-              assert logout(user["username"]) == True
-              assert reset_password(user["username"], "NewSecret1") == True
-              # VERDICT: (your analysis here)
+          VALID_DICE = {1, 2, 3, 4, 5, 6}
 
 
-          # --- Test 2 ---
-          def test_add_returns_sum():
-              assert add(2, 3) == 5
-              # VERDICT: (your analysis here)
+          @dataclass(frozen=True)
+          class ScoringEvent:
+              name: str
+              dice_used: tuple
+              damage: int
 
 
-          # --- Test 3 ---
-          def test_user_internals():
-              user = User("Bob")
-              assert user._internal_id is not None
-              assert user._created_at is not None
-              # VERDICT: (your analysis here)
+          @dataclass(frozen=True)
+          class BattleReport:
+              events: tuple = ()
+
+              @property
+              def total_damage(self):
+                  return sum(event.damage for event in self.events)
+
+              def summary(self):
+                  if not self.events:
+                      return "No damage."
+
+                  event_text = " + ".join(
+                      f"{event.name} ({event.damage})" for event in self.events
+                  )
+
+                  return f"{event_text} = {self.total_damage}"
 
 
-          # --- Test 4 ---
-          def test_divide_by_zero():
-              result = safe_divide(10, 0)
-              assert result is None
-              # VERDICT: (your analysis here)
+          @dataclass(frozen=True)
+          class ComboRule:
+              die: int
+              count: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  number_of_combos = counts[self.die] // self.count
+
+                  for _ in range(number_of_combos):
+                      dice_used = tuple([self.die] * self.count)
+                      events.append(ScoringEvent(self.name, dice_used, self.damage))
+
+                  counts[self.die] %= self.count
+
+                  return events
+
+
+          @dataclass(frozen=True)
+          class SingleRule:
+              die: int
+              name: str
+              damage: int
+
+              def apply(self, counts):
+                  events = []
+
+                  for _ in range(counts[self.die]):
+                      events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                  return events
+
+
+          COMBO_RULES = (
+              ComboRule(1, 3, "Dragon Blast", 1000),
+              ComboRule(2, 3, "Goblin Swarm", 200),
+              ComboRule(3, 3, "Orc Charge", 300),
+              ComboRule(4, 3, "Troll Smash", 400),
+              ComboRule(5, 3, "Lightning Storm", 500),
+              ComboRule(6, 3, "Demon Strike", 600),
+          )
+
+          SINGLE_RULES = (
+              SingleRule(1, "Dragon Flame", 100),
+              SingleRule(5, "Lightning Spark", 50),
+          )
+
+
+          def validate_dice(dice):
+              for die in dice:
+                  if die not in VALID_DICE:
+                      raise ValueError("Die values must be between 1 and 6")
+
+
+          def score(dice):
+              validate_dice(dice)
+
+              counts = Counter(dice)
+              events = []
+
+              for rule in COMBO_RULES:
+                  events.extend(rule.apply(counts))
+
+              for rule in SINGLE_RULES:
+                  events.extend(rule.apply(counts))
+
+              return BattleReport(tuple(events))
         language: "python"
 
+      - path: "test_scorer.py"
+        content: |
+          """All twelve cycles, all green. Read it as a contract."""
+          import pytest
+          from scorer import score, ScoringEvent
+
+
+          def test_empty_roll_has_zero_damage_and_no_events():
+              report = score([])
+
+              assert report.total_damage == 0
+              assert report.events == ()
+
+
+          def test_single_one_creates_dragon_flame_event():
+              report = score([1])
+
+              assert report.total_damage == 100
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_single_five_creates_lightning_spark_event():
+              report = score([5])
+
+              assert report.total_damage == 50
+              assert report.events == (
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_two_ones_create_two_dragon_flames():
+              report = score([1, 1])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+              )
+
+
+          def test_one_and_five_create_two_different_events():
+              report = score([1, 5])
+
+              assert report.total_damage == 150
+              assert report.events == (
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_ones_create_dragon_blast_instead_of_three_flames():
+              report = score([1, 1, 1])
+
+              assert report.total_damage == 1000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          def test_dragon_blast_plus_leftover_flame_and_spark():
+              report = score([1, 1, 1, 1, 5])
+
+              assert report.total_damage == 1150
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Flame", (1,), 100),
+                  ScoringEvent("Lightning Spark", (5,), 50),
+              )
+
+
+          def test_three_twos_create_goblin_swarm():
+              report = score([2, 2, 2])
+
+              assert report.total_damage == 200
+              assert report.events == (
+                  ScoringEvent("Goblin Swarm", (2, 2, 2), 200),
+              )
+
+
+          @pytest.mark.parametrize(
+              "roll, expected_event",
+              [
+                  ([3, 3, 3], ScoringEvent("Orc Charge", (3, 3, 3), 300)),
+                  ([4, 4, 4], ScoringEvent("Troll Smash", (4, 4, 4), 400)),
+                  ([5, 5, 5], ScoringEvent("Lightning Storm", (5, 5, 5), 500)),
+                  ([6, 6, 6], ScoringEvent("Demon Strike", (6, 6, 6), 600)),
+              ],
+          )
+          def test_other_triples_create_combo_events(roll, expected_event):
+              report = score(roll)
+
+              assert report.total_damage == expected_event.damage
+              assert report.events == (expected_event,)
+
+
+          def test_six_ones_create_two_dragon_blasts():
+              report = score([1, 1, 1, 1, 1, 1])
+
+              assert report.total_damage == 2000
+              assert report.events == (
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+                  ScoringEvent("Dragon Blast", (1, 1, 1), 1000),
+              )
+
+
+          def test_invalid_die_value_raises_error():
+              with pytest.raises(ValueError, match="Die values must be between 1 and 6"):
+                  score([1, 2, 9])
+
+
+          def test_battle_report_has_human_readable_summary():
+              report = score([1, 1, 1, 5])
+
+              assert report.summary() == (
+                  "Dragon Blast (1000) + Lightning Spark (50) = 1050"
+              )
+        language: "python"
+
+    open_file: "scorer.py"
+    run_file: "test_scorer.py"
+
+    solution:
+      files:
+        - path: "scorer.py"
+          content: |
+            from collections import Counter
+            from dataclasses import dataclass
+
+
+            VALID_DICE = {1, 2, 3, 4, 5, 6}
+
+
+            @dataclass(frozen=True)
+            class ScoringEvent:
+                name: str
+                dice_used: tuple
+                damage: int
+
+
+            @dataclass(frozen=True)
+            class BattleReport:
+                events: tuple = ()
+
+                @property
+                def total_damage(self):
+                    return sum(event.damage for event in self.events)
+
+                def summary(self):
+                    if not self.events:
+                        return "No damage."
+
+                    event_text = " + ".join(
+                        f"{event.name} ({event.damage})" for event in self.events
+                    )
+
+                    return f"{event_text} = {self.total_damage}"
+
+
+            @dataclass(frozen=True)
+            class ComboRule:
+                die: int
+                count: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    number_of_combos = counts[self.die] // self.count
+
+                    for _ in range(number_of_combos):
+                        dice_used = tuple([self.die] * self.count)
+                        events.append(ScoringEvent(self.name, dice_used, self.damage))
+
+                    counts[self.die] %= self.count
+
+                    return events
+
+
+            @dataclass(frozen=True)
+            class SingleRule:
+                die: int
+                name: str
+                damage: int
+
+                def apply(self, counts):
+                    events = []
+
+                    for _ in range(counts[self.die]):
+                        events.append(ScoringEvent(self.name, (self.die,), self.damage))
+
+                    return events
+
+
+            COMBO_RULES = (
+                ComboRule(1, 3, "Dragon Blast", 1000),
+                ComboRule(2, 3, "Goblin Swarm", 200),
+                ComboRule(3, 3, "Orc Charge", 300),
+                ComboRule(4, 3, "Troll Smash", 400),
+                ComboRule(5, 3, "Lightning Storm", 500),
+                ComboRule(6, 3, "Demon Strike", 600),
+            )
+
+            SINGLE_RULES = (
+                SingleRule(1, "Dragon Flame", 100),
+                SingleRule(5, "Lightning Spark", 50),
+            )
+
+
+            def validate_dice(dice):
+                for die in dice:
+                    if die not in VALID_DICE:
+                        raise ValueError("Die values must be between 1 and 6")
+
+
+            def score(dice):
+                validate_dice(dice)
+
+                counts = Counter(dice)
+                events = []
+
+                for rule in COMBO_RULES:
+                    events.extend(rule.apply(counts))
+
+                for rule in SINGLE_RULES:
+                    events.extend(rule.apply(counts))
+
+                return BattleReport(tuple(events))
+          language: "python"
+      explanation: |
+        The final implementation as it stood at the end of cycle 12. Use this step
+        for reading and reflection — there are no new tasks, just the comprehensive
+        knowledge check that follows.
+
+    tests:
+      - description: "All twelve cycles' tests still green"
+        command: |
+          import pytest, io, sys
+          old = sys.stdout
+          sys.stdout = buf = io.StringIO()
+          code = pytest.main(['/tutorial/test_scorer.py', '-v', '--tb=short', '--no-header'])
+          sys.stdout = old
+          output = buf.getvalue()
+          print(output)
+          assert code == 0, \
+              f"All tests should still pass — this is a reflection step:\n{output}"
+
     quiz:
-      title: "The Big Picture — Knowledge Check"
+      title: "Final Quiz — The Big Picture"
       min_score: 0.8
       shuffle: true
       questions:
 
         - question: |
-            **Evaluate:** For which scenario is TDD **most** beneficial?
+            Which **single** statement most accurately captures TDD?
           type: single
           options:
-            - "Writing a quick one-off script to rename 100 files, where the logic is straightforward and unlikely to change"
-            - "Implementing a payment processing module with complex validation rules that must be correct"
-            - "Experimenting with a new plotting library to explore its API and see what visualizations it can produce"
-            - "Writing CSS for a landing page where visual correctness is judged by eye, not by assertions"
+            - "A way to achieve 100% line coverage without writing extra tests later"
+            - "A *design discipline* where tests drive the structure of production code; the test suite is a valuable byproduct"
+            - "A workflow optimisation that ships features faster than test-after development"
+            - "A coverage technique ensuring every line is exercised before release"
           correct_index: 1
           explanation: |
-            Payment processing has complex logic, strict correctness requirements, and is
-            modified by multiple developers over time. TDD excels here because the tests
-            specify exact behavior and prevent regressions.
+            The threshold concept of the tutorial: TDD is design, not testing. Cycle 8's
+            rule-object refactor *emerged* under cycle-8's test pressure, not from a
+            whiteboard. The test suite is a (valuable) byproduct.
 
         - question: |
-            A student's test file contains a single function with 20 assertions testing five different behaviors. Another student has five functions with four assertions each. Which approach is better, and why?
+            **For which scenario is TDD most beneficial?**
           type: single
           options:
-            - "The single function — keeping all assertions together makes the file shorter and guarantees they run in a predictable sequential order"
-            - "Five functions — each isolates one behavior, so a failure pinpoints which broke. The single function hides failures after the first"
-            - "Both are equivalent — pytest reports the exact line number of every failure regardless of how you organize the test functions"
-            - "Neither — 20 assertions across any number of functions is too many and will slow down the test suite significantly"
+            - "A 25-line one-off file-renaming script run once and discarded"
+            - "A new payment-processing module: complex validation, multi-developer code, high cost of regression"
+            - "A Jupyter notebook exploring a new dataset"
+            - "Hand-written CSS for a landing page judged visually"
           correct_index: 1
           explanation: |
-            Test isolation is a core TDD principle. One test function = one behavior = one
-            potential failure point.
+            Payment processing has every property TDD rewards: complex logic, strict
+            correctness, multiple developers, long life. Microsoft/IBM measured 39–91%
+            defect-density reductions exactly here.
 
         - question: |
-            A test that spawns a subprocess, hits a real Postgres database, and asserts on HTTP status codes from a running API is best classified as which level of the testing pyramid?
-          type: single
-          options:
-            - "A unit test — any test that asserts on the behavior of one function is a unit test, regardless of what that function calls"
-            - "A component test — it exercises one module plus its nearest collaborators, which is the definition of a component"
-            - "An integration or system/end-to-end test — it exercises multiple components together with real infrastructure, so it belongs near the top of the pyramid"
-            - "Not a test at all — anything that uses real infrastructure is a manual check, not an automated test"
-          correct_index: 2
-          explanation: |
-            Real DB + subprocess + network puts this firmly at the system / end-to-end
-            level. Unit tests are fast and in-process; integration tests wire a few modules
-            together but stay in-process; system tests exercise the deployed stack. TDD is
-            almost always practiced at the unit level because only that level gives you the
-            minute-scale feedback loop the Red-Green-Refactor cycle needs.
-
-        - question: |
-            **(Anti-pattern identification)** A developer writes this test:
+            A test file contains:
             ```python
             def test_user_creation():
                 user = User("Alice", "alice@example.com")
                 assert user._name == "Alice"
                 assert user._email == "alice@example.com"
-                assert user._id is not None
             ```
-            What anti-pattern is present?
+            Which anti-pattern is present?
           type: single
           options:
-            - "The test is too short — it should also verify that the user can log in and update their profile"
-            - "The test accesses private attributes (`_name`, `_email`, `_id`) — testing implementation instead of public behavior"
-            - "The test does not use `pytest.fixture` to set up the User object, which reduces reusability"
-            - "The test should use `assertEqual` instead of plain `assert` for more descriptive failure messages"
+            - "*Excessive Setup* — too many asserts"
+            - "*The Nitpicker* — asserts on private attributes (`_name`, `_email`), coupling the test to implementation details"
+            - "*The Mockery* — the test verifies the User constructor"
+            - "*Skip-the-Refactor* — should be split into smaller tests"
           correct_index: 1
           explanation: |
-            This is the "Nitpicker" anti-pattern. The test is coupled to the internal
-            representation rather than the public interface.
+            *The Nitpicker.* Leading underscores signal "private — implementation detail."
+            Tests that touch private state break on every refactor. Assert on observable
+            behavior via the public API.
 
         - question: |
-            **(Spaced review — Step 1)** Two developers are arguing. Dev A says: *"I wrote the function first, then added tests — same result."* Dev B says: *"No, writing the test first changes the design."* Who is right, and why?
+            The "one Dragon Blast for any count ≥ 3" bug lived in cycles 6–10. Why didn't *line coverage* catch it?
           type: single
           options:
-            - "Dev A — the final code is identical either way. The only difference is workflow preference, not the quality of the resulting design"
-            - "Dev B — writing the test first forces you to design the interface and behavior before implementation, producing more modular code"
-            - "Both are right — TDD and test-last produce the same code, but TDD catches regressions earlier in the development timeline"
-            - "Neither — the real value of TDD is the refactoring phase, and both approaches include refactoring regardless of test order"
+            - "Coverage caught it; pytest ignored the warning"
+            - "Coverage measures which *lines ran*, not whether the line is correct *for all relevant inputs*. The concept that catches it is **boundary thinking** — probing inputs at `exactly N`, `2N`, between, etc."
+            - "Coverage requires the `--strict` flag we didn't enable"
+            - "Coverage can't measure exception-raising code"
           correct_index: 1
           explanation: |
-            Dev B is correct. Writing the test first means you must decide the function's name,
-            parameters, and return value BEFORE writing any implementation. This forces you to
-            think as a *caller* (API consumer) rather than an *implementer*.
+            Coverage tells you the line *ran*, not that it was *right*. Every prior combo
+            test used exactly `count` dice; nothing probed `2 × count`. Boundary thinking
+            is the discipline that catches it. Coverage is a *locator of under-tested
+            code*, not a measure of correctness.
 
-        - question: |
-            **(Anti-pattern taxonomy)** A test method has a single line: `account.transfer_and_log_and_email_and_audit(...)` followed by 25 assertions checking every side effect. Which anti-pattern is this?
-          type: single
-          options:
-            - "*Excessive Setup* — the Arrange section has too much fixture data"
-            - "*The Giant* (God Object test) — the test reflects a class that violates the Single Responsibility Principle, attempting too many behaviors at once"
-            - "*Hidden Dependency* — the test relies on external state that is not visible from its name"
-            - "*The Mockery* — the test verifies mocks instead of real behavior"
-          correct_index: 1
-          explanation: |
-            *The Giant* is the test-side fingerprint of a *God Object*. When one method does
-            transfer + log + email + audit, the only way to test it is a giant test. The fix
-            is in the production code: split the responsibilities into separate classes or
-            methods, each tested independently.
 
-        - question: |
-            **(Spaced review — Step 4)** A teammate brags: *"I have Copilot generate every test for me — I get 100% coverage in minutes."* Based on the empirical evidence you saw in this tutorial, what is the most accurate response?
-          type: single
-          options:
-            - "Excellent — AI-generated tests are objectively higher quality than hand-written ones, and 100% coverage proves the suite is complete"
-            - "Coverage measures lines executed, not behavior verified. Studies show novices accept AI tests with minimal review and ship Liar/Mockery anti-patterns. You still need to OWN the test specifications"
-            - "AI tools cannot generate any tests, so your teammate must be lying about how the tests were produced or how coverage was measured"
-            - "100% coverage is unsafe regardless of who wrote it — modern testing has moved away from coverage as a metric, in favor of mutation testing exclusively"
-          correct_index: 1
-          explanation: |
-            Coverage ≠ behavior verification. Empirical research shows novices run AI tests
-            one-third as often as their own and miss subtle anti-patterns (Liar, Mockery,
-            Modify-the-Test). The right workflow is *collaborative*: human writes the test
-            as a behavioral specification, AI implements the production code, human verifies
-            that the test still represents real behavior after the AI's edits.


### PR DESCRIPTION
## Summary
- Rewrites `_data/tutorials/tdd.yml` as a 15-step Red-Green-Refactor journey through twelve tests of a fantasy dice-scoring engine
- Cycle 1 is split into three steps (RED, GREEN, REFACTOR) so the rhythm is *felt*; cycles 2-12 each one step with all three phases. Six quizzes total (after cycle 1, then on design-pressure cycles 4, 6, 8, 10, and a final synthesis)
- TDD instruction is default-visible: R-G-R cycle, RED-for-the-right-reason, contract-as-spec, tests-enable-change, listen-to-the-test, boundary thinking, anti-pattern taxonomy, empirical case (Microsoft/IBM, Janzen, Erdogmus, Fucci)

## Pedagogical grounding
Design rules drawn from cs-tutorial-design and pedagogical-advisor skill references:

- **CLT (Sweller)** — minimised extraneous load; respected expertise reversal for the intermediate-Python audience
- **Mayer's principles** — coherence + redundancy: cut parallel explainer paths; signaling: clear section headings
- **ICAP (Chi & Wylie)** — pushed Active → Constructive: students derive tests/code from the spec rather than copy verbatim
- **Dunlosky / Bjork** — desirable difficulties: predict-before-run, mutation move, retrieval prompts
- **Worked-example fading** — cycles 1-3 most scaffolded; cycles 4-14 use compact spec + 3-task pattern
- **TDD research** — Fucci (granularity > strict test-first ordering), Beck (canon TDD), Fowler (refactor as most-skipped phase), Janzen (Residual Effect)

## Domain choreography
Each cycle earns its design move from the test that demanded it:

| Cycle | Behavior | Design move | Lesson |
|---|---|---|---|
| 1 | Empty roll | First class + function | RED for the right reason |
| 2 | Single 1 | \`ScoringEvent\` | Allow the ugly first GREEN |
| 3 | Single 5 | Second hardcoded branch | Refactor *toward* duplication |
| 4 | Repeated singles | Per-die loop | First real refactor; tests enable change |
| 5 | Mixed dice | (no production change) | Free pass — verify with mutation |
| 6 | Triple 1s | \`Counter\`, count-then-emit | Design-breaking test |
| 7 | Combo + leftovers | (no production change) | Guardrail tests |
| 8 | Triple 2s | Rule objects | Listening to the test; OCP |
| 9 | Other triples | Append data | Refactor pays off; \`parametrize\` |
| 10 | Six 1s | \`//\` and \`%=\` | Boundary > coverage |
| 11 | Invalid dice | \`pytest.raises\` | Robustness is first-class |
| 12 | Summary | Method on \`BattleReport\` | Behavior on the existing object |

## Rendering compatibility
The tutorial engine uses **marked.js v9** (CommonMark, no markdown-in-HTML). All instructions use plain markdown — no \`<details>\` collapsibles, since marked.js does not parse markdown inside HTML block elements.

## Test plan
- [ ] Open the tutorial at \`/SEBook/tools/tdd-tutorial\` and walk through Step 1 (RED), Step 2 (GREEN), Step 3 (REFACTOR + first quiz). Confirm tables and code blocks render
- [ ] Verify each cycle's Run button produces the expected RED-for-the-right-reason on starter files and turns GREEN on the solution
- [ ] Click Show Solution on a few cycles to confirm the full cumulative code is shown correctly
- [ ] Take the first quiz (Step 3) and the final quiz (Step 15) — confirm 80% threshold gates progress
- [ ] Confirm split editor layout (\`scorer.py\` left, \`test_scorer.py\` right) and 25% output panel are preserved
- [ ] Sanity check: pytest passes on the cycle-12 final solution (verified locally — 15/15 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)