### PR TITLE
Add real-time section search to SE Book homepage

### DIFF
--- a/SEBook/index.md
+++ b/SEBook/index.md
@@ -6,6 +6,92 @@ layout: sebook
 # Welcome to the SE Book
 The SE Book brings together material for students in software engineering courses, including [CS 35L](/SEBook/CS35L_bookmarks.html) and [CS 130](/SEBook/CS130_bookmarks.html).
 
+<section id="sebook-search" aria-labelledby="sebook-search-heading" class="sebook-search">
+  <h2 id="sebook-search-heading">Search the SE Book</h2>
+  <div class="sebook-search-controls">
+    <label for="sebook-search-input" class="sebook-search-label">
+      Find a section or tutorial
+    </label>
+    <div class="sebook-search-input-wrap">
+      <input
+        type="search"
+        id="sebook-search-input"
+        class="sebook-search-input"
+        placeholder="Type to filter section and tutorial titles…"
+        autocomplete="off"
+        spellcheck="false"
+        aria-describedby="sebook-search-hint sebook-search-summary"
+        aria-controls="sebook-search-results">
+      <button
+        type="button"
+        id="sebook-search-clear"
+        class="sebook-search-clear"
+        aria-label="Clear search"
+        hidden>
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+    <p id="sebook-search-hint" class="sebook-search-hint">
+      Results filter in real time as you type. Matches are case-insensitive.
+    </p>
+    <p
+      id="sebook-search-summary"
+      class="sebook-search-summary"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"></p>
+  </div>
+
+  {% assign all_entries = "" | split: "" %}
+
+  <ul
+    id="sebook-search-results"
+    class="sebook-search-results"
+    aria-label="Section and tutorial titles">
+    {% for topic in site.data.sebook_nav.topics %}
+      <li
+        class="sebook-search-result sebook-search-result--topic"
+        data-search-title="{{ topic.name | downcase }}">
+        <a href="{{ topic.url }}" class="sebook-search-result-link">
+          <span class="sebook-search-result-title">{{ topic.name }}</span>
+          <span class="sebook-search-result-kind">Section</span>
+        </a>
+      </li>
+      {% if topic.subtopics %}
+        {% for subtopic in topic.subtopics %}
+          <li
+            class="sebook-search-result sebook-search-result--subtopic"
+            data-search-title="{{ subtopic.name | downcase }}">
+            <a href="{{ subtopic.url }}" class="sebook-search-result-link">
+              <span class="sebook-search-result-title">{{ subtopic.name }}</span>
+              <span class="sebook-search-result-kind">{{ topic.name }}</span>
+            </a>
+          </li>
+          {% if subtopic.items %}
+            {% for item in subtopic.items %}
+              <li
+                class="sebook-search-result sebook-search-result--item"
+                data-search-title="{{ item.name | downcase }}">
+                <a href="{{ item.url }}" class="sebook-search-result-link">
+                  <span class="sebook-search-result-title">{{ item.name }}</span>
+                  <span class="sebook-search-result-kind">{{ topic.name }} › {{ subtopic.name }}</span>
+                </a>
+              </li>
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  </ul>
+
+  <p
+    id="sebook-search-no-results"
+    class="sebook-search-no-results"
+    hidden>
+    No results found.
+  </p>
+</section>
+
 ## Interactive Tutorials
 The SE Book includes a broad set of interactive tutorials that run directly in your browser, with no installation required.
 Depending on the topic, you can practice Linux shell scripting in a real Linux VM, explore live UML visualizations of your code, step through programs with a time-travel debugger, inspect Git history through an interactive graph, and work through advanced testing concepts.
@@ -17,3 +103,86 @@ Please consider only the pages linked in your specific course page and already c
 
 ## Practice
 To reinforce the concepts from this book, practice regularly in the [SE Gym](/se-gym).
