### PR TITLE
Show saved SE Gym avatar in tutorial and SEBook quizzes

### DIFF
--- a/_includes/quiz.html
+++ b/_includes/quiz.html
@@ -148,8 +148,9 @@ Data source: _data/quizzes/{{ include.id }}.yml
     </div>
   </div>
 </div>
+{% assign _quiz_av_variant = include.id | slugify | append: "-qa" %}
 <aside class="quiz-avatar-side" aria-hidden="true" style="display:none">
-  {% include se-gym-hero.svg variant="{{ include.id | slugify }}-qa" %}
+  {% include se-gym-hero.svg variant=_quiz_av_variant %}
 </aside>
 </div>
 

--- a/_includes/quiz.html
+++ b/_includes/quiz.html
@@ -23,6 +23,7 @@ Data source: _data/quizzes/{{ include.id }}.yml
 {% assign all_questions = quiz_data.questions %}
 {% endif %}
 
+<div class="quiz-outer-wrap">
 <div class="quiz-container" data-quiz-id="{{ include.id }}"
   data-shuffle="{{ quiz_data.shuffle | default: true }}"
   role="region" aria-label="{{ quiz_data.title | escape }} quiz">
@@ -147,8 +148,57 @@ Data source: _data/quizzes/{{ include.id }}.yml
     </div>
   </div>
 </div>
+<aside class="quiz-avatar-side" aria-hidden="true" style="display:none">
+  {% include se-gym-hero.svg variant="{{ include.id | slugify }}-qa" %}
+</aside>
+</div>
 
 <style>
+  /* Flex wrapper: quiz on the left, avatar character on the right */
+  .quiz-outer-wrap {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    margin: 18px 0;
+  }
+
+  .quiz-outer-wrap > .quiz-container {
+    flex: 1;
+    min-width: 0;
+    margin: 0; /* outer wrap provides vertical margin */
+  }
+
+  .quiz-avatar-side {
+    width: 160px;
+    flex-shrink: 0;
+    position: sticky;
+    top: 80px; /* clear fixed navbar */
+  }
+
+  .quiz-avatar-side [data-gym-hero-svg] {
+    display: block;
+    width: 100%;
+    height: auto;
+    filter: drop-shadow(0 10px 22px rgba(0, 47, 82, 0.22));
+  }
+
+  html.dark-mode .quiz-avatar-side [data-gym-hero-svg] {
+    filter: drop-shadow(0 10px 22px rgba(0, 0, 0, 0.48));
+  }
+
+  @media (max-width: 700px) {
+    .quiz-outer-wrap {
+      flex-direction: column;
+    }
+
+    .quiz-avatar-side {
+      width: 110px;
+      align-self: center;
+      position: static;
+      order: -1;
+    }
+  }
+
   .quiz-container {
     background:
       radial-gradient(circle at 100% 0%, rgba(139, 184, 232, 0.2) 0 88px, transparent 90px),
@@ -889,10 +939,13 @@ Data source: _data/quizzes/{{ include.id }}.yml
   (function () {
     const quizId = "{{ include.id }}";
     const script = document.currentScript;
-    let container = script ? script.previousElementSibling : null;
-    while (container && (!container.classList || !container.classList.contains('quiz-container'))) {
-      container = container.previousElementSibling;
+    // Walk backwards to find the quiz-outer-wrap (the quiz-container is now
+    // nested inside it), then descend to the quiz-container itself.
+    let outerWrap = script ? script.previousElementSibling : null;
+    while (outerWrap && (!outerWrap.classList || !outerWrap.classList.contains('quiz-outer-wrap'))) {
+      outerWrap = outerWrap.previousElementSibling;
     }
+    let container = outerWrap ? outerWrap.querySelector('.quiz-container') : null;
     if (!container) return;
 
     const progressBar = container.querySelector('.progress-fill');
@@ -1601,6 +1654,30 @@ Data source: _data/quizzes/{{ include.id }}.yml
           toggleInGym(toggleBtn);
         });
       }
+    }
+
+    // Show the saved SE Gym avatar next to this quiz when one exists.
+    // HeroAvatar is loaded with `defer` in the SEBook layout, so it may not
+    // be available yet when this inline script runs — wait for `load` if so.
+    function initQuizAvatar() {
+      if (!window.HeroAvatar) return;
+      var state = HeroAvatar.loadAvatar();
+      if (!state) return;
+      var outerWrap = container.parentElement;
+      var side = outerWrap && outerWrap.classList.contains('quiz-outer-wrap')
+        ? outerWrap.querySelector('.quiz-avatar-side')
+        : null;
+      if (!side) return;
+      var svgEl = side.querySelector('[data-gym-hero-svg]');
+      if (!svgEl) return;
+      HeroAvatar.applyToSvg(svgEl, state);
+      side.style.display = '';
+    }
+
+    if (document.readyState === 'complete' || window.HeroAvatar) {
+      initQuizAvatar();
+    } else {
+      window.addEventListener('load', initQuizAvatar);
     }
 
   })();

--- a/_layouts/sebook.html
+++ b/_layouts/sebook.html
@@ -759,6 +759,7 @@
   </script>
 
   {% include scripts.html %}
+  <script src="{{ '/js/se-gym-hero-avatar.js' | relative_url }}" defer></script>
 
 </body>
 

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -918,6 +918,11 @@
        page, the index, blog, and every other layout that has room for it,
        and a direct link to /cookies/ is the single source of truth. -->
 
