### PR TITLE
Fix SVG preview generation and difficult gym visibility

### DIFF
--- a/_includes/se-gym-hero.svg
+++ b/_includes/se-gym-hero.svg
@@ -49,7 +49,7 @@
     <radialGradient id="hero-stage-glow-{{ hero_variant }}" cx=".5" cy=".18" r=".78"><stop offset="0" stop-color="#edf7ff" stop-opacity=".16"/><stop offset=".42" stop-color="#82bde8" stop-opacity=".08"/><stop offset="1" stop-color="#081325" stop-opacity="0"/></radialGradient>
     <radialGradient id="brain-glow-{{ hero_variant }}" cx=".5" cy=".5" r=".5"><stop offset="0" stop-color="#FFE470" stop-opacity=".55"/><stop offset=".55" stop-color="#FFD100" stop-opacity=".18"/><stop offset="1" stop-color="#FFD100" stop-opacity="0"/></radialGradient>
     <linearGradient id="hair-grad-{{ hero_variant }}" x1="0" y1="0" x2="0" y2="1">
-      <!-- The contrast-aware --hero-hair-light token is intentionally desaturated
+      <!-- The contrast-aware hero-hair-light token is intentionally desaturated
            (e.g. #776c64 for near-black hair), which read as a flat gray crown
            streak when used at full strength. color-mix re-warms the highlight
            toward the user's own hair base — safe for any hair color, blonde to

--- a/scripts/build_se_gym_hero_choice_previews.js
+++ b/scripts/build_se_gym_hero_choice_previews.js
@@ -295,6 +295,16 @@ async function main() {
         for (const option of group.options) {
           const svg = source.cloneNode(true);
           svg.querySelectorAll('animate, animateTransform').forEach((node) => node.remove());
+          // Standalone `<img src=*.svg>` previews are parsed as strict XML, so an
+          // authoring comment that contains a double hyphen (e.g. a CSS custom
+          // property name like `--hero-hair-light`) makes the whole file fail to
+          // render as a broken image. Inline SVG tolerates it via the lenient HTML
+          // parser, which is why it only shows up in the pre-rendered thumbnails.
+          // Comments serve no purpose in the rendered preview, so drop them all.
+          const commentWalker = document.createTreeWalker(svg, NodeFilter.SHOW_COMMENT);
+          const comments = [];
+          while (commentWalker.nextNode()) comments.push(commentWalker.currentNode);
+          comments.forEach((node) => node.remove());
           const state = representativeState(definition, option.value);
           window.HeroAvatar.applyToSvg(svg, state);
           measureHost.appendChild(svg);
@@ -317,6 +327,24 @@ async function main() {
       }
     }
     measureHost.remove();
+
+    // Fail loudly if any serialized preview is not well-formed XML. Browsers load
+    // `<img src=*.svg>` through a strict XML parser, so a malformed thumbnail
+    // silently renders as a broken image at runtime (no console error, no 404).
+    // Re-parsing here turns that into a build-time error instead.
+    const malformed = [];
+    const parser = new DOMParser();
+    for (const preview of previews) {
+      const doc = parser.parseFromString(preview.svg, 'image/svg+xml');
+      const error = doc.querySelector('parsererror');
+      if (error) {
+        malformed.push(`${preview.key}/${preview.value}: ${error.textContent.replace(/\s+/g, ' ').trim()}`);
+      }
+    }
+    if (malformed.length) {
+      throw new Error('Malformed SVG previews:\n' + malformed.join('\n'));
+    }
+
     return previews;
   }, {
     representativeSkin: REPRESENTATIVE_PREVIEW_SKIN,

--- a/se-gym.html
+++ b/se-gym.html
@@ -1429,9 +1429,17 @@ layout: sebook
         }
 
         // ---- Difficult Questions Gym ----
+        // Gate on the gym being active, not just performance tracking: the
+        // section (with its "Start Hard Workout" button) lives inside
+        // #gym-entrance-sections, which JS marks `inert` while the gym is
+        // inactive. Showing it then renders a button that looks enabled but
+        // cannot be clicked. Tracking can outlive an active gym (disabling the
+        // gym doesn't clear stats), so without this check the dead button leaks
+        // through whenever a lapsed user still has difficult cards on file.
         var difficultCards = [];
         var hasDifficult = false;
-        if (PersonalGym.isAnalyzePerformance()) {
+        var difficultGymAvailable = PersonalGym.isPersonalGymActive() && PersonalGym.isAnalyzePerformance();
+        if (difficultGymAvailable) {
           difficultCards = getDifficultCards().filter(function (dc) {
             return passesDifficultyFilter(dc.data);
           });
@@ -1440,7 +1448,7 @@ layout: sebook
 
         var difficultInGym = gym.some(function (d) { return d.type === 'difficult' && d.id === 'difficult'; });
 
-        if (PersonalGym.isAnalyzePerformance() && hasDifficult) {
+        if (difficultGymAvailable && hasDifficult) {
           showElement(difficultSection);
           difficultCountEl.textContent = '(' + difficultCards.length + ' cards)';
           difficultAddBtn.classList.toggle('in-gym', difficultInGym);

--- a/tests/se-gym.spec.js
+++ b/tests/se-gym.spec.js
@@ -1848,6 +1848,33 @@ test.describe('Personal Gym - Performance Tracking', () => {
     await expect(page.locator('#difficult-gym-section')).toBeHidden();
   });
 
+  test('difficult questions section stays hidden while the gym is inactive even with difficult cards', async ({ page, context }) => {
+    // Tracking outlives an active gym (disabling the gym keeps stats), so a
+    // lapsed user can have difficult cards on file with the gym switched off.
+    // The section lives inside the `inert` entrance area while inactive, so
+    // surfacing its "Start Hard Workout" button there would render a control
+    // that looks enabled but cannot be clicked. It must stay hidden until the
+    // gym is reactivated.
+    await setCookie(context, 'analyze-performance', 'true'); // tracking on, gym NOT active
+    await page.goto(GYM_URL);
+    await page.evaluate(() => {
+      const quizId = 'design_pattern_singleton';
+      const stats = {};
+      stats[`quiz:${quizId}:1`] = { seen: 10, correct: 1 };
+      stats[`quiz:${quizId}:2`] = { seen: 10, correct: 1 };
+      PersonalGym.saveStats(stats);
+    });
+    await page.reload();
+
+    await expect(page.locator('#difficult-gym-section')).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Start Hard Workout' })).toBeHidden();
+
+    // Reactivating the gym surfaces the section and an enabled, clickable button.
+    await page.locator(ACTIVATE_TOGGLE_SLIDER).click();
+    await expect(page.locator('#difficult-gym-section')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Start Hard Workout' })).toBeEnabled();
+  });
+
   test('difficult questions appear when stats exceed threshold', async ({ page, context }) => {
     // Marker: this test renders the otherwise-hidden Difficult Questions
     // section, which is the only way the audit can sweep it.


### PR DESCRIPTION
## Summary

This PR fixes two issues: (1) SVG preview generation failing due to XML parsing errors from comments containing double hyphens, and (2) the difficult questions gym section incorrectly showing when the gym is inactive but performance tracking is enabled.

## Key Changes

**SVG Preview Generation (`scripts/build_se_gym_hero_choice_previews.js`)**
- Strip all XML comments from generated SVG previews before serialization. Comments containing double hyphens (e.g., CSS custom property names like `--hero-hair-light`) cause strict XML parsers to reject the file, resulting in broken image previews at runtime.
- Add build-time validation that re-parses all serialized previews as XML to catch malformed SVG early, converting silent runtime failures into build errors.

**Difficult Gym Visibility (`se-gym.html`)**
- Gate the difficult questions section on both `PersonalGymActive()` AND `isAnalyzePerformance()`, not just performance tracking alone.
- This prevents the "Start Hard Workout" button from appearing inside the `inert` entrance area when the gym is inactive. Since performance tracking stats persist even after disabling the gym, lapsed users could have difficult cards on file but see a visually enabled button that cannot be clicked.

**Test Coverage (`tests/se-gym.spec.js`)**
- Add test verifying the difficult section stays hidden while the gym is inactive, even with difficult cards in stats.
- Confirm the section and button become visible and enabled when the gym is reactivated.

**SVG Template (`_includes/se-gym-hero.svg`)**
- Fix authoring comment to remove double hyphen that was triggering the XML parsing issue.

## Implementation Details

The SVG comment stripping uses a `TreeWalker` to collect all comment nodes before removal, avoiding iterator invalidation. The validation parser uses `DOMParser` with `'image/svg+xml'` MIME type to trigger strict XML parsing, matching how browsers load `<img src=*.svg>` resources.

https://claude.ai/code/session_01QU5tr3hStb12YcYuREXk73