### PR TITLE
Recalibrate quiz/flashcard difficulty against Bloom's taxonomy

### DIFF
--- a/_data/flashcards/design_pattern_singleton.yml
+++ b/_data/flashcards/design_pattern_singleton.yml
@@ -8,7 +8,7 @@ cards:
     answer: "(1) Private constructor, (2) private static field holding the instance, (3) public static `getInstance()` method as sole access point."
     explanation: "The private constructor prevents external instantiation. The static field stores the single instance. The static method provides controlled access."
   - id: 2
-    difficulty: intermediate
+    difficulty: advanced
     question: "Why is Singleton controversial in modern practice?"
     answer: "It conflates two concerns: ensuring a single instance (legitimate) and providing global access (harmful coupling). DI containers solve the first without introducing the second."
     explanation: "POSA5 calls it 'a well-known pattern with a weak solution.' The literature discussing Singleton's issues dwarfs the original GoF description."

--- a/_data/flashcards/git.yml
+++ b/_data/flashcards/git.yml
@@ -8,7 +8,7 @@ cards:
     answer: "`git stash`"
     explanation: "`git stash` temporarily shelves your staged and unstaged changes for tracked files. To include brand new, untracked files in the stash, you must use `git stash -u`."
   - id: 2
-    difficulty: advanced
+    difficulty: intermediate
     question: "You know a bug was introduced recently, but you aren't sure which commit caused it. How do you perform a binary search through your commit history to find the exact commit that broke the code?"
     answer: "`git bisect`"
     explanation: "`git bisect` systematically halves your commit history, asking you to test if the bug is present at each step, making it highly efficient for tracking down regressions."

--- a/_data/flashcards/git_advanced.yml
+++ b/_data/flashcards/git_advanced.yml
@@ -3,7 +3,7 @@ description: "Which Git command would you use for the following advanced scenari
 active: true
 cards:
   - id: 1
-    difficulty: basic
+    difficulty: intermediate
     question: "You have some uncommitted, incomplete changes in your working directory, but you need to switch to another branch to urgently fix a bug. How do you temporarily save your current work without making a messy commit?"
     answer: "`git stash`"
     explanation: "`git stash` temporarily shelves your staged and unstaged changes for tracked files. To include brand new, untracked files in the stash, you must use `git stash -u`."

--- a/_data/flashcards/shell.yml
+++ b/_data/flashcards/shell.yml
@@ -63,7 +63,7 @@ cards:
     answer: "`wc -l essay.txt`"
     explanation: "The `wc` (word count) command prints newline, word, and byte counts for a file. Adding the `-l` flag restricts the output to only the line count."
   - id: 13
-    difficulty: expert
+    difficulty: intermediate
     question: "You need to perform an automated find-and-replace operation on a stream of text to change the word 'apple' to 'orange'."
     answer: "`sed 's/apple/orange/g'`"
     explanation: "The `sed` (stream editor) `s`: Stands for 'substitute'. `/`: The delimiter that separates the search and replacement terms. `apple`: The string you want to find. `orange`: The string you want to replace it with. `g`: Stands for 'global'. This tells sed to replace every instance of 'apple' on a line, rather than just the first one it finds."

--- a/_data/flashcards/shell_pipes.yml
+++ b/_data/flashcards/shell_pipes.yml
@@ -39,7 +39,7 @@ cards:
     explanation: "`ls -S` sorts directory entries by file size (largest first); `head -5` keeps only the first 5 lines of that output."
 
   - id: 7
-    difficulty: expert
+    difficulty: intermediate
     question: "You want to replace every occurrence of `http://` with `https://` in `links.txt` and save the result to `links_secure.txt`."
     answer: "`sed 's|http://|https://|g' links.txt > links_secure.txt`"
     explanation: "Here we redirect `sed`'s stdout to a file instead of piping it onward, but `sed` reads from a file argument, transforms the stream, and writes to stdout — which the shell redirects with `>`."

--- a/_data/flashcards/study_tips.yml
+++ b/_data/flashcards/study_tips.yml
@@ -23,7 +23,7 @@ cards:
     answer: "Spreading out study sessions over increasing intervals of time."
     explanation: "Spacing allows for some forgetting to occur, which makes the subsequent retrieval more effortful and effective for **durable memory**."
   - id: 5
