### PR TITLE
Make UML playground manual layout robust for actors and activity targets

### DIFF
--- a/SEBook/tools/uml-playground.md
+++ b/SEBook/tools/uml-playground.md
@@ -761,8 +761,17 @@ html.dark-mode #uml-pg-error {
           m = line.match(/^usecase\s+("[^"]+"|\S+)(?:\s+as\s+(\S+))?/i);
           if (m) addElement(elements, seen, m[2] || m[1], m[1]);
         } else if (type === 'activity') {
-          var quoted = line.match(/"([^"]+)"/);
-          if (quoted) addElement(elements, seen, quoted[1], quoted[1]);
+          // A line like `"Receive Order" --> "Validate Payment"` declares two
+          // movable activity nodes. Capture every quoted token, not just the
+          // first — otherwise nodes that only appear as the target of a
+          // transition (e.g. `"Validate Payment"` above, which never appears
+          // again as the start of another transition) silently lose their
+          // movable handle.
+          var quotedRe = /"([^"]+)"/g;
+          var quotedMatch;
+          while ((quotedMatch = quotedRe.exec(line)) !== null) {
+            addElement(elements, seen, quotedMatch[1], quotedMatch[1]);
+          }
         } else if (type === 'freeform') {
           m = line.match(/^box(?:\s+[a-z]+)?\s+"((?:[^"\\]|\\.)*)"\s+as\s+(\S+)/i);
           if (m) addElement(elements, seen, m[2], m[1].replace(/\\n/g, '\n'));
@@ -1089,11 +1098,26 @@ html.dark-mode #uml-pg-error {
       var labels = [element.label, element.id].filter(Boolean).map(function (s) {
         return String(s).replace(/\s+/g, ' ').trim();
       });