+
+<script>
+(function () {
+  'use strict';
+
+  function init() {
+    var input = document.getElementById('sebook-search-input');
+    var clearBtn = document.getElementById('sebook-search-clear');
+    var resultsList = document.getElementById('sebook-search-results');
+    var noResults = document.getElementById('sebook-search-no-results');
+    var summary = document.getElementById('sebook-search-summary');
+    if (!input || !resultsList || !noResults || !summary) return;
+
+    var items = Array.prototype.slice.call(
+      resultsList.querySelectorAll('.sebook-search-result')
+    );
+    var totalCount = items.length;
+
+    function setSummary(text) {
+      if (summary.textContent !== text) summary.textContent = text;
+    }
+
+    function filter(rawQuery) {
+      var query = (rawQuery || '').trim().toLowerCase();
+      var visible = 0;
+      for (var i = 0; i < items.length; i++) {
+        var title = items[i].getAttribute('data-search-title') || '';
+        var match = query === '' || title.indexOf(query) !== -1;
+        items[i].hidden = !match;
+        if (match) visible++;
+      }
+
+      if (query === '') {
+        resultsList.hidden = false;
+        noResults.hidden = true;
+        setSummary('Showing all ' + totalCount + ' titles.');
+      } else if (visible === 0) {
+        resultsList.hidden = true;
+        noResults.hidden = false;
+        setSummary('No results found for "' + rawQuery + '".');
+      } else {
+        resultsList.hidden = false;
+        noResults.hidden = true;
+        setSummary(
+          visible === 1
+            ? '1 title matches "' + rawQuery + '".'
+            : visible + ' titles match "' + rawQuery + '".'
+        );
+      }
+
+      if (clearBtn) clearBtn.hidden = query === '';
+    }
+
+    input.addEventListener('input', function () {
+      filter(this.value);
+    });
+
+    input.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape' && input.value !== '') {
+        event.preventDefault();
+        input.value = '';
+        filter('');
+      }
+    });
+
+    if (clearBtn) {
+      clearBtn.addEventListener('click', function () {
+        input.value = '';
+        filter('');
+        input.focus();
+      });
+    }
+
+    filter('');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+</script>

--- a/css/sebook-theme.css
+++ b/css/sebook-theme.css
@@ -2192,3 +2192,226 @@ body.tutorial-layout :is(small, .small) {
     transition: none !important;
   }
 }
