### PR TITLE
Move UML diagrams from explanations to questions in flashcards

### DIFF
--- a/_data/flashcards/uml_class_diagram_examples.yml
+++ b/_data/flashcards/uml_class_diagram_examples.yml
@@ -3,12 +3,13 @@ description: "Quick review of UML Class Diagram notation and relationships."
 active: true
 cards:
   - id: 1
-    question: "What does the following symbol represent in a class diagram?"
+    question: >
+      What does the following symbol represent in a class diagram?
+
+      <div data-uml-type="class" data-uml-spec="class Department&#10;class Professor&#10;Department o-- Professor"></div>
     answer: "Aggregation"
     explanation: >
       A hollow diamond on the parent class indicates **Aggregation**, representing a 'part-of' relationship where the parts can exist independently of the whole.
-
-      <div data-uml-type="class" data-uml-spec="class Department&#10;class Professor&#10;Department o-- Professor"></div>
 
   - id: 2
     question: "How do you denote a **Static Method** in UML Class Diagrams?"
@@ -19,12 +20,13 @@ cards:
       <div data-uml-type="class" data-uml-spec="class MathUtils {&#10;  {static} +abs(n: int) : int&#10;  +pi() : double&#10;}"></div>
 
   - id: 3
-    question: "What is the difference between these two relationships?"
+    question: >
+      What is the difference between these two relationships?
+
+      <div data-uml-type="class" data-uml-spec="class Building&#10;class Room&#10;class Library&#10;class Book&#10;Building *-- Room&#10;Library o-- Book"></div>
     answer: "The first is **Composition** (strong), the second is **Aggregation** (weak)."
     explanation: >
       A filled diamond (<span class="uml-sym" data-diagram="class" data-sym="*--"></span>) is **Composition**, meaning the parts cannot exist without the whole. A hollow diamond (<span class="uml-sym" data-diagram="class" data-sym="o--"></span>) is **Aggregation**.
-
-      <div data-uml-type="class" data-uml-spec="class Building&#10;class Room&#10;class Library&#10;class Book&#10;Building *-- Room&#10;Library o-- Book"></div>
 
   - id: 4
     question: "What is the difference between **Generalization** and **Realization** arrows?"