-    difficulty: intermediate
+    difficulty: basic
     question: "What is Interleaving?"
     answer: "Mixing the practice of different but related topics or skills."
     explanation: "Unlike **'blocked practice'** (focusing on one topic at a time), interleaving helps learners discriminate between problem types and understand relationships."

--- a/_data/quizzes/ai_quiz.yml
+++ b/_data/quizzes/ai_quiz.yml
@@ -17,7 +17,7 @@ questions:
       3: "External tools do not increase biological memory capacity. They reduce what must be held or processed mentally by putting some of the work outside the mind."
     explanation: "**Cognitive offloading** is the use of external tools (like calculators, calendars, or AI) to reduce the mental effort required for a task."
   - id: 2
-    difficulty: intermediate
+    difficulty: basic
     question: "According to research, who benefits more from using AI for technical tasks?"
     options:
       - "Absolute novices with no prior experience."
@@ -45,7 +45,7 @@ questions:
       3: "Copying code without understanding can create a false sense of fluency and hide defects. Beneficial offloading should leave the learner able to explain, test, and revise the result."
     explanation: "**Beneficial offloading** involves delegating 'extraneous load' (tedious, non-core tasks) to AI so you can focus on the 'intrinsic load' (the actual concepts you need to learn)."
   - id: 4
-    difficulty: intermediate
+    difficulty: basic
     question: "What is the 'desirable difficulty' in the context of learning?"
     options:
       - "Any difficulty that makes a student want to give up."

--- a/_data/quizzes/data_management.yml
+++ b/_data/quizzes/data_management.yml
@@ -3,7 +3,7 @@ description: "Test your ability to reason about ACID, CAP, and the RDBMS/NoSQL t
 active: true
 questions:
   - id: 1
-    difficulty: basic
+    difficulty: intermediate
     type: single
     question: |
       A flight-booking service executes a transaction that (1) debits a passenger's credit card and (2) writes a "seat reserved" row. The server crashes between the two steps. On restart, the card shows a charge but no seat is reserved. **Which ACID property did the system fail to provide?**
@@ -22,7 +22,7 @@ questions:
     explanation: "Atomicity guarantees a transaction is indivisible: either every step of the transaction is applied, or none of them are. A half-applied state (debit ✓, reservation ✗) is the textbook symptom of missing atomicity. Durability is about changes that were *already committed* surviving a crash — here the transaction had not committed. Isolation is about *concurrent* interference, which this scenario doesn't involve."
 
   - id: 2
-    difficulty: basic
+    difficulty: intermediate
     type: single
     question: |
       Two customer-service agents click "apply \\$50 refund" on the same account at the same instant. Each reads the balance \\$100, subtracts 50, and writes back \\$50 — so one refund silently disappears. **Which ACID property would have prevented this lost update?**
@@ -79,7 +79,7 @@ questions:
     explanation: "The two 'Consistency' words refer to different things. ACID-C means committed transactions don't violate declared constraints. CAP-C (linearizability) means every read reflects the latest write across all replicas. A SQL database that asynchronously replicates to read replicas still honors ACID on the primary but can absolutely serve stale reads from a replica — failing CAP-C. Separating these two ideas is one of the most important conceptual moves in this chapter."
 
   - id: 5
-    difficulty: basic
+    difficulty: intermediate
     type: single
     question: |
       A DBMS acknowledges `COMMIT` to your application; half a second later the server loses power. On reboot, the change is **gone**. **Which ACID property did the system fail to provide?**
@@ -285,7 +285,7 @@ questions:
     explanation: "`student_id` alone would be unique only if each student were enrolled in exactly one course ever — not the case. What *is* unique is the combination: one row per (student, course, quarter). RDBMSs fully support **composite primary keys** for exactly this reason, and it is the idiomatic way to model a many-to-many join table. A surrogate auto-increment key is a valid secondary choice but doesn't express the natural uniqueness constraint — you'd still want a UNIQUE constraint on the triple."
 
   - id: 15
-    difficulty: basic
+    difficulty: intermediate
     type: single
     question: |
       A foreign key `Enrollment.course_id` points at `Course.course_id`. The DBMS rejects an `INSERT` into `Enrollment` where `course_id = "CS999"` because no such course exists. **What property is being enforced, and which ACID letter does this fall under?**

