### PR TITLE
Add Makefile syntax highlighting to Monaco tutorial editor

### DIFF
--- a/js/monaco-sebook-langs.js
+++ b/js/monaco-sebook-langs.js
@@ -153,6 +153,121 @@
       },
     });
 
+    // ---- Makefile Monarch tokenizer ----
+    // Monaco's CDN ships a basic-languages Makefile pack, but it lazy-loads
+    // and colors entire recipe lines as 'string'. Registering our own
+    // tokenizer here guarantees the language is ready before any model uses
+    // it and gives us token names that map cleanly to the sebook themes.
+    monaco.languages.register({ id: 'makefile' });
+    monaco.languages.setLanguageConfiguration('makefile', {
+      comments: { lineComment: '#' },
+      brackets: [['(', ')'], ['{', '}']],
+      autoClosingPairs: [
+        { open: '(', close: ')' }, { open: '{', close: '}' },
+        { open: '"', close: '"' }, { open: "'", close: "'" },
+      ],
+      surroundingPairs: [
+        { open: '(', close: ')' }, { open: '{', close: '}' },
+        { open: '"', close: '"' }, { open: "'", close: "'" },
+      ],
+    });
+    monaco.languages.setMonarchTokensProvider('makefile', {
+      defaultToken: '',
+      directives: [
+        'include', 'sinclude', '-include',
+        'ifeq', 'ifneq', 'ifdef', 'ifndef',
+        'else', 'endif',
+        'define', 'endef',
+        'override', 'export', 'unexport',
+        'vpath', 'undefine', 'private',
+      ],
+      builtinFunctions: [
+        'subst', 'patsubst', 'strip', 'findstring', 'filter', 'filter-out',
+        'sort', 'word', 'words', 'wordlist', 'firstword', 'lastword',
+        'dir', 'notdir', 'suffix', 'basename', 'addsuffix', 'addprefix',
+        'join', 'wildcard', 'realpath', 'abspath',
+        'if', 'or', 'and', 'foreach', 'call', 'value', 'eval',
+        'origin', 'flavor', 'shell', 'error', 'warning', 'info',
+        'guile', 'file',
+      ],
+      tokenizer: {
+        root: [
+          // Recipe lines start with a real Tab — the Tab Trap is part of
+          // what the makefile tutorial teaches, so we colour the rest of
+          // the line via a dedicated state.
+          [/^\t/, { token: 'white', next: '@recipe' }],
+          [/#.*$/, 'comment'],
+          // Special targets (.PHONY, .SUFFIXES, …)
+          [/^(\.[A-Z_]+)(\s*)(:)/, ['tag', '', 'delimiter']],
+          // Directives (ifeq, include, define, …)
+          [/^\s*(ifeq|ifneq|ifdef|ifndef|else|endif|define|endef|override|export|unexport|include|-include|sinclude|vpath|undefine|private)\b/, 'keyword'],
+          // Variable assignment: NAME = … (and := ?= += !=)
+          [/^([A-Za-z_][\w.-]*)(\s*)([:+?!]?=)/, ['variable', '', 'operator']],
+          // Target: NAME : … (excluding := which is an assignment op)
+          [/^([\w%.\-\/]+)(\s*)(:)(?!=)/, ['type', '', 'delimiter']],
+          { include: '@common' },
+        ],
+
+        recipe: [
+          [/$/, { token: '', next: '@pop' }],
+          // Recipe modifiers: @ (silent), - (ignore errors), + (always run)
+          [/^[@\-+]+/, 'operator'],
+          [/#.*$/, 'comment'],
+          { include: '@common' },
+          [/\\./, 'string.escape'],
+          [/[^#"'$\\\n]+/, ''],
+        ],
+
+        common: [
+          // Automatic variables: $@ $< $^ $? $* $+ $| $%
+          [/\$[@<^?*+|%]/, 'variable.predefined'],
+          // $(@D), $(<F), … — directory/file modifiers on automatic vars
+          [/\$\([@<^?*+|%][DF]\)/, 'variable.predefined'],
+          // Escaped $$
+          [/\$\$/, 'string.escape'],
+          // $(VAR …) — function call or variable reference
+          [/\$\(/, { token: 'variable', next: '@varParen' }],
+          [/\$\{/, { token: 'variable', next: '@varBrace' }],
+          // $X — single-character variable reference
+          [/\$[A-Za-z_]/, 'variable'],
+          [/"/, { token: 'string', next: '@dstring' }],
+          [/'/, { token: 'string', next: '@sstring' }],
+        ],
+
+        varParen: [
+          [/\)/, { token: 'variable', next: '@pop' }],
+          [/[A-Za-z][\w.-]*/, {
+            cases: {
+              '@builtinFunctions': 'support.function',
+              '@default': 'variable',
+            },
+          }],
+          { include: '@common' },
+          [/\(/, { token: 'variable', next: '@varParen' }],
+          [/[^)$"'(]+/, ''],
+        ],
+
+        varBrace: [
+          [/\}/, { token: 'variable', next: '@pop' }],
+          [/[A-Za-z][\w.-]*/, 'variable'],
+          { include: '@common' },
+          [/[^}$"']+/, ''],
+        ],
+
+        dstring: [
+          [/"/, { token: 'string', next: '@pop' }],
+          [/\\./, 'string.escape'],
+          [/\$\(/, { token: 'variable', next: '@varParen' }],
+          [/[^"\\$]+/, 'string'],
+        ],
+
+        sstring: [
+          [/'/, { token: 'string', next: '@pop' }],
+          [/[^']+/, 'string'],
+        ],
+      },
+    });
+
     // ---- Python tokenizer (with f-string interpolation support) ----
     monaco.languages.setMonarchTokensProvider('python', {
       defaultToken: '',
@@ -399,6 +514,8 @@
         { token: 'delimiter.tag.jsx', foreground: '800000' },
         { token: 'attribute.name.jsx', foreground: 'e50000' },
         { token: 'attribute.value.jsx', foreground: '0451a5' },
+        { token: 'variable.predefined', foreground: '0070c1', fontStyle: 'bold' },
+        { token: 'support.function', foreground: '795e26' },
       ],
       colors: {},
     });
@@ -432,6 +549,8 @@
         { token: 'delimiter.tag.jsx', foreground: 'b5b5b5' },
         { token: 'attribute.name.jsx', foreground: 'd4eaff' },
         { token: 'attribute.value.jsx', foreground: 'ffb88c' },
+        { token: 'variable.predefined', foreground: 'c8b0ff', fontStyle: 'bold' },
+        { token: 'support.function', foreground: 'fff0a0' },
       ],
       colors: {
         'editor.background': '#050608',

--- a/js/tutorial-code.js
+++ b/js/tutorial-code.js
@@ -2072,6 +2072,98 @@
       },
     });
 
+    // ---- Makefile Monarch tokenizer ----
+    monaco.languages.register({ id: 'makefile' });
+    monaco.languages.setLanguageConfiguration('makefile', {
+      comments: { lineComment: '#' },
+      brackets: [['(', ')'], ['{', '}']],
+      autoClosingPairs: [
+        { open: '(', close: ')' }, { open: '{', close: '}' },
+        { open: '"', close: '"' }, { open: "'", close: "'" },
+      ],
+      surroundingPairs: [
+        { open: '(', close: ')' }, { open: '{', close: '}' },
+        { open: '"', close: '"' }, { open: "'", close: "'" },
+      ],
+    });
+    monaco.languages.setMonarchTokensProvider('makefile', {
+      defaultToken: '',
+      directives: [
+        'include', 'sinclude', '-include',
+        'ifeq', 'ifneq', 'ifdef', 'ifndef',
+        'else', 'endif',
+        'define', 'endef',
+        'override', 'export', 'unexport',
+        'vpath', 'undefine', 'private',
+      ],
+      builtinFunctions: [
+        'subst', 'patsubst', 'strip', 'findstring', 'filter', 'filter-out',
+        'sort', 'word', 'words', 'wordlist', 'firstword', 'lastword',
+        'dir', 'notdir', 'suffix', 'basename', 'addsuffix', 'addprefix',
+        'join', 'wildcard', 'realpath', 'abspath',
+        'if', 'or', 'and', 'foreach', 'call', 'value', 'eval',
+        'origin', 'flavor', 'shell', 'error', 'warning', 'info',
+        'guile', 'file',
+      ],
+      tokenizer: {
+        root: [
+          [/^\t/, { token: 'white', next: '@recipe' }],
+          [/#.*$/, 'comment'],
+          [/^(\.[A-Z_]+)(\s*)(:)/, ['tag', '', 'delimiter']],
+          [/^\s*(ifeq|ifneq|ifdef|ifndef|else|endif|define|endef|override|export|unexport|include|-include|sinclude|vpath|undefine|private)\b/, 'keyword'],
+          [/^([A-Za-z_][\w.-]*)(\s*)([:+?!]?=)/, ['variable', '', 'operator']],
+          [/^([\w%.\-\/]+)(\s*)(:)(?!=)/, ['type', '', 'delimiter']],
+          { include: '@common' },
+        ],
+        recipe: [
+          [/$/, { token: '', next: '@pop' }],
+          [/^[@\-+]+/, 'operator'],
+          [/#.*$/, 'comment'],
+          { include: '@common' },
+          [/\\./, 'string.escape'],
+          [/[^#"'$\\\n]+/, ''],
+        ],
+        common: [
+          [/\$[@<^?*+|%]/, 'variable.predefined'],
+          [/\$\([@<^?*+|%][DF]\)/, 'variable.predefined'],
+          [/\$\$/, 'string.escape'],
+          [/\$\(/, { token: 'variable', next: '@varParen' }],
+          [/\$\{/, { token: 'variable', next: '@varBrace' }],
+          [/\$[A-Za-z_]/, 'variable'],
+          [/"/, { token: 'string', next: '@dstring' }],
+          [/'/, { token: 'string', next: '@sstring' }],
+        ],
+        varParen: [
+          [/\)/, { token: 'variable', next: '@pop' }],
+          [/[A-Za-z][\w.-]*/, {
+            cases: {
+              '@builtinFunctions': 'support.function',
+              '@default': 'variable',
+            },
+          }],
+          { include: '@common' },
+          [/\(/, { token: 'variable', next: '@varParen' }],
+          [/[^)$"'(]+/, ''],
+        ],
+        varBrace: [
+          [/\}/, { token: 'variable', next: '@pop' }],
+          [/[A-Za-z][\w.-]*/, 'variable'],
+          { include: '@common' },
+          [/[^}$"']+/, ''],
+        ],
+        dstring: [
+          [/"/, { token: 'string', next: '@pop' }],
+          [/\\./, 'string.escape'],
+          [/\$\(/, { token: 'variable', next: '@varParen' }],
+          [/[^"\\$]+/, 'string'],
+        ],
+        sstring: [
+          [/'/, { token: 'string', next: '@pop' }],
+          [/[^']+/, 'string'],
+        ],
+      },
+    });
+
     // ---- Python Monarch tokenizer with f-string interpolation support ----
     monaco.languages.setMonarchTokensProvider('python', {
       defaultToken: '',
@@ -2361,6 +2453,9 @@
         { token: 'delimiter.tag.jsx', foreground: '800000' },
         { token: 'attribute.name.jsx', foreground: 'e50000' },
         { token: 'attribute.value.jsx', foreground: '0451a5' },
+        // Makefile automatic vars ($@ $< $^) and built-in functions ($(shell), $(wildcard)).
+        { token: 'variable.predefined', foreground: '0070c1', fontStyle: 'bold' },
+        { token: 'support.function', foreground: '795e26' },
       ],
       colors: {},
     });
@@ -2401,6 +2496,9 @@
         { token: 'delimiter.tag.jsx',           foreground: 'b5b5b5' },
         { token: 'attribute.name.jsx',          foreground: 'd4eaff' },
         { token: 'attribute.value.jsx',         foreground: 'ffb88c' },
+        // Makefile automatic vars ($@ $< $^) and built-in functions ($(shell), $(wildcard)).
+        { token: 'variable.predefined',         foreground: 'c8b0ff', fontStyle: 'bold' },
+        { token: 'support.function',            foreground: 'fff0a0' },
       ],
       colors: {
         // Near-true-black background. Pushed all the way down to #050608 so


### PR DESCRIPTION
## Summary
- Register a custom `makefile` Monarch tokenizer in both the shared `monaco-sebook-langs.js` (loaded by main tutorial pages and popout windows) and the inline fallback in `tutorial-code.js`. Monaco's CDN basic-language pack lazy-loads and coloured entire recipe lines as a single `string` token; this guarantees the language is ready before any model uses it and exposes the structure the Makefile tutorial actually teaches.
- Recognise: comments, variable assignments (`=`/`:=`/`?=`/`+=`/`!=`), targets, special targets (`.PHONY`, `.SUFFIXES`, …), directives (`ifeq`/`include`/`define`/…), variable references (`$(VAR)`/`${VAR}`/`$X`), automatic variables (`$@`/`$<`/`$^`/`$?`/`$*`/`$+`/`$|`/`$%`/`$(@D)`), built-in functions (`$(wildcard …)`/`$(shell …)`/…), Tab-prefixed recipe lines, and quoted strings.
- Add matching theme rules for `variable.predefined` (bold blue light / bold lavender dark) and `support.function` (brown light / yellow dark) so automatic variables and built-in functions read as distinct from ordinary variable references.

## Why
The Makefile tutorial currently displays Makefile content as plain unstyled text, hiding the structural distinctions students need to see — targets vs. recipes, variable refs vs. automatic vars, function calls vs. ordinary tokens. The Tab Trap, pattern rules, `.PHONY`, and `$(wildcard …)` are central concepts in the tutorial, and the editor's lack of highlighting works against them.

## Test plan
- [x] `monaco.editor.tokenize` returns correct token classes for every Makefile feature listed above.
- [x] Light-mode visual sampling on `/SEBook/tools/makefile-tutorial/` confirms comments green, variables dark-blue, `wildcard` brown, `$^`/`$@` bold bright-blue, targets teal.
- [x] Dark-mode visual sampling confirms comments light-green, variables white, `wildcard` yellow, `$^`/`$@` bold lavender, targets cyan.
- [x] Both light and dark token colours have WCAG AA contrast against their respective editor backgrounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
