### PR TITLE
SE Gym: per-deck practice buttons, always-available quick starts, dark-mode thumbnail colors

### DIFF
--- a/_includes/se-gym-hero.svg
+++ b/_includes/se-gym-hero.svg
@@ -49,7 +49,7 @@
     <radialGradient id="hero-stage-glow-{{ hero_variant }}" cx=".5" cy=".18" r=".78"><stop offset="0" stop-color="#edf7ff" stop-opacity=".16"/><stop offset=".42" stop-color="#82bde8" stop-opacity=".08"/><stop offset="1" stop-color="#081325" stop-opacity="0"/></radialGradient>
     <radialGradient id="brain-glow-{{ hero_variant }}" cx=".5" cy=".5" r=".5"><stop offset="0" stop-color="#FFE470" stop-opacity=".55"/><stop offset=".55" stop-color="#FFD100" stop-opacity=".18"/><stop offset="1" stop-color="#FFD100" stop-opacity="0"/></radialGradient>
     <linearGradient id="hair-grad-{{ hero_variant }}" x1="0" y1="0" x2="0" y2="1">
-      <!-- The contrast-aware --hero-hair-light token is intentionally desaturated
+      <!-- The contrast-aware hero-hair-light token is intentionally desaturated
            (e.g. #776c64 for near-black hair), which read as a flat gray crown
            streak when used at full strength. color-mix re-warms the highlight
            toward the user's own hair base — safe for any hair color, blonde to

--- a/css/se-gym.css
+++ b/css/se-gym.css
@@ -1083,9 +1083,14 @@
     }
     html.dark-mode .hero-cust-choice-preview .se-gym-hero-svg,
     html.dark-mode .hero-cust-choice-preview .se-gym-hero-choice-preview-img {
+      /* portfolio.css inverts every `.post-content img[src$=".svg"]` / svg in dark
+         mode for line-art diagrams. These thumbnails are full-color avatar art, so
+         that inversion turns skin/hair/suit into their negatives. `!important`
+         beats the (un-flagged) portfolio rule and restores the true colors with a
+         soft well shadow instead. */
       filter:
         drop-shadow(0 0.05em 0.05em rgba(0, 0, 0, 0.35))
-        drop-shadow(0 0 0.08em rgba(255, 255, 255, 0.2));
+        drop-shadow(0 0 0.08em rgba(255, 255, 255, 0.2)) !important;
     }
     html.dark-mode .hero-cust-choice-button[data-choice-pending="true"] .hero-cust-choice-preview::before {
       background:
@@ -3240,6 +3245,47 @@
       border-color: #dc3545;
     }
 