--- a/_data/quizzes/design_pattern_command.yml
+++ b/_data/quizzes/design_pattern_command.yml
@@ -83,7 +83,7 @@ questions:
     explanation: "**This is a Macro Command.** It implements the same command interface while holding and executing a sequence of child commands."
 
   - id: 5
-    difficulty: basic
+    difficulty: advanced
     type: single
     question: |
       When is Command probably over-engineering?

--- a/_data/quizzes/design_pattern_mediator.yml
+++ b/_data/quizzes/design_pattern_mediator.yml
@@ -3,7 +3,7 @@ description: "Test your understanding of the Mediator pattern, its trade-offs, a
 active: true
 questions:
   - id: 1
-    difficulty: intermediate
+    difficulty: advanced
     type: single
     question: |
       In a smart home, the AlarmClock, CoffeeMaker, Calendar, and Sprinkler coordinate via a SmartHomeHub (Mediator). The rule is: "When the alarm rings on a weekday, brew coffee and skip watering." If the team used Observer instead (CoffeeMaker observes AlarmClock directly), where would the "only on weekdays" rule live?
@@ -23,7 +23,7 @@ questions:
     explanation: "**With Observer, the CoffeeMaker would have to check the Calendar itself, creating the tight coupling that Mediator was designed to prevent.** With Observer, each observer **independently decides** how to react. The CoffeeMaker would need to check the Calendar itself to know if it's a weekday — meaning the CoffeeMaker now **depends on** the Calendar, creating exactly the tight coupling that the Mediator was meant to prevent. The Mediator **centralizes** this rule: the Hub checks the calendar and commands the coffee maker, keeping each device independent."
 
   - id: 2
-    difficulty: intermediate
+    difficulty: advanced
     type: single
     question: |
       What is the **core difference** between Observer and Mediator?

--- a/_data/quizzes/design_pattern_singleton.yml
+++ b/_data/quizzes/design_pattern_singleton.yml
@@ -24,7 +24,7 @@ questions:
 
   - id: 3
     type: single
-    difficulty: basic
+    difficulty: intermediate
     question: |
       A system uses Singleton for a database connection pool. A new requirement: the system must support multi-tenant deployments with one pool per tenant. What is the fundamental problem?
     options:

--- a/_data/quizzes/design_pattern_structural.yml
+++ b/_data/quizzes/design_pattern_structural.yml
@@ -63,7 +63,7 @@ questions:
     explanation: "**This is the Transparent Composite trade-off — a runtime exception is thrown because leaves inherit child-management methods that are meaningless for them.** This is the **Transparent Composite** trade-off. By putting `add()`/`remove()` on the abstract `Component`, clients get a uniform interface (any component can be treated the same), but **leaves inherit methods that are semantically meaningless**. The leaf must handle this — typically by throwing `UnsupportedOperationException`. The **Safe Composite** alternative puts these methods only on `Composite`, preventing the call at compile time but requiring clients to downcast."
 
   - id: 4
-    difficulty: intermediate
+    difficulty: advanced
     type: single
     question: |
       All three patterns — Adapter, Facade, and Decorator — involve "wrapping" another object. What is the key distinction between them?

--- a/_data/quizzes/design_patterns.yml
+++ b/_data/quizzes/design_patterns.yml
@@ -3,7 +3,7 @@ description: "Test your understanding of design patterns at the Analyze and Eval
 active: true
 questions:
   - id: 1
-    difficulty: basic
+    difficulty: intermediate
     type: single
     question: |
       A colleague proposes using the Observer pattern in a module that has exactly one dependent object which will never change. What is the best assessment of this decision?

--- a/_data/quizzes/git.yml
+++ b/_data/quizzes/git.yml
@@ -107,7 +107,7 @@ questions:
     explanation: "**`git stash` temporarily shelves uncommitted changes so you can switch contexts without making a messy commit.** `git stash` temporarily shelves your staged and unstaged changes, leaving you with a clean working directory so you can safely switch contexts."
 
   - id: 6
-    difficulty: advanced
+    difficulty: intermediate
     question: "What happens when you enter a 'Detached HEAD' state in Git?"
     options:
       - "A merge conflict occurs that Git cannot resolve automatically."
@@ -146,7 +146,7 @@ questions:
     explanation: "**`git bisect` uses binary search through commit history to efficiently pinpoint the exact commit that introduced a bug.** `git bisect` systematically halves your commit history, asking you to test if the bug is present at each step, to efficiently find the exact commit that broke the code."
 
   - id: 8