+
+/* ---------------------------------------------------------------- */
+/* SE Book homepage search                                           */
+/* ---------------------------------------------------------------- */
+
+/* The `display` rules below override the default UA `[hidden] { display: none }`,
+   so we need to re-assert it for every element that toggles via `.hidden`. */
+.sebook-search-clear[hidden],
+.sebook-search-results[hidden],
+.sebook-search-result[hidden],
+.sebook-search-no-results[hidden] {
+  display: none !important;
+}
+
+.sebook-search {
+  margin: 2em auto;
+  padding: 1.4em 1.6em 1.6em;
+  background: var(--sebook-surface);
+  border: 1px solid var(--sebook-border);
+  border-radius: 12px;
+  box-shadow: 0 4px 18px rgba(0, 59, 92, 0.07);
+  max-width: 900px;
+}
+
+html.dark-mode .sebook-search {
+  background: var(--sebook-surface);
+  border-color: var(--sebook-border);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.42);
+}
+
+.sebook-search > h2 {
+  margin: 0 0 0.6em;
+  font-size: 1.4em;
+  color: var(--sebook-navy);
+}
+
+html.dark-mode .sebook-search > h2 {
+  color: var(--sebook-navy);
+}
+
+.sebook-search-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.sebook-search-label {
+  font-weight: 700;
+  color: var(--sebook-navy);
+  font-size: 1em;
+}
+
+html.dark-mode .sebook-search-label {
+  color: var(--sebook-navy);
+}
+
+.sebook-search-input-wrap {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+
+.sebook-search-input {
+  flex: 1;
+  width: 100%;
+  font: inherit;
+  font-size: 1em;
+  padding: 0.6em 2.4em 0.6em 0.8em;
+  border: 2px solid var(--sebook-button-border);
+  border-radius: 8px;
+  background: var(--sebook-button-bg);
+  color: var(--sebook-button-text);
+  box-sizing: border-box;
+  min-height: 44px;
+}
+
+.sebook-search-input::placeholder {
+  color: #5a6f82;
+  opacity: 1;
+}
+
+html.dark-mode .sebook-search-input::placeholder {
+  color: #b8c6d4;
+  opacity: 1;
+}
+
+.sebook-search-input:focus-visible {
+  outline: var(--focus-width, 3px) solid var(--focus-color, #FFD100);
+  outline-offset: var(--focus-offset, 2px);
+}
+
+.sebook-search-clear {
+  position: absolute;
+  right: 0.4em;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  min-height: 32px;
+  border: 2px solid var(--sebook-button-border);
+  border-radius: 50%;
+  background: var(--sebook-button-bg);
+  color: var(--sebook-button-text);
+  font-size: 1.2em;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.sebook-search-clear:hover {
+  background: var(--sebook-button-bg-hover);
+}
+
+.sebook-search-clear:focus-visible {
+  outline: var(--focus-width, 3px) solid var(--focus-color, #FFD100);
+  outline-offset: var(--focus-offset, 2px);
+}
+
+.sebook-search-hint {
+  margin: 0;
+  font-size: 0.95em;
+  color: var(--sebook-navy);
+  opacity: 0.85;
+}
+
+.sebook-search-summary {
+  margin: 0;
+  font-size: 0.95em;
+  color: var(--sebook-navy);
+  font-weight: 700;
+  min-height: 1.4em;
+}
+
+.sebook-search-results {
+  list-style: none;
+  margin: 1em 0 0;
+  padding: 0;
+  border-top: 1px solid var(--sebook-border);
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.sebook-search-result {
+  border-bottom: 1px solid var(--sebook-border);
+  margin: 0;
+}
+
+.sebook-search-result-link {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.8em;
+  padding: 0.7em 0.6em;
+  text-decoration: none;
+  color: var(--sebook-button-text);
+  border-radius: 6px;
+  min-height: 44px;
+  flex-wrap: wrap;
+}
+
+.sebook-search-result-link:hover {
+  background: var(--sebook-button-bg-hover);
+  text-decoration: underline;
+}
+
+.sebook-search-result-link:focus-visible {
+  outline: var(--focus-width, 3px) solid var(--focus-color, #FFD100);
+  outline-offset: var(--focus-offset, 2px);
+}
+
+html.dark-mode .sebook-search-result-link {
+  color: var(--sebook-button-text);
+}
+
+html.dark-mode .sebook-search-result-link:hover {
+  background: var(--sebook-button-bg-hover);
+}
+
+.sebook-search-result-title {
+  font-weight: 700;
+  flex: 1 1 auto;
+}
+
+.sebook-search-result-kind {
+  font-size: 0.85em;
+  color: #4a5d6f;
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+html.dark-mode .sebook-search-result-kind {
+  color: #b8c6d4;
+}
+
+.sebook-search-result--subtopic .sebook-search-result-link {
+  padding-left: 1.8em;
+}
+
+.sebook-search-result--item .sebook-search-result-link {
+  padding-left: 3em;
+}
+
+.sebook-search-no-results {
+  margin: 1em 0 0;
+  padding: 1em;
+  background: var(--sebook-surface-band);
+  border: 1px dashed var(--sebook-border);
+  border-radius: 8px;
+  color: var(--sebook-navy);
+  font-weight: 700;
+  text-align: center;
+}
+
+html.dark-mode .sebook-search-no-results {
+  background: var(--sebook-surface-band);
+  border-color: var(--sebook-border);
+  color: var(--sebook-navy);
+}
+

--- a/tests/sebook-search.spec.js
+++ b/tests/sebook-search.spec.js
@@ -1,0 +1,212 @@
+// @ts-check
+/**
+ * Tests: SE Book homepage section search
+ *
+ * Acceptance criteria for the user story:
+ *
+ *   As a CS 35L student using the SE Book, I want a search bar that filters
+ *   section/tutorial titles in real time so that I can quickly find the
+ *   relevant sections in the book to help with my studying.
+ *
+ *   AC 1: Given the user is on the SE Book homepage, when the user views the
+ *         page, then a search input field is visible.
+ *   AC 2: Given the user types into the search bar on the homepage, when
+ *         section titles match the search, then only matching titles are
+ *         displayed.
+ *   AC 3: Given no section titles match the search, when the search is
+ *         completed, then a "no results found" message is displayed.
+ *
+ * Each acceptance criterion is covered by at least one test below. Additional
+ * tests cover related WCAG 2.2 AA requirements that fall out of the design:
+ * the input must be labelled, the no-results message must be announced to
+ * assistive tech via aria-live, and the search must keep working in dark
+ * mode (the project rule per CLAUDE.md).
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const SEARCH_INPUT = '#sebook-search-input';
+const RESULTS_LIST = '#sebook-search-results';
+const NO_RESULTS = '#sebook-search-no-results';
+const SUMMARY = '#sebook-search-summary';
+const CLEAR_BUTTON = '#sebook-search-clear';
+
+test.describe('SE Book homepage search — acceptance criteria', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/SEBook/');
+  });
+
+  // AC 1
+  test('AC1: a search input field is visible on the SE Book homepage', async ({ page }) => {
+    const input = page.locator(SEARCH_INPUT);
+    await expect(input, 'search input should exist on the homepage').toHaveCount(1);
+    await expect(input, 'search input should be visible without interaction').toBeVisible();
+    // The element must be a real form input the user can type into, not just a styled div.
+    await expect(input).toHaveAttribute('type', 'search');
+    // It must be reachable by keyboard (no tabindex="-1", not disabled).
+    await expect(input).toBeEnabled();
+    await expect(input).not.toHaveAttribute('tabindex', '-1');
+  });
+
+  // AC 2 — matching titles
+  test('AC2: typing filters the visible titles to those that match', async ({ page }) => {
+    const input = page.locator(SEARCH_INPUT);
+    const allResults = page.locator(`${RESULTS_LIST} .sebook-search-result`);
+    const visibleResults = page.locator(`${RESULTS_LIST} .sebook-search-result:not([hidden])`);
+
+    const totalBefore = await allResults.count();
+    expect(totalBefore, 'homepage should render multiple section titles before filtering').toBeGreaterThan(5);
+
+    // Type a query that should match only the "UML" entries.
+    await input.fill('UML');
+
+    const visibleCount = await visibleResults.count();
+    expect(visibleCount, 'at least one UML entry should remain visible').toBeGreaterThan(0);
+    expect(visibleCount, 'non-matching titles should be hidden').toBeLessThan(totalBefore);
+
+    // Every visible title must contain the query (case-insensitive).
+    const visibleTitles = await visibleResults.locator('.sebook-search-result-title').allTextContents();
+    for (const title of visibleTitles) {
+      expect(title.toLowerCase()).toContain('uml');
+    }
+  });
+
+  // AC 2 — case-insensitive filtering also works for tutorial titles
+  test('AC2: filtering is case-insensitive and matches tutorial titles', async ({ page }) => {
+    const input = page.locator(SEARCH_INPUT);
+    await input.fill('TUTORIAL');
+
+    const visible = page.locator(`${RESULTS_LIST} .sebook-search-result:not([hidden])`);
+    const titles = await visible.locator('.sebook-search-result-title').allTextContents();
+    expect(titles.length, 'tutorial-named entries should match a case-insensitive query').toBeGreaterThan(0);
+    for (const title of titles) {
+      expect(title.toLowerCase()).toContain('tutorial');
+    }
+  });
+
+  // AC 2 — clearing brings everything back
+  test('AC2: clearing the input restores all titles', async ({ page }) => {
+    const input = page.locator(SEARCH_INPUT);
+    const allResults = page.locator(`${RESULTS_LIST} .sebook-search-result`);
+    const visibleResults = page.locator(`${RESULTS_LIST} .sebook-search-result:not([hidden])`);
+    const totalBefore = await allResults.count();
+
+    await input.fill('UML');
+    const visibleWhileFiltered = await visibleResults.count();
+    expect(visibleWhileFiltered).toBeLessThan(totalBefore);
+
+    await input.fill('');
+    await expect.poll(async () => visibleResults.count()).toBe(totalBefore);
+  });
+
+  // AC 3
+  test('AC3: typing a non-matching query shows the "no results found" message', async ({ page }) => {
+    const input = page.locator(SEARCH_INPUT);
+    const noResults = page.locator(NO_RESULTS);
+
+    // Initially the no-results message is hidden.
+    await expect(noResults).toBeHidden();
+
+    // Type a query no section title will ever match.
+    await input.fill('zzzzz-nonsense-query-no-section-uses-this');
+
+    await expect(noResults, 'no-results message should appear').toBeVisible();
+    await expect(noResults).toHaveText(/no results found/i);
+
+    // The results list should be hidden (or contain zero visible items)
+    // since none match.
+    const visible = page.locator(`${RESULTS_LIST} .sebook-search-result:not([hidden])`);
+    expect(await visible.count()).toBe(0);
+  });
+
+  // AC 3 — recovery
+  test('AC3: clearing after no-results hides the no-results message', async ({ page }) => {
+    const input = page.locator(SEARCH_INPUT);
+    const noResults = page.locator(NO_RESULTS);
+
+    await input.fill('zzzzz-nonsense-query-no-section-uses-this');
+    await expect(noResults).toBeVisible();
+
+    await input.fill('');
+    await expect(noResults).toBeHidden();
+  });
+});
+
+test.describe('SE Book homepage search — WCAG 2.2 AA support', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/SEBook/');
+  });
+
+  test('search input has an accessible name from a real <label>', async ({ page }) => {
+    const input = page.locator(SEARCH_INPUT);
+    // The label[for="sebook-search-input"] gives the input its accessible name.
+    const labelText = await page.locator('label[for="sebook-search-input"]').innerText();
+    expect(labelText.trim().length, 'label must provide a non-empty accessible name').toBeGreaterThan(0);
+  });
+
+  test('no-results message uses aria-live so screen readers announce it', async ({ page }) => {
+    // The summary region carries aria-live; the message itself is targeted by
+    // the summary as new text. Verify the live region is wired up.
+    const summary = page.locator(SUMMARY);
+    await expect(summary).toHaveAttribute('aria-live', 'polite');
+    await expect(summary).toHaveAttribute('role', 'status');
+
+    // Trigger a no-results state and confirm the summary updates.
+    await page.locator(SEARCH_INPUT).fill('zzzzz-nonsense-query');
+    await expect(summary).toHaveText(/no results found/i);
+  });
+
+  test('typing summary announces match counts via the status region', async ({ page }) => {
+    const summary = page.locator(SUMMARY);
+    await page.locator(SEARCH_INPUT).fill('UML');
+    // The status text mentions a count when there are matches.
+    await expect(summary).toContainText(/match/i);
+  });
+
+  test('clear button becomes operable when there is text and clears the input', async ({ page }) => {
+    const clear = page.locator(CLEAR_BUTTON);
+    const input = page.locator(SEARCH_INPUT);
+
+    await expect(clear, 'clear button is hidden when input is empty').toBeHidden();
+
+    await input.fill('UML');
+    await expect(clear, 'clear button appears when input has content').toBeVisible();
+
+    // The button must meet a minimum target size (≥ 24 CSS px per WCAG 2.5.8).
+    const box = await clear.boundingBox();
+    expect(box).toBeTruthy();
+    if (box) {
+      expect(box.width).toBeGreaterThanOrEqual(24);
+      expect(box.height).toBeGreaterThanOrEqual(24);
+    }
+
+    await clear.click();
+    await expect(input).toHaveValue('');
+    await expect(clear).toBeHidden();
+  });
+
+  test('Escape clears the input when it has text', async ({ page }) => {
+    const input = page.locator(SEARCH_INPUT);
+    await input.fill('UML');
+    await expect(input).toHaveValue('UML');
+    await input.press('Escape');
+    await expect(input).toHaveValue('');
+  });
+
+  test('search works after enabling dark mode (light/dark mode rule)', async ({ page }) => {
+    // Per CLAUDE.md, every CSS change must work in both light and dark mode.
+    await page.locator('#darkModeToggle').setChecked(true, { force: true });
+    await expect.poll(() => page.evaluate(() =>
+      document.documentElement.classList.contains('dark-mode')
+    )).toBe(true);
+
+    // The search must still filter and render the no-results message in dark mode.
+    const input = page.locator(SEARCH_INPUT);
+    await input.fill('UML');
+    const visible = page.locator(`${RESULTS_LIST} .sebook-search-result:not([hidden])`);
+    expect(await visible.count()).toBeGreaterThan(0);
+
+    await input.fill('zzzzz-nonsense-query');
+    await expect(page.locator(NO_RESULTS)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a search bar to the SE Book homepage (`/SEBook/`) that filters every section, subsection, and tutorial title from `_data/sebook_nav.yml` in real time as the user types.
- Renders a "No results found" message when no titles match, with an `aria-live` status region that also announces match counts to screen readers.
- Ships with full WCAG 2.2 AA support (real `<label>`, focus rings, ≥ 24 px target size on the clear button, `font: inherit` on the input to avoid the project's `1rem = 10px` trap) and works in both light and dark mode via the existing `--sebook-*` design tokens.

## User story
> As a CS 35L student using the SE Book, I want a search bar that filters section/tutorial titles in real time so that I can quickly find the relevant sections in the book to help with my studying.

## Acceptance criteria — automated test mapping
- **AC1** — "search input field is visible" → `AC1: a search input field is visible on the SE Book homepage`
- **AC2** — "only matching titles are displayed" → `AC2: typing filters the visible titles to those that match`, plus a case-insensitive variant and a clear-and-restore variant
- **AC3** — "no results found message is displayed" → `AC3: typing a non-matching query shows the "no results found" message`, plus a recovery test

## Test plan
- [x] `npx playwright test tests/sebook-search.spec.js` — 12/12 pass (the three AC tests plus 9 supporting ones for case-insensitive matching, clearing, aria-live, target size, Escape-to-clear, and dark mode)
- [x] `npx playwright test tests/sebook.spec.js` — 19/19 pass (no regressions in TOC navigation, dark-mode/highlight toggles, or read-aloud)
- [x] `npx playwright test tests/accessibility.spec.js` — 12/12 pass (SEBook index `<title>` + alt-text + skip-link checks)
- [x] `axe-core` scan of `#sebook-search` — 0 violations in empty / no-results / dark-mode states
- [x] Console — 0 errors, 0 warnings while typing, clearing, and toggling dark mode
- [x] Visual check at 1400×900: light and dark mode both render the card with correct contrast and hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)