+    /* Per-deck targeted-practice launcher. Lives next to the add/remove button so
+       a deck can be drilled without changing the gym selection. */
+    .gym-item-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+
+    .gym-practice-btn {
+      background: #1f7a3d;
+      border: 2px solid #145c2c;
+      border-radius: var(--radius-circle, 50%);
+      width: 38px;
+      height: 38px;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: #ffffff;
+      font-size: 16px;
+      transition: border-color 0.2s, color 0.2s, background 0.2s, box-shadow 0.2s;
+      flex-shrink: 0;
+      padding: 0;
+      box-shadow: 0 3px 8px rgba(0, 59, 92, 0.1);
+    }
+
+    .gym-practice-btn:hover {
+      background: #19682f;
+      border-color: #0f4a23;
+      box-shadow: 0 5px 12px rgba(20, 92, 44, 0.28);
+    }
+
+    .gym-practice-btn:disabled {
+      background: #c5d3c8;
+      border-color: #aab9ad;
+      color: #51604f;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
     .empty-gym-msg {
       color: #4b5563;
       font-style: italic;
@@ -4977,6 +5023,26 @@
       background: #ff8585;
       border-color: #ffd3d0;
       color: #0a0a14;
+    }
+
+    html.dark-mode .gym-practice-btn {
+      background: #46c46e;
+      border-color: #6fe093;
+      color: #06210f;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.38);
+    }
+
+    html.dark-mode .gym-practice-btn:hover {
+      background: #58d57f;
+      border-color: #8defa9;
+      color: #06210f;
+    }
+
+    html.dark-mode .gym-practice-btn:disabled {
+      background: #2c3b30;
+      border-color: #3f5244;
+      color: #8a988c;
+      box-shadow: none;
     }
 
     html.dark-mode .workout-quiz-card {

--- a/scripts/build_se_gym_hero_choice_previews.js
+++ b/scripts/build_se_gym_hero_choice_previews.js
@@ -295,6 +295,16 @@ async function main() {
         for (const option of group.options) {
           const svg = source.cloneNode(true);
           svg.querySelectorAll('animate, animateTransform').forEach((node) => node.remove());
+          // Standalone `<img src=*.svg>` previews are parsed as strict XML, so an
+          // authoring comment that contains a double hyphen (e.g. a CSS custom
+          // property name like `--hero-hair-light`) makes the whole file fail to
+          // render as a broken image. Inline SVG tolerates it via the lenient HTML
+          // parser, which is why it only shows up in the pre-rendered thumbnails.
+          // Comments serve no purpose in the rendered preview, so drop them all.
+          const commentWalker = document.createTreeWalker(svg, NodeFilter.SHOW_COMMENT);
+          const comments = [];
+          while (commentWalker.nextNode()) comments.push(commentWalker.currentNode);
+          comments.forEach((node) => node.remove());
           const state = representativeState(definition, option.value);
           window.HeroAvatar.applyToSvg(svg, state);
           measureHost.appendChild(svg);
@@ -317,6 +327,24 @@ async function main() {
       }
     }
     measureHost.remove();
+
+    // Fail loudly if any serialized preview is not well-formed XML. Browsers load
+    // `<img src=*.svg>` through a strict XML parser, so a malformed thumbnail
+    // silently renders as a broken image at runtime (no console error, no 404).
+    // Re-parsing here turns that into a build-time error instead.
+    const malformed = [];
+    const parser = new DOMParser();
+    for (const preview of previews) {
+      const doc = parser.parseFromString(preview.svg, 'image/svg+xml');
+      const error = doc.querySelector('parsererror');
+      if (error) {
+        malformed.push(`${preview.key}/${preview.value}: ${error.textContent.replace(/\s+/g, ' ').trim()}`);
+      }
+    }
+    if (malformed.length) {
+      throw new Error('Malformed SVG previews:\n' + malformed.join('\n'));
+    }
+
     return previews;
   }, {
     representativeSkin: REPRESENTATIVE_PREVIEW_SKIN,

--- a/se-gym.html
+++ b/se-gym.html
@@ -347,9 +347,14 @@ layout: sebook
               <span class="gym-item-count">({{ qdata.questions | size }} questions)</span>
               <p class="gym-item-desc">{{ qdata.description }}</p>
             </div>
-            <button class="gym-add-btn" data-type="quiz" data-id="{{ qid }}" data-original-title="Add to gym" aria-label="Add {{ qdata.title | escape }} to gym">
-              <i class="fa-solid fa-plus" aria-hidden="true"></i>
-            </button>
+            <div class="gym-item-actions">
+              <button class="gym-practice-btn" data-type="quiz" data-id="{{ qid }}" data-original-title="Start targeted practice" aria-label="Start targeted practice for {{ qdata.title | escape }}">
+                <i class="fa-solid fa-dumbbell" aria-hidden="true"></i>
+              </button>
+              <button class="gym-add-btn" data-type="quiz" data-id="{{ qid }}" data-original-title="Add to gym" aria-label="Add {{ qdata.title | escape }} to gym">
+                <i class="fa-solid fa-plus" aria-hidden="true"></i>
+              </button>
+            </div>
           </div>
           {% elsif qdata.decks and qdata.active != false %}
           {% assign meta_count = 0 %}
@@ -366,9 +371,14 @@ layout: sebook
               <span class="gym-item-count">({{ meta_count }} questions)</span>
               <p class="gym-item-desc">{{ qdata.description }}</p>
             </div>
-            <button class="gym-add-btn" data-type="quiz" data-id="{{ qid }}" data-original-title="Add to gym" aria-label="Add {{ qdata.title | escape }} to gym">
-              <i class="fa-solid fa-plus" aria-hidden="true"></i>
-            </button>
+            <div class="gym-item-actions">
+              <button class="gym-practice-btn" data-type="quiz" data-id="{{ qid }}" data-original-title="Start targeted practice" aria-label="Start targeted practice for {{ qdata.title | escape }}">
+                <i class="fa-solid fa-dumbbell" aria-hidden="true"></i>
+              </button>
+              <button class="gym-add-btn" data-type="quiz" data-id="{{ qid }}" data-original-title="Add to gym" aria-label="Add {{ qdata.title | escape }} to gym">
+                <i class="fa-solid fa-plus" aria-hidden="true"></i>
+              </button>
+            </div>
           </div>
           {% endif %}
           {% endfor %}
@@ -387,9 +397,14 @@ layout: sebook
               <span class="gym-item-count">({{ fcdata.cards | size }} cards)</span>
               <p class="gym-item-desc">{{ fcdata.description }}</p>
             </div>
-            <button class="gym-add-btn" data-type="flashcard" data-id="{{ fcid }}" data-original-title="Add to gym" aria-label="Add {{ fcdata.title | escape }} to gym">
-              <i class="fa-solid fa-plus" aria-hidden="true"></i>
-            </button>
+            <div class="gym-item-actions">
+              <button class="gym-practice-btn" data-type="flashcard" data-id="{{ fcid }}" data-original-title="Start targeted practice" aria-label="Start targeted practice for {{ fcdata.title | escape }}">
+                <i class="fa-solid fa-dumbbell" aria-hidden="true"></i>
+              </button>
+              <button class="gym-add-btn" data-type="flashcard" data-id="{{ fcid }}" data-original-title="Add to gym" aria-label="Add {{ fcdata.title | escape }} to gym">
+                <i class="fa-solid fa-plus" aria-hidden="true"></i>
+              </button>
+            </div>
           </div>
           {% elsif fcdata.decks and fcdata.active != false %}
           {% assign meta_count = 0 %}
@@ -406,9 +421,14 @@ layout: sebook
               <span class="gym-item-count">({{ meta_count }} cards)</span>
               <p class="gym-item-desc">{{ fcdata.description }}</p>
             </div>
-            <button class="gym-add-btn" data-type="flashcard" data-id="{{ fcid }}" data-original-title="Add to gym" aria-label="Add {{ fcdata.title | escape }} to gym">
-              <i class="fa-solid fa-plus" aria-hidden="true"></i>
-            </button>
+            <div class="gym-item-actions">
+              <button class="gym-practice-btn" data-type="flashcard" data-id="{{ fcid }}" data-original-title="Start targeted practice" aria-label="Start targeted practice for {{ fcdata.title | escape }}">
+                <i class="fa-solid fa-dumbbell" aria-hidden="true"></i>
+              </button>
+              <button class="gym-add-btn" data-type="flashcard" data-id="{{ fcid }}" data-original-title="Add to gym" aria-label="Add {{ fcdata.title | escape }} to gym">
+                <i class="fa-solid fa-plus" aria-hidden="true"></i>
+              </button>
+            </div>
           </div>
           {% endif %}
           {% endfor %}
@@ -974,13 +994,6 @@ layout: sebook
       function setStartButtonsDisabled(disabled) {
         startButtons.forEach(function (button) {
           button.disabled = disabled;
-        });
-      }
-
-      function setSavedWorkoutStartBlock(disabled) {
-        ['start-daily-workout-btn', 'start-review-btn', 'start-hard-workout-btn'].forEach(function (id) {
-          var button = document.getElementById(id);
-          if (button) button.disabled = disabled;
         });
       }
 
@@ -1561,8 +1574,12 @@ layout: sebook
         } else {
           gymSummary.textContent = '';
         }
+        // A pending saved workout still disables the prominent main "Start
+        // Workout" buttons (paired with the adjacent Resume/Discard prompt), but
+        // the quick-start launchers (Today's Workout, Start Review, Start Hard
+        // Workout) and the per-deck practice buttons stay available — they
+        // replace the saved checkpoint when started (see beginWorkout).
         setStartButtonsDisabled(!PersonalGym.isPersonalGymActive() || !hasAnything || drawCount === 0 || hasSavedWorkout);
-        setSavedWorkoutStartBlock(hasSavedWorkout);
       }
 
       // ---- Difficult questions helper ----
@@ -1668,10 +1685,17 @@ layout: sebook
 
       // Shared workout-start sequence for every entry point (normal, hard,
       // review, daily, direct links). Returns false if there are no cards.
-      function beginWorkout(cards) {
+      function beginWorkout(cards, options) {
+        options = options || {};
         workoutIsDaily = false;
         if (!cards || cards.length === 0) return false;
-        if (!challengeTarget && updateSavedWorkoutResume()) {
+        // A pending saved workout normally blocks a fresh start so the user
+        // resumes or discards it first (this guards the prominent main
+        // "Start Workout" button). Targeted and quick-start practice — hard,
+        // per-deck, daily, review — pass replaceSaved to stay always available;
+        // the saveWorkoutProgress(0) below then overwrites the slot so the new
+        // session cleanly replaces the old checkpoint.
+        if (!challengeTarget && !options.replaceSaved && updateSavedWorkoutResume()) {
           announceGymStatus('Resume or discard the saved workout before starting a new one.');
           return false;
         }
@@ -2069,6 +2093,19 @@ layout: sebook
         });
       });
 
