### PR TITLE
Add CS 35L study schedule generator

### DIFF
--- a/SEBook/CS35L.md
+++ b/SEBook/CS35L.md
@@ -8,4 +8,6 @@ course: CS35L
 
 {% include quiz.html id="CS35_current" %}
 
+{% include study_schedule.html plan="CS35L" %}
+
 # Welcome to Computer Science 35L - Software Construction at UCLA

--- a/_data/study_plans/CS35L.yml
+++ b/_data/study_plans/CS35L.yml
@@ -1,0 +1,110 @@
+# CS 35L Study Plan source list.
+#
+# Items are listed in the recommended pedagogical order. The schedule
+# generator (see js/study-schedule.js) distributes them across the
+# number of days the student chose (4–14, inclusive) while keeping
+# the order intact.
+#
+# Each item has:
+#   title — display name on the schedule card.
+#   type  — "tutorial" (browser tutorial) or "gym" (SE Gym quiz).
+#   url   — link to the underlying page or quiz.
+
+title: "CS 35L study plan"
+description: "Software Construction — recommended order for working through the SE Book."
+
+items:
+  # Foundations
+  - title: "Shell Scripting Tutorial"
+    type: tutorial
+    url: /SEBook/tools/shell-tutorial.html
+  - title: "Shell Quiz"
+    type: gym
+    url: /se-gym/?quiz=shell
+  - title: "Regular Expressions Tutorial (Basics)"
+    type: tutorial
+    url: /SEBook/tools/regex-tutorial.html
+  - title: "Regular Expressions Tutorial (Advanced)"
+    type: tutorial
+    url: /SEBook/tools/regex-tutorial-advanced.html
+  - title: "Regex Quiz"
+    type: gym
+    url: /se-gym/?quiz=regex
+
+  # Programming languages
+  - title: "Python Tutorial"
+    type: tutorial
+    url: /SEBook/tools/python-tutorial.html
+  - title: "Python Quiz"
+    type: gym
+    url: /se-gym/?quiz=python
+  - title: "Node.js Tutorial"
+    type: tutorial
+    url: /SEBook/tools/nodejs-tutorial.html
+  - title: "Node.js Quiz"
+    type: gym
+    url: /se-gym/?quiz=nodejs
+  - title: "React Tutorial"
+    type: tutorial
+    url: /SEBook/tools/react-tutorial.html
+  - title: "React Quiz"
+    type: gym
+    url: /se-gym/?quiz=react
+
+  # Build tools and version control
+  - title: "Git Tutorial"
+    type: tutorial
+    url: /SEBook/tools/git-tutorial.html
+  - title: "Advanced Git Tutorial"
+    type: tutorial
+    url: /SEBook/tools/git-advanced-tutorial.html
+  - title: "Git Quiz"
+    type: gym
+    url: /se-gym/?quiz=git_basic
+  - title: "Makefile Tutorial"
+    type: tutorial
+    url: /SEBook/tools/makefile-tutorial.html
+
+  # Systems
+  - title: "Networking Quiz"
+    type: gym
+    url: /se-gym/?quiz=networking
+  - title: "Data Management Quiz"
+    type: gym
+    url: /se-gym/?quiz=data_management
+  - title: "Security Quiz"
+    type: gym
+    url: /se-gym/?quiz=security
+
+  # Design and process
+  - title: "Observer Pattern Quiz"
+    type: gym
+    url: /se-gym/?quiz=design_pattern_observer
+  - title: "SOLID Quiz"
+    type: gym
+    url: /se-gym/?quiz=design_principle_solid
+  - title: "Design with Reuse Quiz"
+    type: gym
+    url: /se-gym/?quiz=design_with_reuse
+
+  # Testing
+  - title: "Testing Foundations Tutorial"
+    type: tutorial
+    url: /SEBook/tools/testing-foundations-tutorial.html
+  - title: "TDD Tutorial"
+    type: tutorial
+    url: /SEBook/tools/tdd-tutorial.html
+
+  # UML
+  - title: "UML Class Diagram Tutorial (Python)"
+    type: tutorial
+    url: /SEBook/tools/uml-class-diagram-python.html
+  - title: "UML Class Diagram Quiz"
+    type: gym
+    url: /se-gym/?quiz=uml_class_diagram_examples
+  - title: "UML Sequence Diagram Tutorial (Python)"
+    type: tutorial
+    url: /SEBook/tools/uml-sequence-diagram-python.html
+  - title: "UML Sequence Diagram Quiz"
+    type: gym
+    url: /se-gym/?quiz=uml_sequence_diagram_examples

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -394,3 +394,4 @@
 </script>
 <script src="{{ "/js/audio-player.js" | prepend: site.baseurl }}"></script>
 <script src="{{ "/js/se-gym.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/js/study-schedule.js" | prepend: site.baseurl }}"></script>

