### PR TITLE
Add opt-in "more confetti" mode for per-correct celebration

### DIFF
--- a/_includes/flashcards.html
+++ b/_includes/flashcards.html
@@ -620,6 +620,7 @@ Data source: _data/flashcards/{{ include.id }}.yml
     function handleAssessment(correct, card) {
       if (correct) {
         score++;
+        if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(card);
       } else {
         incorrectIndices.push(isReviewMode ? reviewQueue[reviewStep] : currentStep);
       }

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,9 +7,11 @@
     (function () {
       var nameEQ = "show-highlights=";
       var darkEQ = "dark-mode=";
+      var confettiEQ = "more-confetti=";
       var ca = document.cookie.split(';');
       var show = true;
       var dark = false;
+      var moreConfetti = false;
       for (var i = 0; i < ca.length; i++) {
         var c = ca[i];
         while (c.charAt(0) == ' ') c = c.substring(1, c.length);
@@ -19,12 +21,18 @@
         if (c.indexOf(darkEQ) == 0) {
           dark = c.substring(darkEQ.length, c.length) === 'true';
         }
+        if (c.indexOf(confettiEQ) == 0) {
+          moreConfetti = c.substring(confettiEQ.length, c.length) === 'true';
+        }
       }
       if (!show) {
         document.documentElement.classList.add('highlights-disabled');
       }
       if (dark) {
         document.documentElement.classList.add('dark-mode');
+      }
+      if (moreConfetti) {
+        document.documentElement.classList.add('more-confetti-enabled');
       }
       try {
         if (localStorage.getItem('abbr-underlines') === 'false') {

--- a/_includes/quiz.html
+++ b/_includes/quiz.html
@@ -964,6 +964,7 @@ Data source: _data/quizzes/{{ include.id }}.yml
       if (isCorrect) {
         option.classList.add('correct');
         score++;
+        if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(option);
       } else {
         option.classList.add('incorrect');
         // Mark the wrongly-chosen option as invalid (3.3.1 Error
@@ -1014,6 +1015,7 @@ Data source: _data/quizzes/{{ include.id }}.yml
       if (isAnswerCorrect) {
         selectedOptions.forEach(opt => opt.classList.add('correct'));
         score++;
+        if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(card);
       } else {
         options.forEach(opt => {
           const isSelected = opt.classList.contains('selected');
@@ -1337,8 +1339,12 @@ Data source: _data/quizzes/{{ include.id }}.yml
         btn.disabled = true;
         card.querySelector('.parsons-reset-btn').disabled = true;
 
-        if (isCorrect) score++;
-        else incorrectIndices.push(isReviewMode ? reviewQueue[reviewStep] : currentStep);
+        if (isCorrect) {
+          score++;
+          if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(card);
+        } else {
+          incorrectIndices.push(isReviewMode ? reviewQueue[reviewStep] : currentStep);
+        }
 
         // Track performance
         if (window.PersonalGym && PersonalGym.isAnalyzePerformance()) {

--- a/cookies.html
+++ b/cookies.html
@@ -327,6 +327,12 @@ info_nav_title: "Browser storage"
         <td class="status-cell"></td>
         <td class="action-cell"></td>
       </tr>
+      <tr data-storage="cookie" data-key="more-confetti">
+        <td class="storage-key">more-confetti</td>
+        <td>Whether "more confetti" mode is on (<code>true</code>/<code>false</code>). When <code>true</code>, confetti also fires after each correctly answered quiz question and each flashcard marked "I got it right", not only at the end of a workout.</td>
+        <td class="status-cell"></td>
+        <td class="action-cell"></td>
+      </tr>
     </tbody>
   </table>
   <button class="cookies-btn danger" data-clear-category="ui-cookies" type="button">

--- a/js/confetti.js
+++ b/js/confetti.js
@@ -105,4 +105,14 @@
     document.body.appendChild(host);
     setTimeout(function () { if (host.parentNode) host.parentNode.removeChild(host); }, 1700);
   };
+
+  window.isMoreConfettiEnabled = function () {
+    return /(?:^|; )more-confetti=true(?:;|$)/.test(document.cookie || '');
+  };
+
+  window.spawnConfettiIfMore = function (anchor) {
+    if (!anchor) return;
+    if (!window.isMoreConfettiEnabled()) return;
+    window.spawnConfetti(anchor);
+  };
 }());

--- a/js/tutorial-quiz.js
+++ b/js/tutorial-quiz.js
@@ -396,7 +396,7 @@
       var ca = card.querySelector('.quiz-correct-answers');
       var ok = opt.dataset.correct === opt.dataset.index;
       optionsEls.forEach(function (o) { o.setAttribute('disabled', 'true'); });
-      if (ok) { opt.classList.add('correct'); score++; }
+      if (ok) { opt.classList.add('correct'); score++; if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(opt); }
       else {
         opt.classList.add('incorrect');
         var correct = null;
@@ -444,6 +444,7 @@
       if (isAcceptedMultiple(selI, corI, optI)) {
         sel.forEach(function (o) { o.classList.add('correct'); });
         score++;
+        if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(card);
       } else {
         optionsEls.forEach(function (o) {
           var isSel = o.classList.contains('selected');
@@ -668,7 +669,10 @@
         btn.disabled = true;
         var resetBtn = card.querySelector('.parsons-reset-btn');
         if (resetBtn) resetBtn.disabled = true;
-        if (isCorrect) score++;
+        if (isCorrect) {
+          score++;
+          if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(card);
+        }
         var ca = card.querySelector('.quiz-correct-answers');
         var exp = card.querySelector('.quiz-explanation');
         if (ca) ca.style.display = 'flex';

--- a/se-gym.html
+++ b/se-gym.html
@@ -109,6 +109,18 @@ layout: sebook
               <span class="slider round"></span>
             </label>
           </div>
+          <div class="controls-row toggle-row" style="justify-content: space-between; margin-top: 10px;">
+            <span class="toggle-copy">
+              <span class="toggle-label">More confetti</span>
+              <button type="button" class="info-btn" aria-expanded="false" aria-label="Info about more confetti" aria-describedby="more-confetti-tooltip">?</button>
+              <span id="more-confetti-tooltip" role="tooltip" class="info-tooltip">When on, a small burst of confetti fires after each correctly answered quiz question and each flashcard you mark as "I got it right" — not only at the end of the workout. Respects your reduced-motion preference. Off by default.</span>
+            </span>
+            <label class="switch">
+              <span class="sr-only">Toggle more confetti</span>
+              <input type="checkbox" id="moreConfettiToggle" aria-label="More confetti">
+              <span class="slider round"></span>
+            </label>
+          </div>
           <fieldset id="difficulty-filter-fieldset" class="difficulty-filter">
             <legend>Include difficulty levels</legend>
             <p class="difficulty-filter-help">Only cards whose difficulty matches a checked level are included in the next workout. Uncheck a level to drop it. Cards without an assigned difficulty are always included regardless of these settings.</p>
@@ -2418,6 +2430,7 @@ layout: sebook
       var timedPracticeExtendBtn = document.getElementById('timed-practice-extend-btn');
       var timedPracticeStatus = document.getElementById('timed-practice-status');
       var showDifficultyToggle = document.getElementById('showDifficultyToggle');
+      var moreConfettiToggle = document.getElementById('moreConfettiToggle');
       var difficultyFilterCheckboxes = document.querySelectorAll('.difficulty-filter-checkbox');
 
       // Workout state
@@ -2959,6 +2972,16 @@ layout: sebook
         showDifficultyToggle.checked = PersonalGym.isShowDifficulty();
         showDifficultyToggle.addEventListener('change', function () {
           PersonalGym.setShowDifficulty(showDifficultyToggle.checked);
+        });
+      }
+
+      // ---- More-confetti toggle (mirror of /settings/) ----
+      if (moreConfettiToggle) {
+        moreConfettiToggle.checked = /(?:^|; )more-confetti=true(?:;|$)/.test(document.cookie || '');
+        moreConfettiToggle.addEventListener('change', function () {
+          var on = moreConfettiToggle.checked;
+          document.cookie = 'more-confetti=' + (on ? 'true' : 'false') + '; max-age=31536000; path=/; SameSite=Lax';
+          document.documentElement.classList.toggle('more-confetti-enabled', on);
         });
       }
 
@@ -3545,6 +3568,7 @@ layout: sebook
               if (isCorrect) {
                 opt.classList.add('correct');
                 workoutScore++;
+                if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(opt);
               } else {
                 opt.classList.add('incorrect');
                 options.forEach(function (o) {
@@ -3590,6 +3614,7 @@ layout: sebook
             if (isMultiCorrect) {
               selectedOpts.forEach(function (o) { o.classList.add('correct'); });
               workoutScore++;
+              if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(div);
             } else {
               options.forEach(function (o) {
                 var idx = parseInt(o.dataset.index, 10);
@@ -3787,8 +3812,12 @@ layout: sebook
           div.querySelector('.parsons-check-btn').disabled = true;
           div.querySelector('.parsons-reset-btn').disabled = true;
 
-          if (isCorrect) workoutScore++;
-          else workoutIncorrectIndices.push(workoutIsReview ? workoutReviewQueue[workoutReviewStep] : workoutCurrentStep);
+          if (isCorrect) {
+            workoutScore++;
+            if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(div);
+          } else {
+            workoutIncorrectIndices.push(workoutIsReview ? workoutReviewQueue[workoutReviewStep] : workoutCurrentStep);
+          }
 
           recordDifficultyResult(card, isCorrect);
           PersonalGym.recordResult(card.deckId + ':' + (q.id || PersonalGym.hashQuestion(q.question)), isCorrect);
@@ -3909,6 +3938,7 @@ layout: sebook
 
         correctBtn.addEventListener('click', function () {
           workoutScore++;
+          if (typeof window.spawnConfettiIfMore === 'function') window.spawnConfettiIfMore(correctBtn);
           recordDifficultyResult(card, true);
           PersonalGym.recordResult(card.deckId + ':' + (c.id || PersonalGym.hashQuestion(c.question)), true);
           nextWorkoutCard();

--- a/settings.html
+++ b/settings.html
@@ -375,6 +375,30 @@ info_nav_title: "My Settings"
             </div>
           </div>
         </div>
+
+        <div class="setting-row">
+          <div>
+            <p class="setting-name">More confetti</p>
+            <p class="setting-description">
+              By default, confetti only celebrates a finished quiz or
+              flashcard workout. Turn this on to also get a small burst of
+              confetti after <em>each</em> correctly answered quiz question
+              and after each flashcard you mark as "I got it right" — in
+              SEBook, tutorials, and the personal gym. Off by default.
+              Respects your reduced-motion preference.
+            </p>
+          </div>
+          <div class="setting-control">
+            <div class="setting-toggle-row">
+              <label class="switch">
+                <span class="sr-only">More confetti</span>
+                <input type="checkbox" id="setting-more-confetti" data-setting="moreConfetti" data-status-target="setting-more-confetti-status" aria-label="More confetti">
+                <span class="slider round"></span>
+              </label>
+              <span class="setting-toggle-status" id="setting-more-confetti-status" aria-hidden="true"></span>
+            </div>
+          </div>
+        </div>
       </div>
     </fieldset>
 
@@ -984,6 +1008,10 @@ info_nav_title: "My Settings"
     setCheckbox('setting-abbr-underlines', abbrUnderlines);
     applyAbbrUnderlineMode(abbrUnderlines);
 
+    var moreConfetti = readCookie('more-confetti') === 'true';
+    setCheckbox('setting-more-confetti', moreConfetti);
+    document.documentElement.classList.toggle('more-confetti-enabled', moreConfetti);
+
     var volume = document.getElementById('setting-audio-volume');
     if (volume) {
       var savedVolume = parseFloat(readLS('cap_volume'));
@@ -1075,6 +1103,10 @@ info_nav_title: "My Settings"
       else writeLS('abbr-underlines', 'false');
       applyAbbrUnderlineMode(target.checked);
       announce('Abbreviation underline setting saved.');
+    } else if (setting === 'moreConfetti') {
+      writeCookie('more-confetti', target.checked ? 'true' : 'false');
+      document.documentElement.classList.toggle('more-confetti-enabled', target.checked);
+      announce(target.checked ? 'More confetti turned on.' : 'More confetti turned off.');
     } else if (setting === 'ttsVoice') {
       if (target.value) writeLS('tts-voice-name', target.value);
       else clearLS('tts-voice-name');


### PR DESCRIPTION
By default, confetti only fires once a quiz or flashcard workout is fully done. This adds an opt-in toggle that *also* fires a small burst after every individual correct quiz answer and every "I got it right" flashcard click across SEBook, tutorials, and SE Gym workouts.

The mode is gated by a new `more-confetti` cookie (default off), exposed as a toggle in two places that read/write the same cookie: the canonical row in /settings/ ("How the site looks and moves") and a convenience mirror in the SE Gym controls panel. The new key is documented in the /cookies/ inventory. The existing `prefers-reduced-motion` short-circuit inside `spawnConfetti` still wins, so reduced-motion users see no extra confetti even with the mode on.