+      // Per-deck targeted practice: start a workout for just this quiz/flashcard
+      // set without touching the saved gym selection. Delegated so it also covers
+      // any library rows that get re-rendered. replaceSaved keeps it available
+      // even when a saved workout is pending (it replaces that checkpoint).
+      document.addEventListener('click', function (e) {
+        var btn = e.target && e.target.closest ? e.target.closest('.gym-practice-btn') : null;
+        if (!btn || btn.disabled) return;
+        var type = btn.getAttribute('data-type');
+        var id = btn.getAttribute('data-id');
+        if (!type || !id) return;
+        startWorkout({ sourceGym: [{ type: type, id: id }], requireActive: false, replaceSaved: true });
+      });
+
       // Bind difficult gym add button
       difficultAddBtn.addEventListener('click', function () {
         PersonalGym.toggleGym('difficult', 'difficult');
@@ -2197,7 +2234,7 @@ layout: sebook
         });
         challengeTarget = null;
         if (hardWorkoutCards.length === 0) return;
-        beginWorkout(hardWorkoutCards);
+        beginWorkout(hardWorkoutCards, { replaceSaved: true });
       });
 
       // ---- Workout of the Day / Due Review / Topic-Mastery practice / enable tracking ----
@@ -2212,7 +2249,7 @@ layout: sebook
             return;
           }
           // beginWorkout() resets workoutIsDaily, so flag this workout AFTER it starts.
