### PR TITLE
tdd: clearer cycle-3 hints for misplaced branches and wrong-shape assertions

### DIFF
--- a/.agents/skills/tutorial-authoring/SKILL.md
+++ b/.agents/skills/tutorial-authoring/SKILL.md
@@ -363,6 +363,17 @@ the answer. Conventions:
 - **Layer 3 — structural skeleton.** Show the *shape* of the solution with
   the interesting parts as `...` or named blanks. Never paste the literal
   solution.
+- **Title style — describe the *content*, not the layer.** "Orient",
+  "Strategy", "Skeleton", "Layer 1", "Layer 2", "Layer 3" (and parenthetical
+  variants like `Skeleton (you fill in the blanks)`) are author-side
+  *intent* labels and **must not appear in the visible `title:`**. Give each
+  hint a topical title that names the specific advice — `"Read the failing
+  line's expected vs actual"`, `"Value-equality on frozen dataclasses"`,
+  `"Fill the blank"` — so the student sees what the hint is *about*, not
+  which rung of the ladder it sits on. The escalation is communicated by
+  the order of hints in the list, not by their titles. If you find yourself
+  reaching for "Orient" / "Strategy" / "Skeleton" as a title, write down
+  what the hint actually says and use that instead.
 - Use `condition:` to make hints fire only when their trigger is true
   (e.g. `condition: "code_missing: range("` only fires when the student
   hasn't typed `range(`). Conditional hints feel like the tutorial is

--- a/_data/tutorials/python-debugging.yml
+++ b/_data/tutorials/python-debugging.yml
@@ -247,7 +247,7 @@ steps:
           - title: "Strategic hint"
             text: "Trace `greet([\"Ada\", \"Linus\", \"Grace\"])` by hand. What value of `i` does the first iteration use? What index *should* it use to include `\"Ada\"`?"
             condition: "code_contains: range(1, len"
-          - title: "Skeleton — fill the blank"
+          - title: "Fill the blank"
             text: "The `range(...)` call has a wrong start. Fix the shape: `range(___, len(names))` so the very first iteration sees index 0. Pick the integer that makes that true."
             condition: "code_contains: range(1, len"
 
@@ -880,7 +880,7 @@ steps:
             text: "Look at the order of the two checks at the top of `_dfs`. Which one runs first when `steps_used == max_steps` AND `current == goal`?"
           - title: "Strategic hint"
             text: "Trace by hand: when the recursion calls `_dfs(current=goal, ...)` after using all 10 steps, what is `steps_used`? Which check fires? Should reaching the goal be allowed even at the budget limit?"
-          - title: "Skeleton — name the order"
+          - title: "Name the order"
             text: "There are two early-exit checks at the top of `_dfs`: a *success* check (`current == goal`) and a *failure* check (`steps_used >= max_steps`). When both could fire on the same call, which one should win? Reorder so the winner runs first."
 
       - description: "Workaround guard — test file unchanged"
@@ -1364,7 +1364,7 @@ steps:
           - title: "Strategic hint"
             text: "Set a conditional breakpoint at the start of `apply_transaction` with `tx.account == \"ACCT-202\"`. When paused on T011, watch `repr(tx.kind)`. The `repr()` reveals what `print()` hides."
             condition: "code_missing: .strip()"
-          - title: "Skeleton — fill the boundary fix"
+          - title: "Fill the boundary fix"
             text: "In `load_transactions`, the line that builds `kind` is `kind=row[\"type\"].upper()`. Insert one method call between `row[\"type\"]` and `.upper()` that removes leading/trailing whitespace before normalization. Pick the method whose Python name means \"trim\"."
             condition: "code_missing: .strip()"
 
@@ -2058,7 +2058,7 @@ steps:
           - title: "Strategic hint"
             text: "Set a breakpoint on the `next_student = course.waitlist.pop()` line. When paused, watch `course.waitlist[0]` and `course.waitlist[-1]`. Step over. Which one became `next_student`? Which one *should* have, given FIFO policy?"
             condition: "code_contains: waitlist.pop()"
-          - title: "Skeleton — pick the index"
+          - title: "Pick the index"
             text: "`list.pop()` with no argument removes from the *end* (LIFO). FIFO needs an explicit positional argument that picks the *front* of the list. Add that argument to the `course.waitlist.pop()` call. (Or, idiomatically: `collections.deque` with `popleft()`.)"
             condition: "code_contains: waitlist.pop()"
 
@@ -2637,7 +2637,7 @@ steps:
           - title: "Strategic hint"
             text: "When you iterate `for line in f`, each `line` includes its trailing newline. After `line.split('|', 1)`, the trailing `\\n` ends up on `tag`. The fix belongs in the loader, *before* `tag.upper()`."
             condition: "code_missing: .strip()"
-          - title: "Skeleton — same pattern as Case 2"
+          - title: "Same pattern as Case 2"
             text: "The line `counts[tag.upper()] += 1` builds the dict key. `tag` ends with `\\n` here. Insert a method call between `tag` and `.upper()` that removes that newline (and any surrounding whitespace), like Case 2 did with the CSV row's `type` field."
             condition: "code_missing: .strip()"
 

--- a/_data/tutorials/tdd.yml
+++ b/_data/tutorials/tdd.yml
@@ -1230,14 +1230,14 @@ steps:
           assert code == 0, \
               f"All three tests should pass:\n{output}"
         hints:
-          - title: "Orient — read the failing line's *expected vs actual*"
+          - title: "Read the failing line's *expected vs actual*"
             text: |
               pytest's `assert` output shows both sides of the comparison.
               Before changing any code, write down — in your own words — what
               `report.events` *is* in the failing line and what the test
               *expected* it to be. The shape mismatch (one bare value vs. a
               tuple of `ScoringEvent`s) is usually the whole bug.
-          - title: "Strategy — `report.events` holds whole events, not raw dice"
+          - title: "`report.events` holds whole events, not raw dice"
             text: |
               Re-read the cycle-2 reveal. Each entry in `report.events` is a
               *whole* `ScoringEvent` value carrying all three pieces of
@@ -1248,7 +1248,7 @@ steps:
               can never match a correct implementation no matter what `score`
               does.
             condition: "code_contains: report.events == (1,"
-          - title: "Strategy — value-equality on frozen dataclasses"
+          - title: "Value-equality on frozen dataclasses"
             text: |
               `@dataclass(frozen=True)` gives `ScoringEvent` value-based
               equality — two `ScoringEvent` instances are `==` iff every
@@ -1257,7 +1257,7 @@ steps:
               `report.events == (ScoringEvent(<name>, <dice>, <damage>),)`.
               The three values come straight from the rules table at the
               top of the tutorial.
-          - title: "Skeleton — one-element tuple, trailing comma matters"
+          - title: "One-element tuple, trailing comma matters"
             text: |
               Shape of each cycle-2 / cycle-3 `events` assertion (fill the
               blanks from the rules table):
@@ -1310,7 +1310,7 @@ steps:
           assert (1,) in targets and (5,) in targets, \
               f"Cycle 3's smallest GREEN is two `if {param} == [...]:` branches *inside `score()` itself* — one for `[1]` and one for `[5]`. The checker walks `score`'s body for these comparisons, so branches placed elsewhere (e.g. on `BattleReport`) don't count. If you've already replaced the branches with a `for` / `dict` / `match`, that refactor belongs in cycle 4 — restore the two hardcoded `if` branches in `score` for now."
         hints:
-          - title: "Orient — which function does the checker walk?"
+          - title: "Which function does the checker walk?"
             text: |
               The checker imports `scorer.py` and walks the body of `score(dice)`
               itself, looking for two `if dice == [...]:` comparisons. Open
@@ -1318,7 +1318,7 @@ steps:
               logic actually lives there? If `score` immediately hands `dice`
               off to `BattleReport`, the checker sees zero branches in `score`
               even when the right `if` lines exist somewhere else in the file.
-          - title: "Strategy — separate the decider from the container"
+          - title: "Separate the decider from the container"
             text: |
               `BattleReport` is meant to be a passive value object — `events:
               tuple = ()` plus a derived `total_damage` that sums
@@ -1329,7 +1329,7 @@ steps:
               per-rule decisions back into `score(dice)`, and let each branch
               construct the right `BattleReport(events=...)` value.
             condition: "code_contains: self.dice"
-          - title: "Strategy — `for` / `dict` / `match` is cycle 4's job"
+          - title: "`for` / `dict` / `match` is cycle 4's job"
             text: |
               If you went straight to a `for die in dice:` loop (or a `dict`
               dispatch, or `match`/`case`), you've generalised on one too few
@@ -1339,7 +1339,7 @@ steps:
               smell to fix. Back the loop out and write the second `if`
               instead — the cycle-4 step is where it'll come back, justified.
             condition: "code_contains: for "
-          - title: "Skeleton — two top-level ifs, then a default return"
+          - title: "Two top-level ifs, then a default return"
             text: |
               Inside `score(dice)` (not on `BattleReport`), the body has the
               shape:

--- a/_data/tutorials/tdd.yml
+++ b/_data/tutorials/tdd.yml
@@ -1229,6 +1229,50 @@ steps:
           print(output)
           assert code == 0, \
               f"All three tests should pass:\n{output}"
+        hints:
+          - title: "Orient — read the failing line's *expected vs actual*"
+            text: |
+              pytest's `assert` output shows both sides of the comparison.
+              Before changing any code, write down — in your own words — what
+              `report.events` *is* in the failing line and what the test
+              *expected* it to be. The shape mismatch (one bare value vs. a
+              tuple of `ScoringEvent`s) is usually the whole bug.
+          - title: "Strategy — `report.events` holds whole events, not raw dice"
+            text: |
+              Re-read the cycle-2 reveal. Each entry in `report.events` is a
+              *whole* `ScoringEvent` value carrying all three pieces of
+              information the rules table lists (name, dice that fired, damage)
+              — not the raw integer that rolled. If your test asserts
+              something like `report.events == (1,)`, you've collapsed a
+              three-field value down to a single number, and that comparison
+              can never match a correct implementation no matter what `score`
+              does.
+            condition: "code_contains: report.events == (1,"
+          - title: "Strategy — value-equality on frozen dataclasses"
+            text: |
+              `@dataclass(frozen=True)` gives `ScoringEvent` value-based
+              equality — two `ScoringEvent` instances are `==` iff every
+              field matches. That's why each test asserts against a
+              *constructed* event of the same shape on both sides:
+              `report.events == (ScoringEvent(<name>, <dice>, <damage>),)`.
+              The three values come straight from the rules table at the
+              top of the tutorial.
+          - title: "Skeleton — one-element tuple, trailing comma matters"
+            text: |
+              Shape of each cycle-2 / cycle-3 `events` assertion (fill the
+              blanks from the rules table):
+
+              ```python
+              def test_single_one_creates_dragon_flame_event():
+                  report = score([1])
+                  assert report.total_damage == ...
+                  assert report.events == (ScoringEvent(..., ..., ...),)
+              ```
+
+              The trailing comma matters — without it, Python parses the
+              outer parentheses as grouping, not a one-element tuple. Don't
+              paste from the worked example before you've tried filling the
+              blanks yourself.
 
       - description: "Implementation still has the second hardcoded branch (no premature refactor to loop)"
         command: |
@@ -1264,7 +1308,55 @@ steps:
 
           targets = list_eq_targets(score_fn, param)
           assert (1,) in targets and (5,) in targets, \
-              f"Cycle 3's smallest GREEN is to add a second `if {param} == [5]:` branch. The loop refactor belongs in cycle 4 — once a test exists that *requires* it. Restore both hardcoded branches for now."
+              f"Cycle 3's smallest GREEN is two `if {param} == [...]:` branches *inside `score()` itself* — one for `[1]` and one for `[5]`. The checker walks `score`'s body for these comparisons, so branches placed elsewhere (e.g. on `BattleReport`) don't count. If you've already replaced the branches with a `for` / `dict` / `match`, that refactor belongs in cycle 4 — restore the two hardcoded `if` branches in `score` for now."
+        hints:
+          - title: "Orient — which function does the checker walk?"
+            text: |
+              The checker imports `scorer.py` and walks the body of `score(dice)`
+              itself, looking for two `if dice == [...]:` comparisons. Open
+              `scorer.py` and read just the body of `score` — what dispatch
+              logic actually lives there? If `score` immediately hands `dice`
+              off to `BattleReport`, the checker sees zero branches in `score`
+              even when the right `if` lines exist somewhere else in the file.
+          - title: "Strategy — separate the decider from the container"
+            text: |
+              `BattleReport` is meant to be a passive value object — `events:
+              tuple = ()` plus a derived `total_damage` that sums
+              `event.damage` for each event. Asking `BattleReport` "which
+              events does this dice list produce?" puts the dispatch in the
+              wrong class: the report ends up having to know every dragon-dice
+              rule, and re-derives everything on every read. Move the
+              per-rule decisions back into `score(dice)`, and let each branch
+              construct the right `BattleReport(events=...)` value.
+            condition: "code_contains: self.dice"
+          - title: "Strategy — `for` / `dict` / `match` is cycle 4's job"
+            text: |
+              If you went straight to a `for die in dice:` loop (or a `dict`
+              dispatch, or `match`/`case`), you've generalised on one too few
+              data points. Cycle 4's test (`[1, 1]`) is what *earns* the loop
+              by making it the cheapest GREEN; until then, the duplication
+              between two hardcoded `if` branches is the lesson, not a code
+              smell to fix. Back the loop out and write the second `if`
+              instead — the cycle-4 step is where it'll come back, justified.
+            condition: "code_contains: for "
+          - title: "Skeleton — two top-level ifs, then a default return"
+            text: |
+              Inside `score(dice)` (not on `BattleReport`), the body has the
+              shape:
+
+              ```python
+              def score(dice):
+                  if dice == ...:                      # the roll that fires Dragon Flame
+                      return BattleReport((ScoringEvent(...),))
+                  if dice == ...:                      # the roll that fires Lightning Spark
+                      return BattleReport((ScoringEvent(...),))
+                  return BattleReport()
+              ```
+
+              Each `...` is a value the rules table at the top of the
+              tutorial names. No `for`, no `dict`, no `match`. The
+              duplication between the two branches is the *point* of cycle 3
+              — cycle 4's test will earn the right to collapse it.
 
     # NO QUIZ — duplication is the lesson; cycle 4 will pay for it.
 

--- a/_data/tutorials/test-doubles.yml
+++ b/_data/tutorials/test-doubles.yml
@@ -295,7 +295,7 @@ steps:
             text: "The signature is `def is_today_event_day(event_date_str: str, clock=datetime.datetime) -> bool:`. Then inside the function, replace `datetime.now()` with `clock.now()`."
           - title: "Strategic hint"
             text: "Two changes: (1) add `clock=datetime.datetime` as a second parameter with the default value; (2) change the body to use `clock.now()` instead of `datetime.now()`. The default value is the `datetime` class — its classmethod `now()` returns the current datetime, which is what the original code did."
-          - title: "Skeleton (you fill in the blanks)"
+          - title: "Fill in the blanks"
             text: "```python\nimport datetime\n\ndef is_today_event_day(event_date_str: str, clock=___) -> bool:\n    today = clock.___().strftime('%Y-%m-%d')\n    return today == event_date_str\n```\nFill the two blanks. Hints: (1) the default for `clock` is the datetime *class* (it has a `.now()` classmethod) — *not* the module and not a function. (2) The body should use the parameter `clock`, not the imported module directly. Note the top-level `import datetime` (the module), so you can reference `datetime.datetime` as the default."
 
     quiz:
@@ -762,7 +762,7 @@ steps:
           - title: "Strategic hint"
             text: "April 30, 2026 is a Thursday. The canned API list has exactly one Thursday entry. The SUT returns that entry's `title` field."
             condition: "code_missing: Battle the Lich King"
-          - title: "Skeleton (you fill in the title)"
+          - title: "Fill in the title"
             text: "Pin the assertion with `==` and the *exact* title from the matching canned entry:\n```python\nassert service.daily_quest_title(\"u456\") == \"___\"\n```\nThe matching canned entry is the one whose `weekday` field equals what `FrozenClock(datetime(2026, 4, 30, 12, 0))` returns. Use a calendar to confirm the weekday; copy the `title` field exactly (including capitalisation)."
             condition: "code_missing: Battle the Lich King"
 
@@ -1272,7 +1272,7 @@ steps:
           - title: "Small nudge — streak bonus"
             text: "The spec: 10 gold per day, capped at 100. For 5 days, that's 5 * 10 = 50 (under the cap). Pin `assert spy.calls == [(\"u2\", 50)]`."
             condition: "code_missing: 50"
-          - title: "Skeleton (fill the blanks; do not paste the answer)"
+          - title: "Fill the blanks (do not paste the answer)"
             text: |
               Liar comment template (write *your own* explanation — naming **why** `len(...) >= 0` is structurally trivial):
               ```python
@@ -1737,7 +1737,7 @@ steps:
           - title: "Strategic hint"
             text: "The SUT does `try: quests = self._api.fetch_quests(user_id) except ConnectionError: return 'No quests today'`. So `side_effect = ConnectionError` will trigger the catch branch."
             condition: "code_contains: side_effect = ValueError"
-          - title: "Skeleton (you fill in the exception class)"
+          - title: "Fill in the exception class"
             text: |
               Find the `try:` / `except ___:` block in `daily_quest_title` (in `quest_service.py`). Whatever class follows `except` is the same class that should follow `side_effect =`. Replace:
               ```python
@@ -2191,7 +2191,7 @@ steps:
           - title: "Strategic hint"
             text: "Patch the namespace where the SUT will *resolve* the name at runtime. The SUT is `quest_service.celebrate_milestone`; the name `send_push` was imported INTO `quest_service`'s namespace. So the target string is `\"quest_service.send_push\"`."
             condition: "code_contains: patch(\"push_notifier.send_push\")"
-          - title: "Skeleton (you fill in the namespace)"
+          - title: "Fill in the namespace"
             text: |
               The patch target string has the form `\"<module>.<name>\"`. The `<name>` is `send_push`. The `<module>` is the *importing* module (the one whose namespace the SUT looks up the name in), not the *defining* module:
               ```python
@@ -2729,7 +2729,7 @@ steps:
           - title: "Small nudge — scenarios"
             text: "Use the decision rubric in the instructions. Pure function = no double. Clock = stub. Fire-and-forget call = mock/spy. Stateful round-trip = fake. Third-party = adapter."
             condition: "code_missing: adapter"
-          - title: "Skeleton — the rubric, with no answers attached"
+          - title: "The rubric, with no answers attached"
             text: |
               You'll classify five scenarios into one of these categories. Match each scenario by what the *test* needs from the collaborator:
 


### PR DESCRIPTION
Two student failure modes were poorly served by the cycle-3 gates:

  1. Putting `if dice == [1]:` / `if dice == [5]:` branches inside
     BattleReport (as a property reading self.dice) instead of inside
     score(). The "second hardcoded branch" check walks score()'s body
     specifically, so it failed silently and the error message wrongly
     implied a premature loop refactor.

  2. Asserting `report.events == (1,)` against bare integers instead of
     ScoringEvent instances — the cycle-2 reveal explains the shape but
     it's easy to miss.

Improved the failure message on the "second hardcoded branch" check to
name the placement requirement and to differentiate "wrong place" from
"already refactored to a loop". Added three-layer hint ladders (orient
-> strategy -> skeleton) to both that test and "All three tests pass",
with `condition:` triggers on `self.dice`, `for `, and
`report.events == (1,` so the right hint surfaces only when its
misconception is actually in the student's code. Skeleton hints use
`...` placeholders for the rules-table values rather than pasting the
literal solution, per the project's hint best-practices.

https://claude.ai/code/session_016JMP7HZbYh9Rd74UTprgM7