-    difficulty: expert
+    difficulty: intermediate
     question: "What is the primary purpose of Git Submodules?"
     options:
       - "To break a single, massive file into smaller, trackable pieces to improve performance."
@@ -293,7 +293,7 @@ questions:
     explanation: "**Merging, rebasing, and squash-merging are the three integration techniques — `git bisect` and `git blame` are inspection tools, not integration strategies.** Merging, rebasing, and squashing (`git merge --squash`) are all techniques used to integrate branch histories together. Note that `git merge --squash` only **stages** the combined changes — you must follow it with `git commit` to actually create the squashed commit. `git bisect` is a debugging tool for finding bugs, and `git blame` is used to see who last modified specific lines of code."
 
   - id: 14
-    difficulty: intermediate
+    difficulty: advanced
     question: "A faulty commit was pushed to a shared 'main' branch last week and your teammates have already synced it. Why should you use `git revert` to fix this rather than `git reset --hard` followed by a force-push?"
     options:
       - "`git revert` automatically resolves any merge conflicts introduced by the bad commit."

--- a/_data/quizzes/git_advanced.yml
+++ b/_data/quizzes/git_advanced.yml
@@ -3,7 +3,7 @@ description: "Test your knowledge of advanced Git commands, debugging tools, and
 active: true
 questions:
   - id: 1
-    difficulty: basic
+    difficulty: intermediate
     question: "You have some uncommitted, incomplete changes in your working directory, but you need to switch to another branch to urgently fix a bug. Which command is best suited to temporarily save your current work without making a messy commit?"
     options:
       - "`git cherry-pick`"
@@ -63,7 +63,7 @@ questions:
     explanation: "**`git bisect` uses binary search through commit history to efficiently pinpoint the exact commit that introduced a bug.** `git bisect` systematically halves your commit history, asking you to test if the bug is present at each step, to efficiently find the exact commit that broke the code."
 
   - id: 4
-    difficulty: expert
+    difficulty: intermediate
     question: "What is the primary purpose of Git Submodules?"
     options:
       - "To break a single, massive file into smaller, trackable pieces to improve performance."

--- a/_data/quizzes/git_basic.yml
+++ b/_data/quizzes/git_basic.yml
@@ -165,7 +165,7 @@ questions:
     explanation: "**`git log`, `git diff`, and `git show` are the review/inspection commands — `git push` uploads data and `git init` creates repos.** `git log` shows the commit history, `git diff` shows differences between states or commits, and `git show` displays details about a specific Git object (like a commit). `git push` uploads data, and `git init` creates a new repository."
 
   - id: 8
-    difficulty: intermediate
+    difficulty: advanced
     question: "A faulty commit was pushed to a shared 'main' branch last week and your teammates have already synced it. Why should you use `git revert` to fix this rather than `git reset --hard` followed by a force-push?"
     options:
       - "`git revert` automatically resolves any merge conflicts introduced by the bad commit."

--- a/_data/quizzes/makefile.yml
+++ b/_data/quizzes/makefile.yml
@@ -63,9 +63,9 @@ questions:
         each rule invocation.
     explanation: "**`$@` represents the target name of the current rule.** `$@` evaluates to the target name. It is heavily used in compilation commands (e.g., `gcc ... -o $@`) to dynamically specify the output file name."
   
-  - id: 4 
-    difficulty: basic
-    question: "Why is the `.PHONY` directive used in Makefiles (e.g., `.PHONY: clean`)?" 
+  - id: 4
+    difficulty: intermediate
+    question: "Why is the `.PHONY` directive used in Makefiles (e.g., `.PHONY: clean`)?"
     options: 
       - "To suppress `make` from echoing the command to the terminal." 
       - "To declare that the target is an action/command and not a physical file to be created." 

--- a/_data/quizzes/regex.yml
+++ b/_data/quizzes/regex.yml
@@ -2,9 +2,9 @@ title: "RegEx Quiz"
 description: "Test your understanding of regular expressions beyond basic syntax, focusing on underlying mechanics, performance, and theory." 
 active: true
 questions: 