--- a/tests/uml-flashcard-question-rendering.spec.js
+++ b/tests/uml-flashcard-question-rendering.spec.js
@@ -1,0 +1,125 @@
+// @ts-check
+//
+// Regression tests for UML class diagram flashcards whose questions reference
+// a visual ("the following symbol", "these two relationships"). The diagram
+// must appear inside the question, not only in the explanation, in both the
+// SEBook flashcard widget and the SE Gym workout integration.
+const { test, expect } = require('@playwright/test');
+
+const SEBOOK_URL = '/SEBook/uml_class_diagram.html';
+const GYM_URL = '/se-gym/';
+
+async function setCookie(context, name, value) {
+  await context.addCookies([{
+    name,
+    value: encodeURIComponent(value),
+    domain: '127.0.0.1',
+    path: '/',
+  }]);
+}
+
+async function expectRenderedUml(question) {
+  const umlContainer = question.locator('[data-uml-type="class"]');
+  await expect(umlContainer).toBeVisible();
+  // UMLShared.renderAll injects an <svg> child into each container after rendering.
+  await expect(umlContainer.locator('svg')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('UML class diagram flashcards - question diagrams render in SEBook', () => {
+  test('Card 1 (aggregation) shows its diagram in the question', async ({ page }) => {
+    await page.goto(SEBOOK_URL);
+
+    const container = page.locator('.flashcards-container[data-quiz-id="uml_class_diagram_examples"]');
+    await expect(container).toBeVisible();
+
+    // Cards are present in the DOM but only one is .active. Force card 1 active.
+    await page.evaluate(() => {
+      const cards = document.querySelectorAll(
+        '.flashcards-container[data-quiz-id="uml_class_diagram_examples"] .flashcard-card'
+      );
+      cards.forEach((c) => c.classList.remove('active'));
+      const target = document.querySelector(
+        '.flashcards-container[data-quiz-id="uml_class_diagram_examples"] .flashcard-card[data-card-id="1"]'
+      );
+      if (target) target.classList.add('active');
+      if (window.UMLShared) window.UMLShared.renderAll();
+    });
+
+    const card1 = container.locator('.flashcard-card[data-card-id="1"]');
+    const question = card1.locator('.flashcard-question');
+    await expect(question).toContainText('following symbol');
+    await expectRenderedUml(question);
+  });
+
+  test('Card 3 (composition vs aggregation) shows its diagram in the question', async ({ page }) => {
+    await page.goto(SEBOOK_URL);
+
+    const container = page.locator('.flashcards-container[data-quiz-id="uml_class_diagram_examples"]');
+    await expect(container).toBeVisible();
+
+    await page.evaluate(() => {
+      const cards = document.querySelectorAll(
+        '.flashcards-container[data-quiz-id="uml_class_diagram_examples"] .flashcard-card'
+      );
+      cards.forEach((c) => c.classList.remove('active'));
+      const target = document.querySelector(
+        '.flashcards-container[data-quiz-id="uml_class_diagram_examples"] .flashcard-card[data-card-id="3"]'
+      );
+      if (target) target.classList.add('active');
+      if (window.UMLShared) window.UMLShared.renderAll();
+    });
+
+    const card3 = container.locator('.flashcard-card[data-card-id="3"]');
+    const question = card3.locator('.flashcard-question');
+    await expect(question).toContainText('these two relationships');
+    await expectRenderedUml(question);
+  });
+});
+
+test.describe('UML class diagram flashcards - question diagrams render in SE Gym', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.clearCookies();
+    await setCookie(context, 'se-gym-active', 'true');
+    await setCookie(
+      context,
+      'se-gym',
+      JSON.stringify([{ type: 'flashcard', id: 'uml_class_diagram_examples' }])
+    );
+  });
+
+  test('Question diagrams render whenever a card with one is active', async ({ page }) => {
+    await page.goto(GYM_URL);
+
+    // Run all 10 cards so we will encounter cards 1 and 3 regardless of shuffle.
+    await page.locator('#max-cards').fill('10');
+    await page.locator('#start-workout-btn').click();
+
+    const flashcard = page.locator('.workout-flashcard');
+    await expect(flashcard).toBeVisible();
+
+    let sawAggregation = false;
+    let sawComparison = false;
+
+    for (let step = 0; step < 10; step++) {
+      const question = flashcard.locator('.flashcard-question');
+      const text = (await question.innerText()) || '';
+
+      if (text.includes('following symbol') || text.includes('these two relationships')) {
+        // The question references a visual — verify it's actually rendered.
+        await expectRenderedUml(question);
+        if (text.includes('following symbol')) sawAggregation = true;
+        if (text.includes('these two relationships')) sawComparison = true;
+      }
+
+      await flashcard.locator('.show-answer-btn').click();
+      await flashcard.locator('.correct-btn').click();
+
+      // After the last card, the workout completes and the card disappears.
+      if (step === 9) break;
+      await expect(flashcard).toBeVisible();
+    }
+
+    expect(sawAggregation, 'Card 1 (aggregation) should appear in 10-card workout').toBe(true);
+    expect(sawComparison, 'Card 3 (composition vs aggregation) should appear in 10-card workout').toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Updated UML class diagram flashcards to display diagrams in the question section rather than only in the explanation. This ensures users see the visual reference when answering the question, not just after revealing the answer. Added comprehensive regression tests to verify diagram rendering in both SEBook and SE Gym environments.

## Key Changes
- **Flashcard content restructuring**: Moved `<div data-uml-type="class">` elements from the `explanation` field to the `question` field for cards 1 and 3 in `uml_class_diagram_examples.yml`
- **Question formatting**: Converted single-line questions to multi-line format using YAML `>` syntax to accommodate the embedded diagram markup
- **Regression test suite**: Added `uml-flashcard-question-rendering.spec.js` with Playwright tests covering:
  - Card 1 (aggregation) diagram rendering in SEBook flashcard widget
  - Card 3 (composition vs aggregation) diagram rendering in SEBook
  - Question diagram rendering across all cards in SE Gym workout integration
  - Verification that SVG elements are properly injected by `UMLShared.renderAll()`

## Implementation Details
- Tests use `data-uml-type="class"` selector to locate diagram containers and verify SVG rendering with a 5-second timeout
- SE Gym tests set up cookies to configure the workout and iterate through all 10 cards to ensure both target cards are encountered
- Tests validate that questions containing visual references ("following symbol", "these two relationships") have properly rendered diagrams before answer reveal

https://claude.ai/code/session_01D7ziUN4e1VyTk2vdh7RDRY