--- a/_includes/study_schedule.html
+++ b/_includes/study_schedule.html
@@ -1,0 +1,317 @@
+{% comment %}
+Study Schedule include for SEBook course pages.
+
+Usage:
+  {% include study_schedule.html plan="CS35L" %}
+
+Renders:
+  • A "Schedule Study" button.
+  • A modal with a 4–14 day range selector + a "Create Study Plan" button.
+  • A results region showing the organized per-day list once the plan is generated.
+
+The actual scheduling logic lives in /js/study-schedule.js. The list of items
+to schedule lives in /_data/study_plans/<plan>.yml.
+{% endcomment %}
+
+{% assign plan_key = include.plan | default: page.course %}
+{% assign plan_data = site.data.study_plans[plan_key] %}
+
+{% if plan_data %}
+<section class="study-schedule" aria-labelledby="study-schedule-heading">
+  <div class="study-schedule__intro">
+    <h2 id="study-schedule-heading">Need a study plan?</h2>
+    <p>
+      Tell the SE Book how many days you have and it will give you an organized
+      list of tutorials and SE Gym questions to work through each day.
+    </p>
+    <button type="button" id="schedule-study-btn" class="study-schedule__open-btn">
+      <i class="fa-solid fa-calendar-days" aria-hidden="true"></i>
+      Schedule Study
+    </button>
+  </div>
+
+  <!--
+    Inline plan output region. Lives in the page so screen readers can find
+    the headings produced by the schedule generator. Hidden until a plan is
+    rendered.
+  -->
+  <div id="study-plan-output"
+       class="study-schedule__output"
+       role="region"
+       aria-live="polite"
+       aria-label="Generated study plan"
+       hidden></div>
+
+  <!-- Modal: time-range picker -->
+  <div id="study-schedule-modal"
+       class="study-schedule__modal"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="study-schedule-modal-title"
+       hidden>
+    <div class="study-schedule__modal-backdrop" data-close-modal></div>
+    <div class="study-schedule__modal-box" role="document">
+      <h3 id="study-schedule-modal-title">Schedule Your Study Plan</h3>
+      <p id="study-schedule-modal-desc">
+        Pick how many days you want to spread CS 35L material over. Plans must
+        run for at least four days and at most two weeks.
+      </p>
+
+      <!--
+        novalidate: hand validation to study-schedule.js so the error appears
+        in the polite live region (#study-schedule-error). Native tooltips
+        bypass screen readers and would also short-circuit the JS handler.
+        The min/max attributes on the input remain so the visible spinner
+        still constrains values and assistive tech can announce the range.
+      -->
+      <form id="study-schedule-form" aria-describedby="study-schedule-modal-desc" novalidate>
+        <label for="study-schedule-days" class="study-schedule__field-label">
+          Number of days (4–14):
+        </label>
+        <input id="study-schedule-days"
+               name="days"
+               type="number"
+               min="4"
+               max="14"
+               step="1"
+               value="7"
+               required
+               aria-describedby="study-schedule-days-help study-schedule-error" />
+        <p id="study-schedule-days-help" class="study-schedule__help">
+          Choose any whole number between four days and two weeks.
+        </p>
+        <p id="study-schedule-error"
+           class="study-schedule__error"
+           role="alert"
+           aria-live="assertive"
+           hidden></p>
+
+        <div class="study-schedule__modal-btns">
+          <button type="submit"
+                  id="create-study-plan-btn"
+                  class="study-schedule__primary-btn">
+            Create Study Plan
+          </button>
+          <button type="button"
+                  id="study-schedule-cancel-btn"
+                  class="study-schedule__secondary-btn"
+                  data-close-modal>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Plan data, embedded so JS can read it without an extra fetch. -->
+  <script id="study-schedule-data" type="application/json">
+{
+  "title": {{ plan_data.title | jsonify }},
+  "items": [
+    {% for item in plan_data.items %}{
+      "title": {{ item.title | jsonify }},
+      "type":  {{ item.type  | jsonify }},
+      "url":   {{ item.url   | jsonify }}
+    }{% unless forloop.last %},{% endunless %}{% endfor %}
+  ]
+}
+  </script>
+</section>
+
+<style>
+  .study-schedule {
+    margin: 24px 0;
+    padding: 18px 20px;
+    background: var(--color-surface-2, #f8f9fa);
+    border: 1px solid var(--color-border, #d8dde2);
+    border-radius: var(--radius-md, 8px);
+  }
+  html.dark-mode .study-schedule {
+    background: var(--color-surface, #1e1e1e);
+    border-color: var(--color-border, #444);
+  }
+  .study-schedule__intro h2 {
+    margin-top: 0;
+    font-size: 1.4em;
+  }
+  .study-schedule__intro p {
+    margin: 0 0 12px 0;
+  }
+  .study-schedule__open-btn,
+  .study-schedule__primary-btn,
+  .study-schedule__secondary-btn {
+    font: inherit;
+    padding: 10px 18px;
+    border-radius: var(--radius-md, 8px);
+    cursor: pointer;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid transparent;
+  }
+  .study-schedule__open-btn,
+  .study-schedule__primary-btn {
+    background: var(--color-primary, #2774AE);
+    color: var(--color-text-on-primary, #fff);
+    border-color: var(--color-primary, #2774AE);
+  }
+  .study-schedule__open-btn:hover,
+  .study-schedule__open-btn:focus-visible,
+  .study-schedule__primary-btn:hover,
+  .study-schedule__primary-btn:focus-visible {
+    background: var(--color-primary-hover, #1e5c8a);
+    border-color: var(--color-primary-hover, #1e5c8a);
+  }
+  .study-schedule__secondary-btn {
+    background: var(--color-surface, #fff);
+    color: var(--color-text, #111);
+    border-color: var(--color-border-strong, #767676);
+  }
+  html.dark-mode .study-schedule__secondary-btn {
+    background: var(--color-surface, #2a2a2a);
+    color: var(--color-text, #e0e0e0);
+    border-color: var(--color-border-strong, #888);
+  }
+  .study-schedule__secondary-btn:hover,
+  .study-schedule__secondary-btn:focus-visible {
+    background: var(--color-surface-3, #f5f5f5);
+  }
+  html.dark-mode .study-schedule__secondary-btn:hover,
+  html.dark-mode .study-schedule__secondary-btn:focus-visible {
+    background: var(--color-surface-2, #333);
+  }
+
+  .study-schedule__modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+  }
+  .study-schedule__modal[hidden] {
+    display: none;
+  }
+  .study-schedule__modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+  }
+  .study-schedule__modal-box {
+    position: relative;
+    z-index: 1;
+    background: var(--color-surface, #fff);
+    color: var(--color-text, #111);
+    border-radius: var(--radius-md, 8px);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+    padding: 22px 24px;
+    max-width: 480px;
+    width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+  html.dark-mode .study-schedule__modal-box {
+    background: var(--color-surface, #1e1e1e);
+    color: var(--color-text, #e0e0e0);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.7);
+  }
+  .study-schedule__modal-box h3 {
+    margin-top: 0;
+    font-size: 1.3em;
+  }
+  .study-schedule__field-label {
+    display: block;
+    margin-top: 12px;
+    font-weight: 600;
+  }
+  #study-schedule-days {
+    font: inherit;
+    padding: 8px 10px;
+    border: 1px solid var(--color-border-strong, #767676);
+    border-radius: var(--radius-sm, 4px);
+    width: 100px;
+    margin-top: 6px;
+    background: var(--color-surface, #fff);
+    color: var(--color-text, #111);
+  }
+  html.dark-mode #study-schedule-days {
+    background: var(--color-surface, #2a2a2a);
+    color: var(--color-text, #e0e0e0);
+    border-color: var(--color-border-strong, #888);
+  }
+  .study-schedule__help {
+    margin: 6px 0 0 0;
+    color: var(--color-text-muted, #595959);
+    font-size: 0.9em;
+  }
+  html.dark-mode .study-schedule__help {
+    color: var(--color-text-muted, #bdbdbd);
+  }
+  .study-schedule__error {
+    margin: 8px 0 0 0;
+    color: var(--color-error, #b81e2c);
+    font-weight: 600;
+  }
+  html.dark-mode .study-schedule__error {
+    color: var(--color-error, #ff8585);
+  }
+  .study-schedule__modal-btns {
+    margin-top: 18px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .study-schedule__output {
+    margin-top: 22px;
+  }
+  .study-schedule__output[hidden] {
+    display: none;
+  }
+  .study-schedule__output h3 {
+    margin-top: 0;
+  }
+  .study-schedule__day {
+    margin: 14px 0;
+    padding: 14px 16px;
+    background: var(--color-surface, #fff);
+    border: 1px solid var(--color-border, #d8dde2);
+    border-radius: var(--radius-md, 8px);
+  }
+  html.dark-mode .study-schedule__day {
+    background: var(--color-surface, #1e1e1e);
+    border-color: var(--color-border, #444);
+  }
+  .study-schedule__day h4 {
+    margin: 0 0 8px 0;
+    font-size: 1.1em;
+    color: var(--color-primary, #2774AE);
+  }
+  html.dark-mode .study-schedule__day h4 {
+    color: var(--color-accent, #FFD100);
+  }
+  .study-schedule__day ul {
+    margin: 0;
+    padding-left: 22px;
+  }
+  .study-schedule__day li {
+    margin: 4px 0;
+  }
+  .study-schedule__type-badge {
+    display: inline-block;
+    margin-right: 6px;
+    padding: 2px 7px;
+    border-radius: 999px;
+    font-size: 0.85em;
+    font-weight: 600;
+    background: var(--color-accent, #FFD100);
+    color: var(--color-text-on-accent, #000);
+  }
+  .study-schedule__type-badge--gym {
+    background: var(--color-primary, #2774AE);
+    color: var(--color-text-on-primary, #fff);
+  }
+</style>
+{% endif %}

--- a/js/study-schedule.js
+++ b/js/study-schedule.js
@@ -1,0 +1,223 @@
+/*
+ * Study Schedule — SEBook course study planner.
+ *
+ * Wires up the "Schedule Study" button (rendered by _includes/study_schedule.html)
+ * to a modal, validates the chosen number of days (4–14), and generates a
+ * per-day plan from the list of tutorials and gym quizzes embedded in the page.
+ *
+ * Exposes a single global object `StudySchedule` with the pure schedule
+ * generator and the validation helper, so Playwright tests can exercise the
+ * scheduling logic without driving the DOM.
+ */
+(function () {
+  'use strict';
+
+  var MIN_DAYS = 4;
+  var MAX_DAYS = 14;
+
+  /**
+   * Validate a requested number of days.
+   * @param {*} value — any input.
+   * @returns {{ ok: true, days: number } | { ok: false, reason: string }}
+   */
+  function validateDays(value) {
+    var n = Number(value);
+    if (!Number.isFinite(n) || Math.floor(n) !== n) {
+      return { ok: false, reason: 'Please enter a whole number of days.' };
+    }
+    if (n < MIN_DAYS) {
+      return { ok: false, reason: 'Study plans must run for at least ' + MIN_DAYS + ' days.' };
+    }
+    if (n > MAX_DAYS) {
+      return { ok: false, reason: 'Study plans cannot exceed ' + MAX_DAYS + ' days (two weeks).' };
+    }
+    return { ok: true, days: n };
+  }
+
+  /**
+   * Split an ordered list of items into `days` buckets while keeping order.
+   * Earlier days receive an extra item when the list does not divide evenly.
+   *
+   * @param {Array} items — list of items to distribute.
+   * @param {number} days — bucket count (validated by caller).
+   * @returns {Array<Array>} an array of `days` arrays. Trailing buckets may be empty
+   *          if `items.length < days`, but the function still returns one bucket
+   *          per requested day so the UI can render the schedule.
+   */
+  function buildSchedule(items, days) {
+    var schedule = [];
+    for (var d = 0; d < days; d++) schedule.push([]);
+    if (!Array.isArray(items) || items.length === 0 || days <= 0) return schedule;
+
+    var base = Math.floor(items.length / days);
+    var remainder = items.length % days;
+    var cursor = 0;
+    for (var i = 0; i < days; i++) {
+      var size = base + (i < remainder ? 1 : 0);
+      for (var k = 0; k < size; k++) {
+        schedule[i].push(items[cursor++]);
+      }
+    }
+    return schedule;
+  }
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function renderSchedule(target, schedule) {
+    var html = '<h3>Your Study Plan</h3>';
+    for (var i = 0; i < schedule.length; i++) {
+      var dayItems = schedule[i];
+      html += '<div class="study-schedule__day" data-day-index="' + i + '">';
+      html += '<h4>Day ' + (i + 1) + '</h4>';
+      if (dayItems.length === 0) {
+        html += '<p><em>Rest day — review previous material.</em></p>';
+      } else {
+        html += '<ul>';
+        for (var j = 0; j < dayItems.length; j++) {
+          var item = dayItems[j];
+          var badgeClass = item.type === 'gym'
+            ? 'study-schedule__type-badge study-schedule__type-badge--gym'
+            : 'study-schedule__type-badge';
+          var badgeLabel = item.type === 'gym' ? 'Gym' : 'Tutorial';
+          html += '<li data-item-type="' + escapeHtml(item.type) + '">';
+          html += '<span class="' + badgeClass + '">' + badgeLabel + '</span>';
+          html += '<a href="' + escapeHtml(item.url) + '">' + escapeHtml(item.title) + '</a>';
+          html += '</li>';
+        }
+        html += '</ul>';
+      }
+      html += '</div>';
+    }
+    target.innerHTML = html;
+    target.hidden = false;
+  }
+
+  function readPlanData() {
+    var script = document.getElementById('study-schedule-data');
+    if (!script) return null;
+    try {
+      return JSON.parse(script.textContent || script.innerText || '');
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function showError(errorEl, message) {
+    errorEl.textContent = message;
+    errorEl.hidden = false;
+  }
+  function clearError(errorEl) {
+    errorEl.textContent = '';
+    errorEl.hidden = true;
+  }
+
+  // --- Modal plumbing ------------------------------------------------------
+  var lastFocusedBeforeModal = null;
+
+  function openModal(modal) {
+    lastFocusedBeforeModal = document.activeElement;
+    modal.hidden = false;
+    var input = document.getElementById('study-schedule-days');
+    if (input) input.focus();
+    document.addEventListener('keydown', onModalKeydown, true);
+  }
+
+  function closeModal(modal) {
+    modal.hidden = true;
+    document.removeEventListener('keydown', onModalKeydown, true);
+    if (lastFocusedBeforeModal && typeof lastFocusedBeforeModal.focus === 'function') {
+      lastFocusedBeforeModal.focus();
+    }
+  }
+
+  function onModalKeydown(e) {
+    if (e.key === 'Escape' || e.keyCode === 27) {
+      var modal = document.getElementById('study-schedule-modal');
+      if (modal && !modal.hidden) {
+        e.preventDefault();
+        closeModal(modal);
+      }
+    }
+  }
+
+  function init() {
+    var openBtn = document.getElementById('schedule-study-btn');
+    var modal = document.getElementById('study-schedule-modal');
+    var form = document.getElementById('study-schedule-form');
+    var input = document.getElementById('study-schedule-days');
+    var errorEl = document.getElementById('study-schedule-error');
+    var output = document.getElementById('study-plan-output');
+
+    // The include only renders when plan data is present. If any of these
+    // pieces are missing, the page isn't a study-schedule page — bail out.
+    if (!openBtn || !modal || !form || !input || !errorEl || !output) return;
+
+    openBtn.addEventListener('click', function () {
+      clearError(errorEl);
+      openModal(modal);
+    });
+
+    // Close handlers — buttons / backdrop carry `data-close-modal`.
+    modal.addEventListener('click', function (e) {
+      var target = e.target;
+      while (target && target !== modal) {
+        if (target.hasAttribute && target.hasAttribute('data-close-modal')) {
+          closeModal(modal);
+          return;
+        }
+        target = target.parentNode;
+      }
+    });
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var result = validateDays(input.value);
+      if (!result.ok) {
+        showError(errorEl, result.reason);
+        input.setAttribute('aria-invalid', 'true');
+        input.focus();
+        return;
+      }
+      input.removeAttribute('aria-invalid');
+      clearError(errorEl);
+
+      var data = readPlanData();
+      if (!data || !Array.isArray(data.items)) {
+        showError(errorEl, 'Could not load study plan data.');
+        return;
+      }
+
+      var schedule = buildSchedule(data.items, result.days);
+      renderSchedule(output, schedule);
+      closeModal(modal);
+
+      // Move focus into the freshly rendered plan so assistive tech reads it.
+      var planHeading = output.querySelector('h3');
+      if (planHeading) {
+        planHeading.setAttribute('tabindex', '-1');
+        planHeading.focus();
+      }
+    });
+  }
+
+  // Public surface for tests / other modules.
+  window.StudySchedule = {
+    MIN_DAYS: MIN_DAYS,
+    MAX_DAYS: MAX_DAYS,
+    validateDays: validateDays,
+    buildSchedule: buildSchedule
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/tests/study-schedule.spec.js
+++ b/tests/study-schedule.spec.js
@@ -1,0 +1,349 @@
+// @ts-check
+//
+// Tests for the CS 35L study schedule feature.
+//
+// Acceptance criteria under test (from the originating user story):
+//
+//   AC1 — Given that the user is on the CS 35L page, when the user clicks
+//         "Schedule Study", then they can select a given time period between
+//         four days and two weeks for their study plan.
+//
+//   AC2 — Given that the user has selected a valid time range, when the user
+//         clicks "Create Study Plan", then the SE Book will provide an
+//         organized list of what tutorials and Gym questions to do each day
+//         in their selected time range.
+//
+// Each acceptance criterion has its own describe-block, with the boundary
+// cases (4 days, 14 days, < 4, > 14, non-numeric) and the per-day rendering
+// covered as separate test cases.
+//
+const { test, expect } = require('@playwright/test');
+
+const CS35L_URL = '/SEBook/CS35L.html';
+
+async function openSchedulerModal(page) {
+  await page.locator('#schedule-study-btn').click();
+  await expect(page.locator('#study-schedule-modal')).toBeVisible();
+}
+
+test.describe('CS 35L Study Schedule — page entry point', () => {
+  test('the CS 35L page exposes a Schedule Study button', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    const btn = page.locator('#schedule-study-btn');
+    await expect(btn).toBeVisible();
+    await expect(btn).toHaveText(/Schedule Study/i);
+  });
+
+  test('the time-range modal is not visible before the button is clicked', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await expect(page.locator('#study-schedule-modal')).toBeHidden();
+  });
+});
+
+test.describe('AC1 — selecting a time period between four days and two weeks', () => {
+  test('clicking Schedule Study reveals a number-input limited to 4–14 days', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    const input = page.locator('#study-schedule-days');
+    await expect(input).toBeVisible();
+    await expect(input).toHaveAttribute('type', 'number');
+    await expect(input).toHaveAttribute('min', '4');
+    await expect(input).toHaveAttribute('max', '14');
+  });
+
+  test('an associated label explains the 4–14 day range', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    const label = page.locator('label[for="study-schedule-days"]');
+    await expect(label).toBeVisible();
+    await expect(label).toHaveText(/4.*14|four.*fourteen|four.*two weeks/i);
+  });
+
+  test('the minimum 4-day plan is accepted', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('4');
+    await page.locator('#create-study-plan-btn').click();
+
+    await expect(page.locator('#study-schedule-error')).toBeHidden();
+    await expect(page.locator('#study-plan-output')).toBeVisible();
+  });
+
+  test('the maximum 14-day (two-week) plan is accepted', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('14');
+    await page.locator('#create-study-plan-btn').click();
+
+    await expect(page.locator('#study-schedule-error')).toBeHidden();
+    await expect(page.locator('#study-plan-output')).toBeVisible();
+  });
+
+  test('3 days (below minimum) is rejected with an error message', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('3');
+    await page.locator('#create-study-plan-btn').click();
+
+    const error = page.locator('#study-schedule-error');
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/at least 4/i);
+    await expect(page.locator('#study-plan-output')).toBeHidden();
+  });
+
+  test('15 days (above maximum) is rejected with an error message', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('15');
+    await page.locator('#create-study-plan-btn').click();
+
+    const error = page.locator('#study-schedule-error');
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/14|two weeks/i);
+    await expect(page.locator('#study-plan-output')).toBeHidden();
+  });
+
+  test('non-integer values are rejected', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    // Submit via the form so the JS validator (not the browser's built-in
+    // numeric constraints) is the layer under test.
+    await page.evaluate(() => {
+      const input = /** @type {HTMLInputElement} */ (document.getElementById('study-schedule-days'));
+      input.value = '5.5';
+      document.getElementById('study-schedule-form').dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+    });
+
+    await expect(page.locator('#study-schedule-error')).toBeVisible();
+    await expect(page.locator('#study-plan-output')).toBeHidden();
+  });
+
+  test('Escape closes the modal without generating a plan', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#study-schedule-modal')).toBeHidden();
+    await expect(page.locator('#study-plan-output')).toBeHidden();
+  });
+});
+
+test.describe('AC2 — Create Study Plan renders an organized per-day list', () => {
+  test('the result is broken down into one section per chosen day', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('7');
+    await page.locator('#create-study-plan-btn').click();
+
+    const dayCards = page.locator('#study-plan-output .study-schedule__day');
+    await expect(dayCards).toHaveCount(7);
+
+    // Each card carries a "Day N" heading.
+    for (let i = 0; i < 7; i++) {
+      await expect(dayCards.nth(i).locator('h4')).toHaveText(new RegExp(`Day\\s+${i + 1}\\b`));
+    }
+  });
+
+  test('each plan lists at least one tutorial AND at least one gym question overall', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('7');
+    await page.locator('#create-study-plan-btn').click();
+
+    const tutorials = page.locator('#study-plan-output li[data-item-type="tutorial"]');
+    const gym = page.locator('#study-plan-output li[data-item-type="gym"]');
+
+    expect(await tutorials.count()).toBeGreaterThan(0);
+    expect(await gym.count()).toBeGreaterThan(0);
+  });
+
+  test('each scheduled item links to its tutorial or gym URL', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('5');
+    await page.locator('#create-study-plan-btn').click();
+
+    const links = page.locator('#study-plan-output li a');
+    const linkCount = await links.count();
+    expect(linkCount).toBeGreaterThan(0);
+
+    for (let i = 0; i < linkCount; i++) {
+      const href = await links.nth(i).getAttribute('href');
+      // Must be a real internal route — never empty, never "#".
+      expect(href).toBeTruthy();
+      expect(href).not.toBe('#');
+      expect(href.startsWith('/SEBook/') || href.startsWith('/se-gym/')).toBe(true);
+    }
+  });
+
+  test('every item from the data file ends up in the schedule exactly once', async ({ page }) => {
+    await page.goto(CS35L_URL);
+
+    // Use the (validated, observable) script tag the include emits to derive
+    // the spec — this guards against an item being silently dropped during
+    // distribution.
+    const expectedTitles = await page.evaluate(() => {
+      const data = JSON.parse(document.getElementById('study-schedule-data').textContent || '');
+      return data.items.map((i) => i.title);
+    });
+    expect(expectedTitles.length).toBeGreaterThan(0);
+
+    await openSchedulerModal(page);
+    await page.locator('#study-schedule-days').fill('7');
+    await page.locator('#create-study-plan-btn').click();
+
+    const scheduled = await page.locator('#study-plan-output li a').allTextContents();
+    expect(scheduled.sort()).toEqual(expectedTitles.slice().sort());
+  });
+
+  test('items keep their original course order across days', async ({ page }) => {
+    await page.goto(CS35L_URL);
+
+    const expectedTitles = await page.evaluate(() => {
+      const data = JSON.parse(document.getElementById('study-schedule-data').textContent || '');
+      return data.items.map((i) => i.title);
+    });
+
+    await openSchedulerModal(page);
+    await page.locator('#study-schedule-days').fill('6');
+    await page.locator('#create-study-plan-btn').click();
+
+    // Order across days/items must match the data file order (the pedagogical
+    // sequence): foundations first, design/testing/UML last.
+    const scheduled = await page.locator('#study-plan-output li a').allTextContents();
+    expect(scheduled).toEqual(expectedTitles);
+  });
+
+  test('different day choices produce different schedules', async ({ page }) => {
+    await page.goto(CS35L_URL);
+
+    async function buildFor(days) {
+      await page.locator('#schedule-study-btn').click();
+      await page.locator('#study-schedule-days').fill(String(days));
+      await page.locator('#create-study-plan-btn').click();
+      const cards = page.locator('#study-plan-output .study-schedule__day');
+      const count = await cards.count();
+      const sizes = [];
+      for (let i = 0; i < count; i++) {
+        sizes.push(await cards.nth(i).locator('li').count());
+      }
+      return sizes;
+    }
+
+    const fourDay = await buildFor(4);
+    const fourteenDay = await buildFor(14);
+
+    expect(fourDay).toHaveLength(4);
+    expect(fourteenDay).toHaveLength(14);
+    expect(fourDay).not.toEqual(fourteenDay);
+
+    // 4-day plan must pack more items per day than the 14-day plan.
+    const fourDayMax = Math.max(...fourDay);
+    const fourteenDayMax = Math.max(...fourteenDay);
+    expect(fourDayMax).toBeGreaterThan(fourteenDayMax);
+  });
+
+  test('each day card distinguishes Tutorials from Gym items via a labeled badge', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('4');
+    await page.locator('#create-study-plan-btn').click();
+
+    // At least one of each kind should be flagged visibly so the learner can
+    // tell hands-on tutorials apart from quiz review.
+    await expect(page.locator('#study-plan-output .study-schedule__type-badge').first()).toBeVisible();
+    await expect(page.locator('#study-plan-output .study-schedule__type-badge--gym').first()).toBeVisible();
+  });
+
+  test('submitting closes the modal and surfaces the plan in place', async ({ page }) => {
+    await page.goto(CS35L_URL);
+    await openSchedulerModal(page);
+
+    await page.locator('#study-schedule-days').fill('5');
+    await page.locator('#create-study-plan-btn').click();
+
+    await expect(page.locator('#study-schedule-modal')).toBeHidden();
+    await expect(page.locator('#study-plan-output')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure-function tests for the schedule generator.
+//
+// The DOM tests above pin down the user-facing behavior. The pure-function
+// tests below pin down the distribution algorithm itself so a refactor that
+// breaks the contract fails loudly with a precise diff, not as a flaky end-
+// to-end mismatch.
+// ---------------------------------------------------------------------------
+test.describe('StudySchedule.buildSchedule — distribution invariants', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(CS35L_URL);
+    // The page already loads js/study-schedule.js — wait for the public API.
+    await page.waitForFunction(() => !!window.StudySchedule);
+  });
+
+  test('returns exactly `days` buckets', async ({ page }) => {
+    const sizes = await page.evaluate(() => {
+      const items = Array.from({ length: 12 }, (_, i) => ({ title: 'i' + i, type: 'tutorial', url: '/x' }));
+      return [4, 7, 10, 14].map((d) => window.StudySchedule.buildSchedule(items, d).length);
+    });
+    expect(sizes).toEqual([4, 7, 10, 14]);
+  });
+
+  test('preserves the full item list (no drops, no duplicates)', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const items = Array.from({ length: 12 }, (_, i) => ({ title: 't' + i, type: 'tutorial', url: '/' + i }));
+      const flat = window.StudySchedule.buildSchedule(items, 5).flat();
+      return { len: flat.length, titles: flat.map((x) => x.title) };
+    });
+    expect(result.len).toBe(12);
+    expect(result.titles).toEqual(['t0', 't1', 't2', 't3', 't4', 't5', 't6', 't7', 't8', 't9', 't10', 't11']);
+  });
+
+  test('distributes the extras to the earliest days (largest-first front-loading)', async ({ page }) => {
+    const bucketSizes = await page.evaluate(() => {
+      const items = Array.from({ length: 13 }, (_, i) => ({ title: 't' + i, type: 'tutorial', url: '/' + i }));
+      return window.StudySchedule.buildSchedule(items, 5).map((bucket) => bucket.length);
+    });
+    // 13 items / 5 days = 2 base + 3 remainder, so the first three days have
+    // 3 items and the last two have 2.
+    expect(bucketSizes).toEqual([3, 3, 3, 2, 2]);
+  });
+
+  test('validateDays accepts 4–14 and rejects everything else', async ({ page }) => {
+    const verdicts = await page.evaluate(() => {
+      const v = window.StudySchedule.validateDays;
+      return {
+        four: v(4).ok,
+        fourteen: v(14).ok,
+        seven: v(7).ok,
+        three: v(3).ok,
+        fifteen: v(15).ok,
+        fractional: v(5.5).ok,
+        text: v('abc').ok,
+        empty: v('').ok,
+      };
+    });
+    expect(verdicts).toEqual({
+      four: true,
+      fourteen: true,
+      seven: true,
+      three: false,
+      fifteen: false,
+      fractional: false,
+      text: false,
+      empty: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **Schedule Study** button + modal to the CS 35L SEBook page that lets a student pick a window between **4 days and 2 weeks** and receive an organized per-day list of tutorials and SE Gym questions to work through.
- Schedule items, source of truth, live in `_data/study_plans/CS35L.yml`; the JS distribution algorithm (`window.StudySchedule.buildSchedule`) front-loads remainder items to earlier days while preserving the pedagogical order from the YAML.
- 22 Playwright tests under `tests/study-schedule.spec.js` cover the user story's acceptance criteria, boundary cases, and the pure-function distribution invariants.

## User story
> As a CS 35L student, I want the SE Book to give me a study schedule so that I don't have to worry about what to study in which order.
>
> 1. Given the user is on the CS 35L page, when they click Schedule Study, then they can select a time period between four days and two weeks.
> 2. Given a valid time range, when they click Create Study Plan, then the SE Book provides an organized list of tutorials and Gym questions to do each day.

## What changed
| File | Why |
| --- | --- |
| `_data/study_plans/CS35L.yml` | Ordered list of tutorials + gym quizzes the planner schedules. |
| `_includes/study_schedule.html` | "Schedule Study" button, modal with a 4–14 day number picker, plan output region. Inline CSS uses the existing design tokens so light + dark mode both work. |
| `js/study-schedule.js` | Modal plumbing, input validation (4–14, integer only), schedule generation, per-day rendering. Exposes `window.StudySchedule.{ validateDays, buildSchedule, MIN_DAYS, MAX_DAYS }` so tests can pin down the distribution algorithm directly. |
| `_includes/scripts.html` | Loads the new JS module site-wide (so the API is available on any page that uses the include in the future). |
| `SEBook/CS35L.md` | Drops in `{% include study_schedule.html plan=\"CS35L\" %}`. |
| `tests/study-schedule.spec.js` | New spec; see test plan. |

## Test plan
- [x] AC1 — 4-day and 14-day plans accepted (boundary tests).
- [x] AC1 — 3-day and 15-day inputs rejected with a user-facing error message.
- [x] AC1 — Fractional / non-numeric inputs rejected.
- [x] AC1 — Modal dismisses on Escape without generating a plan.
- [x] AC2 — Rendered plan has exactly N day cards for N days.
- [x] AC2 — Plan contains at least one tutorial and one gym item overall.
- [x] AC2 — Every item from the YAML appears exactly once across the days.
- [x] AC2 — Items keep their original pedagogical order across days.
- [x] AC2 — Each item is a real internal link (no `#` placeholders).
- [x] AC2 — Different day counts produce different schedules (4-day packs more per day than 14-day).
- [x] AC2 — Each item carries a Tutorial / Gym type badge.
- [x] Algorithm — `buildSchedule(items, days)` returns exactly `days` buckets, no drops, no duplicates, remainder distributed to the earliest days.
- [x] Algorithm — `validateDays` accepts the full inclusive 4–14 range and rejects everything else.
- [x] All 22 tests green: `JEKYLL_PORT=4003 npx playwright test tests/study-schedule.spec.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)