-  - id: 1 
-    difficulty: expert
-    question: "You are tasked with extracting all data enclosed in HTML `<div>` tags. You write a regular expression, but it consistently fails on deeply nested divs (e.g., `<div><div>text</div></div>`). From a theoretical computer science perspective, why is standard RegEx the wrong tool for this?" 
+  - id: 1
+    difficulty: advanced
+    question: "You are tasked with extracting all data enclosed in HTML `<div>` tags. You write a regular expression, but it consistently fails on deeply nested divs (e.g., `<div><div>text</div></div>`). From a theoretical computer science perspective, why is standard RegEx the wrong tool for this?"
     options: 
       - "RegEx engines process strings right-to-left, making opening tags impossible to track." 
       - "Standard regular expressions are based on finite automata, which lack the memory to track arbitrarily deep nested structures." 

--- a/_data/quizzes/requirements.yml
+++ b/_data/quizzes/requirements.yml
@@ -66,7 +66,7 @@ questions:
     explanation: "**Specifying a 'graph database' is a design decision, not a user need — including it in the requirement prematurely constrains the engineering team from exploring better solutions.** Specifying a 'graph database' is a design decision. Including it in the requirement prematurely constrains the engineering team from exploring potentially better data persistence options."
 
   - id: 4
-    difficulty: intermediate
+    difficulty: basic
     question: "In a cross-functional Agile team, who is ideally suited to articulate the functional expectations of a new feature, and who should decide the underlying technical mechanics?"
     options:
       - "Software engineers define expectations; product managers dictate mechanics."
@@ -108,7 +108,7 @@ questions:
     explanation: "**'Embed a Redis store' is a solution-space statement because it names a specific technology — the other options describe required system behavior without dictating the implementation.** Utilizing **`Redis`** is a specific technical implementation (design decision) for data persistence, unlike the other options which simply state the required system behavior."
 
   - id: 6
-    difficulty: advanced
+    difficulty: intermediate
     question: "A development team originally built a search feature using a basic database query but later migrated to a dedicated indexing engine to handle typos more effectively. If their original specification was written perfectly, what happened to that specification during this technical migration?"
     options:
       - "It was completely rewritten to reflect the new indexing engine."
@@ -129,7 +129,7 @@ questions:
     explanation: "**A well-written requirement focused on the 'what' remains unchanged even when the implementation is completely replaced — it stayed valid through the migration because it never named a specific technology.** Because design decisions change frequently, a well-written requirement focused strictly on the **'what'** preserves flexibility and remains valid even if the underlying technical solution is swapped out."
 
   - id: 7
-    difficulty: intermediate
+    difficulty: basic
     question: "A team needs to ensure their new banking portal can handle 10,000 simultaneous logins within two seconds without crashing. What is the recommended format for capturing this specific type of system characteristic?"
     options:
       - "A high-level user persona."

--- a/_data/quizzes/shell.yml
+++ b/_data/quizzes/shell.yml
@@ -63,7 +63,7 @@ questions:
         whether loop variables remain visible after the loop.
     explanation: "**Bash lacks block-level scoping, so variables set inside loops remain accessible throughout the entire script.** Bash does not use block-level scoping. Unless explicitly declared as `local` inside a function, variables assigned within control structures like loops or conditionals bleed into the rest of the script."
   - id: 4
-    difficulty: expert
+    difficulty: intermediate
     question: "You want to use a command that requires two file inputs (like `diff`), but your data is currently coming from the live outputs of two different commands. Instead of creating temporary files on the disk, you use the `<(command)` syntax. What is this concept called and what does it achieve?"
     options:
       - "Piping; it concatenates the outputs of both commands into a single, unified text stream."

--- a/_data/quizzes/software_architecture.yml
+++ b/_data/quizzes/software_architecture.yml
@@ -3,7 +3,7 @@ description: "Recalling what you just learned is the best way to form lasting me
 active: true
 questions:
   - id: 1
-    difficulty: advanced
+    difficulty: basic
     question: "Taylor et al. champion a paradigm that defines software architecture as 'the set of principal choices governing a system' — emphasizing rationale rather than boxes and lines. Which paradigm is this?"
     options:
       - "The Structural Paradigm"
@@ -108,7 +108,7 @@ questions:
     explanation: "**When descriptive and prescriptive architectures diverge completely, the system loses conceptual integrity and accumulates technical debt until it becomes a 'Big Ball of Mud' — unmaintainable and unstructured.** Complete divergence leads to loss of conceptual integrity, technical debt accumulation, and unmaintainability (often resulting in a 'Big Ball of Mud')."
 
   - id: 6
