### PR TITLE
Fix h2->h4 heading skips and carousel listbox ARIA on homepage

### DIFF
--- a/_includes/activities.html
+++ b/_includes/activities.html
@@ -20,7 +20,7 @@
 			  	<div class="row">
 		          <div class="col-md-2 col-sm-2 text-right">
 		          	{% assign currentconf = r.conference_short %}
-				    {% if currentconf != previousconf %}<h4>{{ r.conference_short }} {{ r.year }}</h4>{% endif %}
+				    {% if currentconf != previousconf %}<h3>{{ r.conference_short }} {{ r.year }}</h3>{% endif %}
 				    {% assign previousconf = currentconf %}
 		          </div>
 		          <div class="col-md-10 col-sm-10">

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -15,7 +15,7 @@
       duration_days=duration_sec | divided_by: 60 | divided_by: 60 | divided_by: 24 %} {% if duration_days
       <=site.data.news.max_days %} <div class="row">
       <div class="col-md-2 col-md-offset-1 col-sm-2 text-right">
-        <h4>{{ n.date | date : "%d %b. %Y" }}</h4>
+        <h3>{{ n.date | date : "%d %b. %Y" }}</h3>
       </div>
       <div class="col-md-8 col-sm-10">
         <p>{{ n.text}}</p>

--- a/_includes/pencilhatching/description.html
+++ b/_includes/pencilhatching/description.html
@@ -10,7 +10,7 @@
     <li data-target="#carousel-example-generic" data-slide-to="6" aria-label="Go to slide 7"></li>
     <li data-target="#carousel-example-generic" data-slide-to="7" aria-label="Go to slide 8"></li>
   </ol>
-  <div class="carousel-inner" role="listbox">
+  <div class="carousel-inner">
     <div class="item active">
       <img alt="Pencil hatching result 1. Press and hold, or focus and press Enter, to view the original photo." src="img/pencilhatching/img_1.jpg" data-ph-original="img/pencilhatching/img_1_org.jpg" data-ph-rendered="img/pencilhatching/img_1.jpg" class="ph-compare" tabindex="0" title="Press and hold (or focus + Enter) for before / after comparison.">
     </div>

--- a/_includes/photography/overview.html
+++ b/_includes/photography/overview.html
@@ -13,7 +13,7 @@
     <li data-target="#carousel-example-generic" data-slide-to="9" aria-label="Go to slide 10"></li>
     <li data-target="#carousel-example-generic" data-slide-to="10" aria-label="Go to slide 11"></li>
   </ol>
-  <div class="carousel-inner" role="listbox">
+  <div class="carousel-inner">
     <div class="item active">
       <img alt="Photograph 1" src="img/photography/img_1.jpg">
     </div>

--- a/_includes/project.html
+++ b/_includes/project.html
@@ -13,7 +13,7 @@
   {% assign thumbnail_src = p.thumbnail %}
   {% assign thumbnail_alt = p.title %}
   {% assign thumbnail_flickr = p.flickr %}
-  <h4 class="mt-1">{{ p.title | escape }}</h4>
+  <h3 class="mt-1">{{ p.title | escape }}</h3>
   {% include thumbnail.html %}
   <p>{{ p.caption.[page.lang] }}</p>
   <p>{% if p.bibtex %}<a data-toggle="modal" href="#bibtex-{{ p.key }}">BibTex</a>{% if p.downloads %}, {% endif %}{% endif %}

--- a/_includes/publications.html
+++ b/_includes/publications.html
@@ -17,7 +17,7 @@
     {% include thumbnail.html %}
   </div>
   <div class="col-sm-8">
-    <h4 class="title">{{ p.title }}</h4>
+    <h3 class="title">{{ p.title }}</h3>
     <p><span class="author">{% for author in p.authors %}{% if author == p.authors.last and p.authors.size > 1 %}and {%
         endif %}{% assign found = false %}{% for a in co_authors %}{% if a.key == author %}{% assign found = true %}{%
         if a.website %}<a class="author" data-toggle="tooltip" title="{{ a.note }}" href="{{ a.website }}">{{ a.name

--- a/_includes/publications_thesis.html
+++ b/_includes/publications_thesis.html
@@ -16,7 +16,7 @@
         {% include thumbnail.html %}
       </div>
       <div class="col-sm-9">
-        <h4>{{ p.title }}</h4>
+        <h3>{{ p.title }}</h3>
         <p>{% for author in p.authors %}{% if author == p.authors.last and p.authors.count > 1 %}and {% endif %}{{ author }}{% if p.authors.size > 2 and author != p.authors.last %},{% endif %} {% endfor %}<br><span class="text-danger">{{ p.published }} {{ p.date | date: '%Y' }}</span></p>
         <p>{{ p.caption }}</p>
         <p>

--- a/_includes/talks.html
+++ b/_includes/talks.html
@@ -13,11 +13,11 @@
     {% for t in talks reversed %}
     <div class="row">
       <div class="col-md-2 col-md-offset-1 col-sm-2 text-right">
-        <h4>{{ t.date | date : "%d %b. %Y" }}</h4>
+        <h3>{{ t.date | date : "%d %b. %Y" }}</h3>
       </div>
 	  {% assign talkDate = t.date | date: '%s' %}
       <div class="col-md-8 col-sm-10">
-        <h4>{{ t.title}}</h4>
+        <h3>{{ t.title}}</h3>
         <p class="text-danger">{% if talkDate > curDate %}<b>To be held at {% endif %}{{ t.location }}{% if talkDate > curDate %}</b>{% endif %}</p>
         {% if t.downloads %}
         <p>{% for download in t.downloads %}

--- a/_includes/teaching.html
+++ b/_includes/teaching.html
@@ -18,7 +18,7 @@
           <div class="panel-body">
             <ul>{% for c in t.courses %}
               <li>
-                <h4>{{ c.course }}</h4>
+                <h3>{{ c.course }}</h3>
                 <span class="text-danger">{{ c.type }}</span>, {{ c.role }}
               </li>{% endfor %}
             </ul>


### PR DESCRIPTION
## Summary

- Convert `<h4>` item titles to `<h3>` inside homepage `<h2>` sections (news, publications, projects, teaching, talks, activities, thesis) so the heading hierarchy is `h1 → h2 → h3` instead of skipping a level.
- Remove the invalid `role="listbox"` from the photography and pencil-hatching carousel inners. An image carousel is a slideshow, not a listbox; `role="listbox"` requires `role="option"` children, which `<img tabindex>` is not.
- Surfaced by `tests/wcag22-complete-audit.spec.js` (WCAG 1.3.1 Info and Relationships, 4.1.2 Name, Role, Value).

## Test plan

- [x] `WCAG_AUDIT_URL_FILTER='^/index\.html$' npx playwright test tests/wcag22-complete-audit.spec.js --reporter=line` → 1 passed, 0 findings
- [x] `WCAG_AUDIT_URL_FILTER='/SEBook/' WCAG_AUDIT_PAGE_LIMIT=3 npx playwright test tests/wcag22-complete-audit.spec.js --reporter=line` → 1 passed, 0 findings (no new heading-skip findings on SEBook pages)
- [x] Verified homepage renders correctly in both light and dark mode (h3 inherits the same dark-mode `#FFD100` color rule as h2/h4 in `css/portfolio.css`, no extra CSS needed)
- [x] Verified `_site/index.html` shows `h2 → h3` hierarchy after build, and `<div class="carousel-inner">` no longer carries `role="listbox"` on `/index.html`, `/photography.html`, `/pencilhatching.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)