-          if (beginWorkout(dailyWorkout)) {
+          if (beginWorkout(dailyWorkout, { replaceSaved: true })) {
             workoutIsDaily = true;
             saveWorkoutProgress(0);
           }
@@ -2234,7 +2271,7 @@ layout: sebook
             announceGymStatus('No due cards match your current difficulty filter. Adjust the filter and try again.');
             return;
           }
-          beginWorkout(due);
+          beginWorkout(due, { replaceSaved: true });
         });
       }
 
@@ -2511,7 +2548,7 @@ layout: sebook
           announceGymStatus('No cards match your current gym and difficulty filter.');
           return;
         }
-        beginWorkout(cards);
+        beginWorkout(cards, { replaceSaved: !!(options && options.replaceSaved) });
       }
 
       function showWorkoutCard(index) {

--- a/se-gym.html
+++ b/se-gym.html
@@ -1429,9 +1429,17 @@ layout: sebook
         }
 
         // ---- Difficult Questions Gym ----
+        // Gate on the gym being active, not just performance tracking: the
+        // section (with its "Start Hard Workout" button) lives inside
+        // #gym-entrance-sections, which JS marks `inert` while the gym is
+        // inactive. Showing it then renders a button that looks enabled but
+        // cannot be clicked. Tracking can outlive an active gym (disabling the
+        // gym doesn't clear stats), so without this check the dead button leaks
+        // through whenever a lapsed user still has difficult cards on file.
         var difficultCards = [];
         var hasDifficult = false;