-      var texts = Array.prototype.slice.call(svg.querySelectorAll('text')).filter(function (t) {
-        var txt = textOf(t);
-        return labels.some(function (label) { return txt === label || txt.indexOf(label) !== -1; });
+      var allTexts = Array.prototype.slice.call(svg.querySelectorAll('text')).filter(function (t) {
+        return !t.closest('.uml-pg-edit-layer') && !t.closest('defs');
       });
-      if (!texts.length) return null;
+
+      // Split candidate texts into exact and partial matches. The text-based
+      // heuristic must prefer texts that are *equal* to the label over texts
+      // that only contain it as a substring — otherwise an actor named
+      // `User` happily latches on to a use case `"Manage Users"` (because
+      // "Manage Users" contains "User"), and the resulting hitbox sits on
+      // top of the wrong shape with no way to drag the actor itself.
+      var exactTexts = allTexts.filter(function (t) {
+        var txt = textOf(t);
+        return labels.some(function (label) { return txt === label; });
+      });
+      var partialTexts = allTexts.filter(function (t) {
+        var txt = textOf(t);
+        if (labels.some(function (label) { return txt === label; })) return false;
+        return labels.some(function (label) { return txt.indexOf(label) !== -1; });
+      });
+      if (!exactTexts.length && !partialTexts.length) return null;
 
       var shapes = Array.prototype.slice.call(svg.querySelectorAll('rect,circle,ellipse,polygon,path')).filter(function (el) {
         return !el.closest('.uml-pg-edit-layer') && !el.closest('defs');
@@ -1101,26 +1125,38 @@ html.dark-mode #uml-pg-error {
         return { el: el, box: elementSvgBox(svg, el) };
       }).filter(function (item) { return item.box; });
 
-      var best = null;
-      for (var ti = 0; ti < texts.length; ti++) {
-        var tb = elementSvgBox(svg, texts[ti]);
-        if (!tb) continue;
-        var cx = tb.x + tb.width / 2;
-        var cy = tb.y + tb.height / 2;
-        for (var si = 0; si < shapes.length; si++) {
-          var sb = shapes[si].box;
-          if (!containsPoint(sb, cx, cy, 4)) continue;
-          var area = sb.width * sb.height;
-          if (area < Math.max(80, tb.width * tb.height * 1.2)) continue;
-          if (!best || area < best.area) {
-            best = { box: sb, area: area };
+      function bestForTexts(texts) {
+        var local = null;
+        for (var ti = 0; ti < texts.length; ti++) {
+          var tb = elementSvgBox(svg, texts[ti]);
+          if (!tb) continue;
+          var cx = tb.x + tb.width / 2;
+          var cy = tb.y + tb.height / 2;
+          var foundShape = false;
+          for (var si = 0; si < shapes.length; si++) {
+            var sb = shapes[si].box;
+            if (!containsPoint(sb, cx, cy, 4)) continue;
+            var area = sb.width * sb.height;
+            if (area < Math.max(80, tb.width * tb.height * 1.2)) continue;
+            // Real shape always beats a text-bounds fallback (which carries
+            // area=0 and would otherwise dominate via `area < best.area`).
+            if (!local || local.fallback || area < local.area) {
+              local = { box: sb, area: area, fallback: false };
+            }
+            foundShape = true;
+          }
+          if (!foundShape && !local) {
+            local = {
+              box: { x: tb.x - 12, y: tb.y - 10, width: tb.width + 24, height: tb.height + 20 },
+              area: 0,
+              fallback: true
+            };
           }
         }
-        if (!best) {
-          best = { box: { x: tb.x - 12, y: tb.y - 10, width: tb.width + 24, height: tb.height + 20 }, area: 0 };
-        }
+        return local;
       }
 
+      var best = bestForTexts(exactTexts) || bestForTexts(partialTexts);
       return best ? expandStackedRects(svg, best.box) : null;
     }
 

--- a/tests/uml-visual-layout-editor.spec.js
+++ b/tests/uml-visual-layout-editor.spec.js
@@ -1238,4 +1238,59 @@ test.describe('UML playground visual editor', () => {
     expect(source).not.toContain('@layout');
     expect(source).not.toContain('@endlayout');
   });
+
+  test('use case actor handles do not collide with use case ellipses that share substring labels', async ({ page }) => {
+    await openPlayground(page);
+    await selectDiagram(page, 'usecase');
+    await selectEditMode(page, 'nodes');
+
+    const boxes = await page.evaluate(() => {
+      const svg = document.querySelector('#uml-pg-output svg');
+      const out = {};
+      Array.from(svg.querySelectorAll('.uml-pg-edit-hitbox')).forEach((h) => {
+        out[h.getAttribute('data-layout-id')] = {
+          x: Number(h.getAttribute('x')),
+          y: Number(h.getAttribute('y')),
+          w: Number(h.getAttribute('width')),
+          h: Number(h.getAttribute('height')),
+        };
+      });
+      return out;
+    });
+
+    // The default usecase example has UC4 = "Manage Users", which contains
+    // the substring "User". Without the exact-match preference fix, the
+    // User actor's hitbox would land on top of the UC4 ellipse.
+    expect(boxes.User, 'User actor handle should exist').toBeTruthy();
+    expect(boxes.UC4, 'Manage Users handle should exist').toBeTruthy();
+    const userCenterX = boxes.User.x + boxes.User.w / 2;
+    const userCenterY = boxes.User.y + boxes.User.h / 2;
+    const insideUC4 =
+      userCenterX >= boxes.UC4.x &&
+      userCenterX <= boxes.UC4.x + boxes.UC4.w &&
+      userCenterY >= boxes.UC4.y &&
+      userCenterY <= boxes.UC4.y + boxes.UC4.h;
+    expect(insideUC4, 'User actor handle should not sit inside the UC4 ellipse').toBe(false);
+  });
+
+  test('activity diagram exposes handles for nodes that only appear as transition targets', async ({ page }) => {
+    await openPlayground(page);
+    await selectDiagram(page, 'activity');
+    await selectEditMode(page, 'nodes');
+
+    const ids = await page.evaluate(() => {
+      const svg = document.querySelector('#uml-pg-output svg');
+      return Array.from(svg.querySelectorAll('.uml-pg-edit-hitbox'))
+        .map((h) => h.getAttribute('data-layout-id'));
+    });
+
+    // "Validate Payment" appears only as the target of a transition
+    // (`"Receive Order" --> "Validate Payment"`), never as a source —
+    // exactly the case that the single-quoted-token regex used to miss.
+    expect(ids).toContain('Receive Order');
+    expect(ids).toContain('Validate Payment');
+    expect(ids).toContain('Process Order');
+    expect(ids).toContain('Reject Order');
+    expect(ids).toContain('Ship Order');
+  });
 });


### PR DESCRIPTION
## Summary

In-depth audit of the UML playground's manual layout adjustment feature surfaced three bugs in continuity of moved elements. This PR fixes the two that live in the playground itself; the third lives in the [ArchUML](https://github.com/ArchesLab/ArchUML) submodule and needs a parallel PR there (patch included below).

### Bug 1 — Use case actors latched onto unrelated use case ellipses
`findRenderedBox` matched any text whose content *contained* the label as a substring. With the default usecase example, the `User` actor matched both its own \`User\` text and \`Manage Users\` (UC4). The actor stick figure has no containing rect; UC4 has a containing ellipse — so the actor's hitbox sat on top of UC4 with no way to grab the actor itself. Two compounding logic errors made this stick: substring matches got equal priority to exact matches, and the \`area=0\` text-bounds fallback prevented later real shapes from replacing it (\`area < 0\` is never true).

**Fix:** split candidates into exact-match and substring-match buckets, try the exact bucket first (shape OR text-bounds fallback), only fall through to substrings if the exact bucket is empty. Inside each bucket, real shapes always replace a \`fallback\` flag instead of competing on area.

### Bug 2 — Activity nodes that only appear as transition targets had no handle
\`collectModelElements\` for activity used \`line.match(/\"([^\"]+)\"/)\` (no \`g\` flag), so \`\"Receive Order\" --> \"Validate Payment\"\` only registered \`Receive Order\`. The default example's \`Validate Payment\` rendered fine but had no movable handle — drag wouldn't work on it.

**Fix:** use a global regex so every quoted token on a line is captured.

### Bug 3 (deferred) — Sequence \`id: Label\` participants silently drop \`@pos\`
\`inferLayoutTargetId\` in the ArchUML submodule captures \`user:\` (with trailing colon) for \`actor user: User\`, then the renderer looks up by \`user\` and misses, so dragging a sequence lifeline updates the source but never moves the rendered element. This is the bug that breaks lifeline swapping in sequence diagrams.

This fix lives in the [ArchUML submodule](https://github.com/ArchesLab/ArchUML), not this repo. Patch:

\`\`\`diff
$(cat /tmp/archuml-colon-id-fix.patch)
\`\`\`

Once that lands and the submodule pointer is bumped, the two regression tests for this bug (kept locally, removed from this PR to keep CI green) can be added back.

## Tested in browser (Jekyll preview)

- Use case: User actor handle now sits over the actor stick figure, not on top of UC4 (\"Manage Users\")
- Activity: \`Validate Payment\` now exposes a drag handle alongside \`Receive Order\`, \`Process Order\`, \`Reject Order\`, \`Ship Order\`
- Verified all 10 diagram types still expose their hitboxes and existing drag scenarios still work

## Test plan

- [x] All 26 existing UML visual layout tests pass
- [x] New: \`use case actor handles do not collide with use case ellipses that share substring labels\`
- [x] New: \`activity diagram exposes handles for nodes that only appear as transition targets\`
- [x] Reviewer: open ArchUML PR with the patch above, then bump the submodule pointer here

🤖 Generated with [Claude Code](https://claude.com/claude-code)