### PR TITLE
Sync guest clock with host to prevent make timestamp drift

### DIFF
--- a/js/tutorial-code.js
+++ b/js/tutorial-code.js
@@ -716,6 +716,10 @@
       this._restartFileWatchOnResume = true;
       this._stopFileWatch();
     }
+    if (this._guestClockTimer) {
+      this._restartGuestClockSyncOnResume = true;
+      this._stopGuestClockSync();
+    }
   };
 
   TutorialCode.prototype._resumeBackgroundSync = function () {
@@ -727,6 +731,10 @@
       this._restartFileWatchOnResume = false;
       this._startFileWatch(2000);
     }
+    if (this._restartGuestClockSyncOnResume && this.config.backend === 'v86' && this.booted) {
+      this._restartGuestClockSyncOnResume = false;
+      this._startGuestClockSync(2000);
+    }
     if (refreshGraph && this.gitGraphPath && this.booted) {
       this._refreshGitGraph();
     }
@@ -734,6 +742,7 @@
 
   TutorialCode.prototype.destroy = function () {
     this._stopFileWatch();
+    this._stopGuestClockSync();
     clearTimeout(this._terminalReadinessTimer);
     if (this.emulator) { this.emulator.stop(); this.emulator = null; }
     if (this._worker) { this._worker.terminate(); this._worker = null; }
@@ -8182,6 +8191,12 @@
         if (self.makeDagPath && self._isMakeDagFile(filename)) {
           if (self._currentView === 'make_dag') self._maybeAutoRefreshMakeDag();
         }
+        // create_file stamped the inode with the host's Date.now(); pin the
+        // guest's wall clock to the same second so make doesn't see the file
+        // as in the future when v86's emulated clock has drifted behind.
+        // Await it so a make/gcc run that follows the save in the same tick
+        // can't race ahead of the resync.
+        return self._resyncGuestClock();
       }).catch(function (err) {
         var dirname = filename.indexOf('/') !== -1
           ? filename.substring(0, filename.lastIndexOf('/'))
@@ -9070,7 +9085,10 @@
       self._refreshStepVisibleFiles(step, { includeStepFiles: false });
     }
 
-    if (this.config.backend === 'v86' && !this._isBackgroundSyncPaused()) this._startFileWatch(2000);
+    if (this.config.backend === 'v86' && !this._isBackgroundSyncPaused()) {
+      this._startFileWatch(2000);
+      this._startGuestClockSync(2000);
+    }
 
     // step_dir: cd to the configured directory if not already there.
     // Runs visibly in the terminal so the user sees their prompt land in the
@@ -10598,6 +10616,48 @@
 
   TutorialCode.prototype._stopFileWatch = function () {
     if (this._reverseSyncTimer) { clearInterval(this._reverseSyncTimer); this._reverseSyncTimer = null; }
+  };
+
+  // File mtimes set via emulator.create_file() and 9p attribute updates use
+  // the host's Date.now() (see libv86.js CreateInode), but make / gcc inside
+  // the guest read the emulated CMOS clock — which drifts behind real time
+  // whenever v86 misses real-time deadlines (idle VM, throttled tab, busy
+  // setup like the gcc "sleep 2" wrapper). When the drift exceeds a second,
+  // make warns "Makefile modification time N.Ns in the future" and may
+  // rebuild targets in a loop. Re-pinning the guest wall clock to the host's
+  // current second keeps both domains aligned so every build target has a
+  // consistent timestamp.
+  TutorialCode.prototype._resyncGuestClock = function () {
+    if (this.config.backend !== 'v86' || !this.emulator || !this.booted) {
+      return Promise.resolve();
+    }
+    if (this._guestClockSyncing) return this._guestClockSyncing;
+    var self = this;
+    var hostEpoch = Math.floor(Date.now() / 1000);
+    var cmd = 'date -u -s @' + hostEpoch + ' >/dev/null 2>&1 || ' +
+              'date -s @' + hostEpoch + ' >/dev/null 2>&1 || true';
+    this._guestClockSyncing = this._probeRPCDaemon().then(function (avail) {
+      if (!avail) return null;
+      return self._runRPC(cmd, { timeout: 3000 }).catch(function () { return null; });
+    }).catch(function () { return null; }).then(function (r) {
+      self._guestClockSyncing = null;
+      return r;
+    });
+    return this._guestClockSyncing;
+  };
+
+  TutorialCode.prototype._startGuestClockSync = function (intervalMs) {
+    if (this.config.backend !== 'v86') return;
+    this._stopGuestClockSync();
+    var self = this;
+    if (this.booted && !this._isBackgroundSyncPaused()) this._resyncGuestClock();
+    this._guestClockTimer = setInterval(function () {
+      if (self.booted && !self._isBackgroundSyncPaused()) self._resyncGuestClock();
+    }, intervalMs || 2000);
+  };
+
+  TutorialCode.prototype._stopGuestClockSync = function () {
+    if (this._guestClockTimer) { clearInterval(this._guestClockTimer); this._guestClockTimer = null; }
   };
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds guest clock synchronization for v86 backend to prevent make/gcc from seeing files as having future timestamps when the emulated CMOS clock drifts behind real time.

## Problem
When v86's emulated clock drifts behind the host clock (due to idle VM, throttled tabs, or busy setup), files created via `emulator.create_file()` get host timestamps but make/gcc read the guest's drifted CMOS clock. When drift exceeds a second, make warns "Makefile modification time N.Ns in the future" and may rebuild targets in a loop.

## Solution
- **`_resyncGuestClock()`**: Periodically re-pins the guest wall clock to the host's current second via RPC daemon, keeping both domains aligned
- **`_startGuestClockSync()` / `_stopGuestClockSync()`**: Manages a 2-second interval timer for background clock synchronization
- **Pause/resume handling**: Stops clock sync when background sync pauses (e.g., on app suspend) and restarts on resume
- **File save integration**: Calls `_resyncGuestClock()` after file creation to ensure subsequent make/gcc runs see consistent timestamps
- **Lifecycle management**: Cleans up timer in `destroy()` and integrates with existing file watch lifecycle

## Key Changes
- Added three new methods to `TutorialCode.prototype` for guest clock synchronization
- Integrated clock sync start/stop with file watch lifecycle in `_startFileWatch()` context
- Added pause/resume state tracking (`_restartGuestClockSyncOnResume`) mirroring file watch pattern
- Clock resync awaited after file saves to prevent race conditions with subsequent build commands
- Graceful degradation: no-op if backend is not v86, emulator unavailable, or RPC daemon unreachable

https://claude.ai/code/session_01C326bDnkrW42DUBVbpyZfb