-        if (PersonalGym.isAnalyzePerformance()) {
+        var difficultGymAvailable = PersonalGym.isPersonalGymActive() && PersonalGym.isAnalyzePerformance();
+        if (difficultGymAvailable) {
           difficultCards = getDifficultCards().filter(function (dc) {
             return passesDifficultyFilter(dc.data);
           });
@@ -1440,7 +1448,7 @@ layout: sebook
 
         var difficultInGym = gym.some(function (d) { return d.type === 'difficult' && d.id === 'difficult'; });
 
-        if (PersonalGym.isAnalyzePerformance() && hasDifficult) {
+        if (difficultGymAvailable && hasDifficult) {
           showElement(difficultSection);
           difficultCountEl.textContent = '(' + difficultCards.length + ' cards)';
           difficultAddBtn.classList.toggle('in-gym', difficultInGym);

--- a/tests/se-gym-hero-avatar.spec.js
+++ b/tests/se-gym-hero-avatar.spec.js
@@ -932,6 +932,29 @@ test.describe('SE Gym Hero Avatar Customizer', () => {
       .toHaveAttribute('src', '/assets/se-gym-hero-choice-previews/accessory-headset-mic.svg');
   });
 
+  test('Production choice thumbnails keep their true colors in dark mode (no SVG inversion)', async ({ page }) => {
+    await page.addInitScript(() => { document.documentElement.classList.add('dark-mode'); });
+    await installStaticChoicePreviewManifest(page, {
+      hairStyle: { long: 'hair-style-long.svg' },
+    });
+
+    await page.goto(GYM_URL);
+    await page.evaluate(() => { document.documentElement.classList.add('dark-mode'); });
+    await activatePersonalGym(page);
+    await page.getByRole('button', { name: 'Customize Hero' }).click();
+
+    const hairImage = page.getByRole('button', { name: 'Choose Hair style: Long and flowing' })
+      .locator('[data-hero-choice-preview-img]');
+    await expect(hairImage).toHaveAttribute('src', '/assets/se-gym-hero-choice-previews/hair-style-long.svg');
+
+    // portfolio.css inverts every `.post-content img[src$=".svg"]` in dark mode
+    // for line-art diagrams. These thumbnails are full-color avatar art, so that
+    // inversion would render skin/hair/suit as their negatives — the per-component
+    // override in se-gym.css must win and keep the colors intact.
+    const filter = await hairImage.evaluate((img) => getComputedStyle(img).filter);
+    expect(filter, `thumbnail must opt out of the dark-mode SVG inversion (got "${filter}")`).not.toContain('invert');
+  });
+
   test('Large scroll jumps drop thumbnail work for options that moved far away', async ({ page }) => {
     await useDefaultSavedHero(page);
     await page.goto(GYM_URL);

--- a/tests/se-gym.spec.js
+++ b/tests/se-gym.spec.js
@@ -1848,6 +1848,33 @@ test.describe('Personal Gym - Performance Tracking', () => {
     await expect(page.locator('#difficult-gym-section')).toBeHidden();
   });
 
+  test('difficult questions section stays hidden while the gym is inactive even with difficult cards', async ({ page, context }) => {
+    // Tracking outlives an active gym (disabling the gym keeps stats), so a
+    // lapsed user can have difficult cards on file with the gym switched off.
+    // The section lives inside the `inert` entrance area while inactive, so
+    // surfacing its "Start Hard Workout" button there would render a control
+    // that looks enabled but cannot be clicked. It must stay hidden until the
+    // gym is reactivated.
+    await setCookie(context, 'analyze-performance', 'true'); // tracking on, gym NOT active
+    await page.goto(GYM_URL);
+    await page.evaluate(() => {
+      const quizId = 'design_pattern_singleton';
+      const stats = {};
+      stats[`quiz:${quizId}:1`] = { seen: 10, correct: 1 };
+      stats[`quiz:${quizId}:2`] = { seen: 10, correct: 1 };
+      PersonalGym.saveStats(stats);
+    });
+    await page.reload();
+
+    await expect(page.locator('#difficult-gym-section')).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Start Hard Workout' })).toBeHidden();
+
+    // Reactivating the gym surfaces the section and an enabled, clickable button.
+    await page.locator(ACTIVATE_TOGGLE_SLIDER).click();
+    await expect(page.locator('#difficult-gym-section')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Start Hard Workout' })).toBeEnabled();
+  });
+
   test('difficult questions appear when stats exceed threshold', async ({ page, context }) => {
     // Marker: this test renders the otherwise-hidden Difficult Questions
     // section, which is the only way the audit can sweep it.

--- a/tests/se-gym.spec.js
+++ b/tests/se-gym.spec.js
@@ -1936,6 +1936,67 @@ test.describe('Personal Gym - Performance Tracking', () => {
     await expect(page.locator('#workout-total')).toHaveText('1');
   });
 
+  test('quick-start workouts stay available while a workout is saved', async ({ page, context }) => {
+    await setCookie(context, 'se-gym-active', 'true');
+    await setCookie(context, 'analyze-performance', 'true');
+    await page.goto(GYM_URL);
+    await page.evaluate(() => {
+      const quizId = 'design_pattern_singleton';
+      const stats = {};
+      stats[`quiz:${quizId}:1`] = { seen: 10, correct: 1 };
+      stats[`quiz:${quizId}:2`] = { seen: 10, correct: 1 };
+      PersonalGym.saveStats(stats);
+      PersonalGym.addToGym('quiz', quizId);
+    });
+    await page.reload();
+
+    // Create a saved checkpoint: start the main gym workout and answer one card.
+    await page.locator('#max-cards').fill('2');
+    await page.getByRole('button', { name: 'Start Workout' }).first().click();
+    await expect(page.locator('#gym-workout')).toBeVisible();
+    await answerVisibleWorkoutCard(page);
+
+    await page.reload();
+    await expect(page.locator('#saved-workout-row')).toBeVisible();
+    // The prominent main Start button still defers to Resume/Discard...
+    await expect(page.getByRole('button', { name: 'Start Workout' }).first()).toBeDisabled();
+
+    // ...but the quick-start launchers stay available and start immediately,
+    // replacing the saved checkpoint instead of being blocked by it.
+    const hardWorkout = page.getByRole('button', { name: 'Start Hard Workout' });
+    await expect(hardWorkout).toBeEnabled();
+    await hardWorkout.click();
+    await expect(page.locator('#gym-workout')).toBeVisible();
+    await expect(page.locator('#gym-entrance')).toBeHidden();
+  });
+
+  test('per-deck practice button drills one deck without changing the gym', async ({ page, context }) => {
+    await setCookie(context, 'se-gym-active', 'true');
+    await page.goto(GYM_URL);
+    await page.locator('#max-cards').fill('50');
+
+    const expectedCount = await page.evaluate(
+      () => ALL_CARD_DATA.quizzes['design_pattern_singleton'].questions.length
+    );
+
+    const deckCard = page.locator('.gym-item[data-type="quiz"][data-id="design_pattern_singleton"]');
+    const practiceBtn = deckCard.locator('.gym-practice-btn');
+    await expect(practiceBtn).toBeVisible();
+    await expect(practiceBtn).toHaveAccessibleName(/^Start targeted practice for /);
+    await practiceBtn.click();
+
+    await expect(page.locator('#gym-workout')).toBeVisible();
+    await expect(page.locator('#gym-entrance')).toBeHidden();
+    // The whole deck (capped by max-cards, here 50) is drilled.
+    await expect(page.locator('#workout-total')).toHaveText(String(expectedCount));
+
+    // Targeted practice must not modify the saved gym selection.
+    const inGym = await page.evaluate(
+      () => PersonalGym.getGym().some((e) => e.type === 'quiz' && e.id === 'design_pattern_singleton')
+    );
+    expect(inGym).toBe(false);
+  });
+
   test('difficult gym can be added to workout', async ({ page, context }) => {
     await setCookie(context, 'se-gym-active', 'true');
     await setCookie(context, 'analyze-performance', 'true');


### PR DESCRIPTION
Follow-up to the merged #77, addressing three more SE Gym issues reported from the live site.

## Changes

**1. Per-deck targeted practice button** 🏋
Every quiz and flashcard library card now has a "Start targeted practice" button (dumbbell icon) next to the add button. It drills *just that deck* via a one-off `sourceGym` workout **without touching the saved gym selection**. Works for both regular and master decks. AA-contrast light/dark styling, accessible label, and tooltip.

**2. Quick-start workouts are always available**
A pending saved workout previously disabled **Start Hard Workout**, **Today's Workout**, and **Start Review**. Those deliberate launchers (and the new per-deck buttons) now pass `replaceSaved` through `beginWorkout`, so they stay available and cleanly replace the saved checkpoint instead of being blocked. The prominent main **Start Workout** button still defers to the adjacent Resume/Discard prompt.

**3. Dark-mode thumbnail colors**
The hero customizer choice thumbnails rendered color-inverted in dark mode: `portfolio.css` inverts every `.post-content img[src$=".svg"]` for line-art diagrams, which negated the full-color avatar previews. The per-component dark-mode rule in `se-gym.css` now wins (`!important`), restoring the true colors.

## Testing
- New Playwright tests: quick-start availability with a saved workout, per-deck targeted practice (card count + no gym mutation), and a dark-mode no-inversion guard — all pass.
- Regression: 96 passed. The only 3 failures (`se-gym.spec.js:1623/1661/1682`) are **pre-existing** Singleton difficulty-count drift, unrelated to this change.
- WCAG 2.2 AA: axe-core scan of the library (with the new buttons) is clean in light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5tr3hStb12YcYuREXk73

---
_Generated by [Claude Code](https://claude.ai/code/session_01QU5tr3hStb12YcYuREXk73)_