### PR TITLE
Auto-unlock Next on tutorial steps with no tests

### DIFF
--- a/.agents/skills/tutorial-authoring/SKILL.md
+++ b/.agents/skills/tutorial-authoring/SKILL.md
@@ -491,8 +491,16 @@ backend: v86 | pyodide | webcontainer | react   # default: v86
 # react         — React + Vite + live preview iframe + Playwright-compat.
 
 # === Common feature flags ===
-require_tests: boolean                 # If true, student must pass step's
+require_tests: boolean                 # If true, student must pass each step's
                                        # tests to advance. Default false.
+                                       # NOTE: only steps that actually declare
+                                       # `tests:` are gated. A step with no
+                                       # `tests:` block is treated as ungated
+                                       # — Next is enabled immediately (a quiz,
+                                       # if present, opens via clicking Next).
+                                       # This makes purely-quiz / summary /
+                                       # reflection steps work inside an
+                                       # otherwise test-gated tutorial.
 linter: boolean | "pyflakes"           # Live diagnostics in Monaco gutter.
 debugger: boolean                      # Time-travel debugger (pyodide only).
 debugger_options: { ... }              # Per-tutorial debugger config

--- a/js/tutorial-code.js
+++ b/js/tutorial-code.js
@@ -5929,8 +5929,11 @@
     };
   };
 
-  TutorialCode.prototype._isNextStepLocked = function () {
-    var idx = this.currentStep;
+  TutorialCode.prototype._isNextStepLocked = function (idx) {
+    if (idx == null) idx = this.currentStep;
+    // Steps with no tests can't be gated by tests — there's nothing to pass.
+    // (A quiz, if present, opens via clicking Next, not by gating it.)
+    if (!this._stepHasTests(this.steps[idx])) return false;
     var nextStepUnlocked = !this.requireTests || this.instructorMode || this._stepsUnlocked.has(idx + 1);
     return !nextStepUnlocked;
   };
@@ -8808,8 +8811,7 @@
   TutorialCode.prototype._renderStepControls = function (index) {
     var self = this;
     var step = this.steps[index];
-    var nextStepUnlocked = !this.requireTests || this.instructorMode || this._stepsUnlocked.has(index + 1);
-    var nextLocked = !nextStepUnlocked;
+    var nextLocked = this._isNextStepLocked(index);
 
     var html = '';
     html += index > 0


### PR DESCRIPTION
A test-gated tutorial (`require_tests: true`) used to lock the Next button on every step, even steps with no `tests:` block. That left no way to advance from quiz-only / summary / reflection steps such as the Observer Pattern's "Comprehensive Assessment" step — clicking Next was a no-op and the quiz never opened.

Treat steps with no tests as ungated: Next is enabled immediately, and a present quiz still opens via the click handler and gates the next step on quiz pass as before.

https://claude.ai/code/session_01QhDQZ2ypxdSjxBFsCVJy8R