### PR TITLE
Fix SEGym max-cards minimum to 0, prevent negative values

### DIFF
--- a/se-gym.html
+++ b/se-gym.html
@@ -59,7 +59,7 @@ layout: sebook
           <div class="controls-row toggle-row" style="margin-top: 14px; justify-content: space-between;">
             <label for="max-cards" class="toggle-label" style="margin: 0; text-transform: uppercase;">Max cards:</label>
             <div style="display: inline-flex; align-items: center; gap: 12px;">
-              <input type="number" id="max-cards" value="50" min="1" max="9999">
+              <input type="number" id="max-cards" value="50" min="0" max="9999">
               <button id="start-workout-btn" class="gym-btn primary" disabled>Start Workout</button>
             </div>
           </div>
@@ -1825,7 +1825,7 @@ layout: sebook
         }
 
         // Update summary and start button
-        var maxCards = parseInt(maxCardsInput.value) || 20;
+        var maxCards = Math.max(0, isNaN(parseInt(maxCardsInput.value)) ? 20 : parseInt(maxCardsInput.value));
         var drawCount = Math.min(maxCards, totalCards);
         if (gym.length > 0 || (difficultInGym && hasDifficult)) {
           gymSummary.textContent = totalCards + ' total cards available. Will draw ' + drawCount + ' cards.';
@@ -2065,7 +2065,7 @@ layout: sebook
 
         shuffleArray(cards);
 
-        var maxCards = parseInt(maxCardsInput.value) || 20;
+        var maxCards = Math.max(0, isNaN(parseInt(maxCardsInput.value)) ? 20 : parseInt(maxCardsInput.value));
         if (cards.length > maxCards) {
           cards = cards.slice(0, maxCards);
         }


### PR DESCRIPTION
## Summary

- Change `min="1"` to `min="0"` on the max-cards `<input>` so 0 is a valid setting
- Replace `parseInt(...) || 20` fallbacks (which silently treated 0 as falsy and jumped to 20) with an explicit NaN-guard + `Math.max(0, …)` to clamp out negative values that could bypass the HTML constraint

## Test plan

- [ ] Set max-cards to 0 — summary should say "Will draw 0 cards", not 20
- [ ] Set max-cards to a positive number — behaviour unchanged
- [ ] Clear the input (empty) — should fall back to 20 as before
- [ ] Try typing a negative number — browser should reject it (min=0); JS clamps to 0 as a safety net

https://claude.ai/code/session_016sBGHMyG53f8BhGqpyZ6gM

---
_Generated by [Claude Code](https://claude.ai/code/session_016sBGHMyG53f8BhGqpyZ6gM)_