-    difficulty: expert
+    difficulty: intermediate
     question: "In the context of the JackTrip project, what was identified as a primary driver of 'link overload smells' and erosion?"
     options:
       - "Using too many descriptive diagrams."


### PR DESCRIPTION
## Summary

Pedagogical audit of the difficulty labels on every deck under `_data/quizzes/` and `_data/flashcards/` — applying Bloom's revised taxonomy (Anderson & Krathwohl 2001), Cognitive Load Theory's expertise-reversal principle, and assessment-principles reliability/discrimination — found four systematic mislabelling patterns. This PR fixes the high-confidence subset: **32 single-line label changes across 21 files**, no content changes.

The audit was produced by running `/pedagogical-advisor` over the corpus in three passes (cross-file inconsistencies, foundational-deck calibration, advanced-deck calibration) and synthesizing findings.

## Patterns fixed

**Pattern 1 — cross-file inconsistency.** Same / near-identical stem labelled differently in two decks (assessment-principles *reliability* failure: a learner studying the same skill twice should see the same calibration both times).

| Stem | Before | After |
|---|---|---|
| `git stash` for context-switch | basic / intermediate (mixed) | **intermediate** (Bloom Apply) |
| Detached HEAD definition | advanced / intermediate (mixed) | **intermediate** (Bloom Understand) |
| `git bisect` flashcard | advanced / intermediate (mixed) | **intermediate** |
| Singleton multi-tenant scenario | basic | **intermediate** (Bloom Analyze) |
| Singleton "weak solution" flashcard | intermediate | **advanced** (Bloom Evaluate) |
| `.PHONY` directive | basic / intermediate (mixed) | **intermediate** |

**Pattern 3 — recall labelled too high.** Topic is advanced but cognitive demand is recall (Bloom Remember). 8 items down-labelled.

**Pattern 4 — definitions labelled too high.** Pure Remember items in foundational decks marked intermediate. 6 items down-labelled.

**Pattern 5 — cross-pattern comparison labelled too low.** Items demanding Bloom Analyze (compare two patterns) marked intermediate. 9 items up-labelled.

See the commit message for the full per-item list with Bloom-level justifications.

## Out of scope (deferred to future PRs)

The audit also identified higher-effort improvements that aren't relabels and need content authoring:

- **Missing basic floor**: [user_stories.yml](_data/quizzes/user_stories.yml) (0 pure-recall items), [shell.yml](_data/quizzes/shell.yml) (4/22 basic), [python.yml](_data/quizzes/python.yml) (2/10 basic), [regex.yml](_data/quizzes/regex.yml) (2/13 basic) — under-staffed entry tier per CLT expertise-reversal.
- **Missing expert ceiling**: [git_advanced.yml](_data/quizzes/git_advanced.yml), [makefile.yml](_data/quizzes/makefile.yml), [networking.yml](_data/quizzes/networking.yml), [scrum.yml](_data/quizzes/scrum.yml) lack genuine expert items even though the topics admit them.
- **Final exam Bloom mix**: [CS35_fall_2025_final.yml](_data/quizzes/CS35_fall_2025_final.yml) is ~40% Remember — too recall-heavy for a course-level summative; risks washback.
- **Deduplication**: [ai_fundamentals.yml](_data/quizzes/ai_fundamentals.yml) (active:false) and [ai_quiz.yml](_data/quizzes/ai_quiz.yml) overlap; [networking_decisions_old.yml](_data/quizzes/networking_decisions_old.yml) is deprecated.
- **Deck-relative vs absolute label semantics**: in topic-specific advanced decks (e.g. `git_advanced.yml`), the easiest item gets `basic` even though it'd be `intermediate` in absolute terms — confusing the SE Gym filter UI which treats `basic` as a beginner-floor label. Worth a deck-level decision.

## Test plan

- [ ] All 21 modified YAML files parse cleanly (verified locally with `yaml.safe_load`).
- [ ] Spot-check rendering on a few SEBook chapters that include relabelled decks: [SEBook/tools/git.md](SEBook/tools/git.md), [SEBook/systems/data_management.md](SEBook/systems/data_management.md), [SEBook/designpatterns/singleton.md](SEBook/designpatterns/singleton.md), [SEBook/designpatterns/mediator.md](SEBook/designpatterns/mediator.md).
- [ ] Spot-check the SE Gym difficulty-filter UI to confirm chip rendering still picks up the new labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)