+  <!-- Avatar template used by SebookQuiz to show the user's saved SE Gym
+       hero below quiz questions when an avatar has been set. The <template>
+       content lives in a DocumentFragment (not rendered, no ID conflicts). -->
+  <template id="quiz-avatar-tpl">{% include se-gym-hero.svg variant="tquiz" %}</template>
+  <script src="{{ '/js/se-gym-hero-avatar.js' | relative_url }}" defer></script>
 
 </body>
 </html>

--- a/css/tutorial.css
+++ b/css/tutorial.css
@@ -5241,3 +5241,24 @@ body :is(
 ) {
   font-size: max(1em, var(--font-size-readable-min, 16px)) !important;
 }
+
+/* ── Tutorial quiz avatar ─────────────────────────────────────────────────────
+   Decorative hero character shown below the quiz after the student has a
+   saved SE Gym avatar. Hidden by default; shown by _mountQuizAvatar() in
+   tutorial-quiz.js only when localStorage['se-gym-hero-avatar'] is present. */
+.tvm-quiz-avatar-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 4px 0 20px;
+}
+
+.tvm-quiz-avatar-wrap [data-gym-hero-svg] {
+  display: block;
+  width: 160px;
+  height: auto;
+  filter: drop-shadow(0 10px 22px rgba(0, 47, 82, 0.22));
+}
+
+html.dark-mode .tvm-quiz-avatar-wrap [data-gym-hero-svg] {
+  filter: drop-shadow(0 10px 22px rgba(0, 0, 0, 0.48));
+}

--- a/js/tutorial-quiz.js
+++ b/js/tutorial-quiz.js
@@ -222,6 +222,7 @@
       + (isFinalQuiz ? '' : '<button class="tvm-quiz-continue-btn hidden">Continue to Step ' + nextStepNum + ' →</button>')
       + '<button class="restart-btn">Try Again</button></div>'
       + '<p class="quiz-result-shortcut-hint hidden"></p></div></div></div>';
+    html += '<div class="tvm-quiz-avatar-wrap" aria-hidden="true" style="display:none"></div>';
     return html;
   }
 
@@ -697,6 +698,28 @@
   }
 
   // ---------------------------------------------------------------------------
+  // Quiz avatar — shows the saved SE Gym hero below the quiz when one exists.
+  // Clones the SVG from a <template id="quiz-avatar-tpl"> injected by the
+  // tutorial layout and popup HTML, then applies the avatar via HeroAvatar.
+  // ---------------------------------------------------------------------------
+  function _mountQuizAvatar(hostEl) {
+    if (!window.HeroAvatar) return;
+    var state = HeroAvatar.loadAvatar();
+    if (!state) return;
+    var tpl = document.getElementById('quiz-avatar-tpl');
+    if (!tpl || !tpl.content) return;
+    var wrap = hostEl && hostEl.querySelector('.tvm-quiz-avatar-wrap');
+    if (!wrap) return;
+    var clone = tpl.content.cloneNode(true);
+    wrap.innerHTML = '';
+    wrap.appendChild(clone);
+    var svgEl = wrap.querySelector('[data-gym-hero-svg]');
+    if (!svgEl) return;
+    HeroAvatar.applyToSvg(svgEl, state);
+    wrap.style.display = '';
+  }
+
+  // ---------------------------------------------------------------------------
   // mount = buildHTML + setInnerHTML + attach (the common entry point)
   // ---------------------------------------------------------------------------
   function mount(opts) {
@@ -717,6 +740,7 @@
       isFinalQuiz: !!opts.isFinalQuiz,
       onPass: opts.onPass,
     });
+    _mountQuizAvatar(hostEl);
   }
 
   window.SebookQuiz = {

--- a/tutorial-instructions-popup.html
+++ b/tutorial-instructions-popup.html
@@ -72,6 +72,8 @@
   <script src="{{ '/js/tutorial-popout-client.js' | relative_url }}"></script>
   <script src="{{ '/js/tutorial-quiz.js' | relative_url }}"></script>
   <script src="{{ '/js/tutorial-inline-markdown.js' | relative_url }}"></script>
+  <script src="{{ '/js/se-gym-hero-avatar.js' | relative_url }}" defer></script>
+  <template id="quiz-avatar-tpl">{% include se-gym-hero.svg variant="tquiz-pop" %}</template>
   <script>
   (function () {
     var els = {


### PR DESCRIPTION
If a user has customised their hero avatar in SE Gym, it now appears:

- Below the answer/submit area in tutorial step quizzes (main view and
  the detached popup window), rendered from a <template> element so the
  SVG's gradient/clipPath IDs never conflict with live-DOM elements.
- To the right of each quiz on SEBook pages, sticky while scrolling,
  collapsing below the quiz on narrow viewports.

Avatar loading reuses the existing HeroAvatar API (loadAvatar /
applyToSvg) and the se-gym-hero.svg include — no logic is duplicated and
neither of those files is modified. Each placement uses a unique SVG
variant string (tquiz / tquiz-pop / <quiz-id>-qa) so gradient IDs remain
unique across the page. Containers start hidden and are revealed only
after a valid avatar is loaded, so users without a saved avatar see no
change. Full light/dark-mode drop-shadow variants and aria-hidden on all
decorative avatar containers included.

https://claude.ai/code/session_016VrhFbhiiri8vWpMEUh1m2